### PR TITLE
github: move sanitizer config from .gitlab directory

### DIFF
--- a/.github/SanitizerIgnores.txt
+++ b/.github/SanitizerIgnores.txt
@@ -1,0 +1,21 @@
+# This is a list with filters for all sanitizers,
+# applied at compile time!
+#
+# NOTE: In general nothing should be added here to
+#       suppress some sanitizer issues, instead the
+#       sanitizer-specific suppression files should
+#       be used!
+#
+# The main purpose of this is to ignore third-party
+# code in sanitzer instrumentation.
+#
+# For documentation about the format of this file, see:
+# https://clang.llvm.org/docs/SanitizerSpecialCaseList.html
+
+# Ignore false-positives in third-party code such as:
+#   basic_string.h:403:51: runtime error: unsigned integer overflow: 18 - 22 cannot be represented in type 'unsigned long'
+# See https://github.com/google/sanitizers/issues/1348
+src:*/lib/gcc/x86_64-linux-gnu/.*
+
+# Ignore failures in googletest
+src:.*/third_party/googletest/.*

--- a/.github/UBSan.supp
+++ b/.github/UBSan.supp
@@ -1,0 +1,73 @@
+# Undefined behavior sanitizer suppression file
+#
+# For documentation of the format, see:
+# https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#issue-suppression
+
+# av2/encoder/x86/pickrst_sse4.c
+alignment:acc_stat_highbd_win7_one_line_sse4_1
+alignment:acc_stat_highbd_win5_one_line_sse4_1
+alignment:acc_stat_win7_one_line_sse4_1
+alignment:acc_stat_win5_one_line_sse4_1
+
+# av2/encoder/x86/rdopt_sse4.c
+alignment:horver_correlation_4x4
+
+# av2/common/x86/convolve_sse2.c
+alignment:av2_convolve_y_sr_sse2
+
+# avm_dsp/x86/blend_a64_mask_sse4.c
+alignment:highbd_blend_a64_d16_mask_w4_sse4_1
+
+# avm_dsp/x86/blend_a64_mask_avx2.c
+alignment:highbd_blend_a64_d16_mask_w4_avx2
+
+# av2/common/reconintra.c
+implicit-signed-integer-truncation:get_y_intra_mode_set
+implicit-signed-integer-truncation:get_uv_intra_mode_set
+
+# A few similar errors in this file.
+implicit-signed-integer-truncation:av2/common/x86/optflow_refine_sse4.c
+
+# av2/common/mvref_common.h
+implicit-signed-integer-truncation:av2_collect_neighbors_ref_counts
+
+# av2/encoder/x86/av2_fwd_txfm_sse2.c
+implicit-signed-integer-truncation:av2_fdct8x64_new_sse2
+
+# nullptr-with-offset warnings.
+pointer-overflow:vfilter8
+pointer-overflow:highbd_vfilter8
+
+# nullptr-with-nonzero-offset warning.
+pointer-overflow:av2_set_mv_search_method
+
+# Files with 'invalid-shift-base' warnings.
+shift-base:avm_dsp/simd/*_intrinsics_c.h
+shift-base:avm_dsp/x86/txfm_common_avx2.h
+shift-base:av2/common/x86/av2_inv_txfm_ssse3.c
+shift-base:av2/encoder/hash.c
+shift-base:av2/encoder/rdopt_utils.h
+shift-base:av2/encoder/tx_search.c
+shift-base:av2/encoder/x86/av2_fwd_txfm2d_avx2.c
+shift-base:av2/encoder/x86/av2_fwd_txfm_sse2.c
+shift-base:av2/encoder/x86/pickrst_avx2.c
+shift-base:av2/encoder/x86/pickrst_sse4.c
+shift-base:common/md5_utils.c
+shift-base:test/simd_cmp_impl.h
+
+# Lots of warnings throughout codebase.
+implicit-integer-sign-change:*/avm/*
+
+# Tflite and dependencies.
+unsigned-integer-overflow:*/tensorflow/*
+unsigned-integer-overflow:*/XNNPACK/*
+unsigned-integer-overflow:*/cpuinfo/*
+implicit-signed-integer-truncation:*/XNNPACK/*
+shift-base:*/tensorflow/*
+function:*/XNNPACK/*
+function:*/cpuinfo/*
+function:*/pthreadpool/*
+
+# Others
+unsigned-integer-overflow:*/basic_string.h
+unsigned-integer-overflow:*/stl_uninitialized.h

--- a/.github/workflows/common-builds-reusable.yaml
+++ b/.github/workflows/common-builds-reusable.yaml
@@ -342,7 +342,7 @@ jobs:
       image: ${{ inputs.container-image }}
     env:
       AVM_SANITIZER_TYPE: ${{ matrix.avm-sanitizer-type }}
-      SANITIZER_IGNORES_FILE: .gitlab/SanitizerIgnores.txt
+      SANITIZER_IGNORES_FILE: .github/SanitizerIgnores.txt
       CMAKE_FLAGS: >-
         -DENABLE_CCACHE=1
         -DCMAKE_C_COMPILER=clang

--- a/.github/workflows/sanitizer-job-reusable.yaml
+++ b/.github/workflows/sanitizer-job-reusable.yaml
@@ -127,7 +127,7 @@ jobs:
             undefined|integer)
               SANITIZER_OPTIONS="${SANITIZER_OPTIONS}:print_stacktrace=1"
               SANITIZER_OPTIONS="${SANITIZER_OPTIONS}:report_error_type=1"  # TODO: this was not set in gitlab's nightly, is there a problem to keep it ?
-              SANITIZER_OPTIONS="${SANITIZER_OPTIONS}:suppressions=.gitlab/UBSan.supp"
+              SANITIZER_OPTIONS="${SANITIZER_OPTIONS}:suppressions=.github/UBSan.supp"
               export UBSAN_OPTIONS="${SANITIZER_OPTIONS}"
               ;;
           esac


### PR DESCRIPTION
Sanitizers config leftover from gitlab.

Data from `.gitlab` directory will be removed in a later PR.