### PR TITLE
Remove unreachable return statements after `avm_internal_error` calls.

### DIFF
--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -3621,7 +3621,6 @@ static avm_codec_err_t ctrl_copy_reference(avm_codec_alg_priv_t *ctx,
       AV2_COMMON *cm = &ctx->cpi->common;
       avm_internal_error(&cm->error, AVM_CODEC_INVALID_PARAM,
                          "Incorrect buffer dimensions");
-      return cm->error.error_code;
     }
     image2yuvconfig(&frame->img, &sd);
     av2_copy_reference_enc(ctx->cpi, frame->idx, &sd);
@@ -3678,7 +3677,6 @@ static avm_codec_err_t ctrl_copy_new_frame_image(avm_codec_alg_priv_t *ctx,
         AV2_COMMON *cm = &ctx->cpi->common;
         avm_internal_error(&cm->error, AVM_CODEC_INVALID_PARAM,
                            "Incorrect buffer dimensions");
-        return cm->error.error_code;
       }
       image2yuvconfig(new_img, &sd);
       return av2_copy_new_frame_enc(&ctx->cpi->common, &new_frame, &sd);

--- a/av2/av2_dx_iface.c
+++ b/av2/av2_dx_iface.c
@@ -1336,7 +1336,6 @@ static avm_codec_err_t ctrl_copy_reference(avm_codec_alg_priv_t *ctx,
       AV2_COMMON *cm = &frame_worker_data->pbi->common;
       avm_internal_error(&cm->error, AVM_CODEC_INVALID_PARAM,
                          "Incorrect buffer dimensions");
-      return cm->error.error_code;
     }
     image2yuvconfig(&frame->img, &sd);
     return av2_copy_reference_dec(frame_worker_data->pbi, frame->idx, &sd);
@@ -1393,7 +1392,6 @@ static avm_codec_err_t ctrl_copy_new_frame_image(avm_codec_alg_priv_t *ctx,
         AV2_COMMON *cm = &frame_worker_data->pbi->common;
         avm_internal_error(&cm->error, AVM_CODEC_INVALID_PARAM,
                            "Incorrect buffer dimensions");
-        return cm->error.error_code;
       }
       image2yuvconfig(img, &sd);
       return av2_copy_new_frame_dec(&frame_worker_data->pbi->common, &new_frame,

--- a/av2/common/ccso.c
+++ b/av2/common/ccso.c
@@ -374,13 +374,11 @@ void av2_apply_ccso_filter_for_row(AV2_COMMON *cm, MACROBLOCKD *xd,
       avm_internal_error(
           &cm->error, AVM_CODEC_ERROR,
           "Invalid BRU activity in CCSO: only active SB can be filtered");
-      return;
     }
     if (cm->bridge_frame_info.is_bridge_frame) {
       avm_internal_error(
           &cm->error, AVM_CODEC_ERROR,
           "Invalid Bridge frame activity in CCSO: can not be filtered");
-      return;
     }
 
     if (cm->features.has_lossless_segment) {
@@ -533,7 +531,6 @@ void apply_ccso_filter(AV2_COMMON *cm, MACROBLOCKD *xd, int plane,
                   avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                                      "Invalid BRU activity in CCSO: only "
                                      "active SB can be filtered");
-                  return;
                 }
                 if (cm->features.has_lossless_segment) {
                   ccso_filter_block_hbd_wo_buf_4x4_c(

--- a/av2/common/reconinter.c
+++ b/av2/common/reconinter.c
@@ -1972,7 +1972,6 @@ void av2_build_one_bawp_inter_predictor(
     avm_internal_error(
         (struct avm_internal_error_info *)&cm->error, AVM_CODEC_ERROR,
         "Inter BAWP template cannot outside the valid reference range");
-    return;
   } else {
     uint16_t *recon_buf = xd->plane[plane].dst.buf;
     int recon_stride = xd->plane[plane].dst.stride;

--- a/av2/common/restoration.c
+++ b/av2/common/restoration.c
@@ -1218,7 +1218,6 @@ static void pc_wiener_stripe_highbd(const RestorationUnitInfo *rui,
       avm_internal_error(
           rui->error, AVM_CODEC_ERROR,
           "Invalid BRU activity in LR: only active SB can be filtered");
-      return;
     }
     MB_MODE_INFO **mbmi_ptr_procunit = rui->mbmi_ptr + mi_offset_x;
 
@@ -1592,7 +1591,6 @@ static void wiener_nsfilter_stripe_highbd(const RestorationUnitInfo *rui,
       avm_internal_error(
           rui->error, AVM_CODEC_ERROR,
           "Invalid BRU activity in LR: only active SB can be filtered");
-      return;
     }
     MB_MODE_INFO **mbmi_ptr_procunit = rui->mbmi_ptr + mi_offset_x;
     apply_wienerns_class_id_highbd(

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -2676,7 +2676,6 @@ static AVM_INLINE void decode_restoration_mode(AV2_COMMON *cm,
         avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                            "Invalid RU size, RU size shall not be smaller than "
                            "stripe height which is 64 for 422 format");
-        return;
       }
     }
     cm->rst_info[2].restoration_unit_size =
@@ -2697,7 +2696,6 @@ static AVM_INLINE void decode_restoration_mode(AV2_COMMON *cm,
           &cm->error, AVM_CODEC_ERROR,
           "Invalid RU size, RU size shall be an integer divisor of tiles "
           "width or height, except right-most and bottom tiles");
-      return;
     }
   }
 
@@ -2710,7 +2708,6 @@ static AVM_INLINE void decode_restoration_mode(AV2_COMMON *cm,
           &cm->error, AVM_CODEC_ERROR,
           "Invalid RU size, RU size shall be an integer divisor of tiles "
           "width or height, except right-most and bottom tiles");
-      return;
     }
   }
 
@@ -7223,7 +7220,6 @@ static int read_show_existing_frame(AV2Decoder *pbi, bool is_regular_obu,
       avm_internal_error(&cm->error, AVM_CODEC_UNSUP_BITSTREAM,
                          "the reference frame should be a hidden frame when "
                          "derive_sef_order_hint is true");
-      return 0;
     }
     current_frame->order_hint = cm->cur_frame->order_hint =
         frame_to_show->order_hint;
@@ -7748,7 +7744,6 @@ static void handle_sequence_header(AV2Decoder *pbi, OBU_TYPE obu_type,
                          "Sequence Header changed at OBU_OPEN_LOOP_KEY when "
                          "pbi->random_accessed %d",
                          pbi->random_accessed);
-      return;
     }
   }
 
@@ -9527,20 +9522,17 @@ static int32_t read_tile_indices_in_tilegroup(AV2Decoder *pbi,
     avm_internal_error(&cm->error, AVM_CODEC_CORRUPT_FRAME,
                        "tg_start (%d) must be equal to %d", *start_tile,
                        pbi->next_start_tile);
-    return -1;
   }
   if (*start_tile > *end_tile) {
     avm_internal_error(
         &cm->error, AVM_CODEC_CORRUPT_FRAME,
         "tg_end (%d) must be greater than or equal to tg_start (%d)", *end_tile,
         *start_tile);
-    return -1;
   }
   if (*end_tile >= num_tiles) {
     avm_internal_error(&cm->error, AVM_CODEC_CORRUPT_FRAME,
                        "tg_end (%d) must be less than NumTiles (%d)", *end_tile,
                        num_tiles);
-    return -1;
   }
   pbi->next_start_tile = (*end_tile == num_tiles - 1) ? 0 : *end_tile + 1;
 

--- a/av2/decoder/decoder.c
+++ b/av2/decoder/decoder.c
@@ -502,7 +502,6 @@ avm_codec_err_t av2_copy_reference_dec(AV2Decoder *pbi, int idx,
   const YV12_BUFFER_CONFIG *const cfg = get_ref_frame(cm, idx);
   if (cfg == NULL) {
     avm_internal_error(&cm->error, AVM_CODEC_ERROR, "No reference frame");
-    return AVM_CODEC_ERROR;
   }
   if (!equal_dimensions(cfg, sd))
     avm_internal_error(&cm->error, AVM_CODEC_ERROR,
@@ -532,7 +531,6 @@ avm_codec_err_t av2_set_reference_dec(AV2_COMMON *cm, int idx,
 
   if (ref_buf == NULL) {
     avm_internal_error(&cm->error, AVM_CODEC_ERROR, "No reference frame");
-    return AVM_CODEC_ERROR;
   }
 
   if (!use_external_ref) {

--- a/av2/decoder/obu_buf.c
+++ b/av2/decoder/obu_buf.c
@@ -56,7 +56,6 @@ uint32_t av2_read_buffer_removal_timing_obu(struct AV2Decoder *pbi,
           "No matching operating point set OBU found for br_ops_id = %d. "
           "Bitstream conformance requires an OPS OBU with ops_id = %d.",
           brt_info->br_ops_id, brt_info->br_ops_id);
-      return 0;
     }
     // It is a requirement of bitstream conformance that br_ops_cnt[br_ops_id]
     // when present shall be equal to the value of ops_cnt of the corresponding
@@ -69,7 +68,6 @@ uint32_t av2_read_buffer_removal_timing_obu(struct AV2Decoder *pbi,
           "OBU (%d) and Operating Point set OBU (%d).",
           brt_info->br_ops_cnt[brt_info->br_ops_id],
           pbi->ops_list[xlayer_id][brt_info->br_ops_id].ops_cnt);
-      return 0;
     }
     // decoder model
     for (int i = 0; i < brt_info->br_ops_cnt[brt_info->br_ops_id]; i++) {

--- a/av2/encoder/bitstream.c
+++ b/av2/encoder/bitstream.c
@@ -6828,7 +6828,6 @@ size_t av2_write_banding_hints_metadata(
                                         &payload_size) != 0) {
     avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                        "Error encoding banding hints metadata");
-    return 0;
   }
 
   avm_metadata_t *metadata =
@@ -6837,7 +6836,6 @@ size_t av2_write_banding_hints_metadata(
   if (!metadata) {
     avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
                        "Error allocating banding hints metadata");
-    return 0;
   }
 
   // Set up metadata fields
@@ -6907,7 +6905,6 @@ size_t av2_write_metadata_user_data_unregistered(AV2_COMP *const cpi,
     avm_internal_error(
         &cpi->common.error, AVM_CODEC_ERROR,
         "User data unregistered payload must be at least 16 bytes (UUID)");
-    return 0;
   }
 
   avm_metadata_t *metadata =
@@ -6916,7 +6913,6 @@ size_t av2_write_metadata_user_data_unregistered(AV2_COMP *const cpi,
   if (!metadata) {
     avm_internal_error(&cpi->common.error, AVM_CODEC_MEM_ERROR,
                        "Error allocating user data unregistered metadata");
-    return 0;
   }
   size_t total_bytes_written = 0;
   OBU_TYPE obu_type = cpi->oxcf.tool_cfg.use_short_metadata

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -5245,7 +5245,6 @@ int av2_encode(AV2_COMP *const cpi, uint8_t *const dest,
         if (cm->bridge_frame_info.bridge_frame_ref_idx == INVALID_IDX) {
           avm_internal_error(&cm->error, AVM_CODEC_CORRUPT_FRAME,
                              "Cannot find bridge frame reference frame");
-          return AVM_CODEC_ERROR;
         }
         cm->bridge_frame_info.bridge_frame_overwrite_flag = 1;
         cm->current_frame.refresh_frame_flags =
@@ -5291,7 +5290,6 @@ static int apply_denoise_2d(AV2_COMP *cpi, YV12_BUFFER_CONFIG *sd,
     if (!cpi->denoise_and_model) {
       avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
                          "Error allocating denoise and model");
-      return -1;
     }
   }
   if (!cpi->film_grain_table) {
@@ -5299,7 +5297,6 @@ static int apply_denoise_2d(AV2_COMP *cpi, YV12_BUFFER_CONFIG *sd,
     if (!cpi->film_grain_table) {
       avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
                          "Error allocating grain table");
-      return -1;
     }
     memset(cpi->film_grain_table, 0, sizeof(*cpi->film_grain_table));
   }

--- a/avm_dsp/grain_table.c
+++ b/avm_dsp/grain_table.c
@@ -49,7 +49,6 @@ static void grain_table_entry_read(FILE *file,
   if (num_read != 5) {
     avm_internal_error(error_info, AVM_CODEC_ERROR,
                        "Unable to read entry header. Read %d != 5", num_read);
-    return;
   }
   if (pars->update_parameters) {
     num_read = fscanf(
@@ -63,45 +62,38 @@ static void grain_table_entry_read(FILE *file,
       avm_internal_error(error_info, AVM_CODEC_ERROR,
                          "Unable to read entry params. Read %d != 13",
                          num_read);
-      return;
     }
     if (!fscanf(file, "\tsY %d ", &pars->fgm_points[0])) {
       avm_internal_error(error_info, AVM_CODEC_ERROR,
                          "Unable to read num y points");
-      return;
     }
     for (int i = 0; i < pars->fgm_points[0]; ++i) {
       if (2 != fscanf(file, "%d %d", &pars->fgm_scaling_points_0[i][0],
                       &pars->fgm_scaling_points_0[i][1])) {
         avm_internal_error(error_info, AVM_CODEC_ERROR,
                            "Unable to read y scaling points");
-        return;
       }
     }
     if (!fscanf(file, "\n\tsCb %d", &pars->fgm_points[1])) {
       avm_internal_error(error_info, AVM_CODEC_ERROR,
                          "Unable to read num cb points");
-      return;
     }
     for (int i = 0; i < pars->fgm_points[1]; ++i) {
       if (2 != fscanf(file, "%d %d", &pars->fgm_scaling_points_1[i][0],
                       &pars->fgm_scaling_points_1[i][1])) {
         avm_internal_error(error_info, AVM_CODEC_ERROR,
                            "Unable to read cb scaling points");
-        return;
       }
     }
     if (!fscanf(file, "\n\tsCr %d", &pars->fgm_points[2])) {
       avm_internal_error(error_info, AVM_CODEC_ERROR,
                          "Unable to read num cr points");
-      return;
     }
     for (int i = 0; i < pars->fgm_points[2]; ++i) {
       if (2 != fscanf(file, "%d %d", &pars->fgm_scaling_points_2[i][0],
                       &pars->fgm_scaling_points_2[i][1])) {
         avm_internal_error(error_info, AVM_CODEC_ERROR,
                            "Unable to read cr scaling points");
-        return;
       }
     }
 
@@ -111,7 +103,6 @@ static void grain_table_entry_read(FILE *file,
       if (1 != fscanf(file, "%d", &pars->ar_coeffs_y[i])) {
         avm_internal_error(error_info, AVM_CODEC_ERROR,
                            "Unable to read Y coeffs");
-        return;
       }
     }
     fscanf(file, "\n\tcCb");
@@ -119,7 +110,6 @@ static void grain_table_entry_read(FILE *file,
       if (1 != fscanf(file, "%d", &pars->ar_coeffs_cb[i])) {
         avm_internal_error(error_info, AVM_CODEC_ERROR,
                            "Unable to read Cb coeffs");
-        return;
       }
     }
     fscanf(file, "\n\tcCr");
@@ -127,7 +117,6 @@ static void grain_table_entry_read(FILE *file,
       if (1 != fscanf(file, "%d", &pars->ar_coeffs_cr[i])) {
         avm_internal_error(error_info, AVM_CODEC_ERROR,
                            "Unable to read Cr coeffs");
-        return;
       }
     }
     fscanf(file, "\n");
@@ -262,7 +251,6 @@ avm_codec_err_t avm_film_grain_table_read(
   if (!file) {
     avm_internal_error(error_info, AVM_CODEC_ERROR, "Unable to open %s",
                        filename);
-    return error_info->error_code;
   }
   error_info->error_code = AVM_CODEC_OK;
 
@@ -304,7 +292,6 @@ avm_codec_err_t avm_film_grain_table_write(
   if (!file) {
     avm_internal_error(error_info, AVM_CODEC_ERROR, "Unable to open file %s",
                        filename);
-    return error_info->error_code;
   }
 
   if (!fwrite(kFileMagic, 8, 1, file)) {

--- a/test/film_grain_table_test.cc
+++ b/test/film_grain_table_test.cc
@@ -168,13 +168,49 @@ class FilmGrainTableIOTest : public ::testing::Test {
  protected:
   void SetUp() { memset(&error_, 0, sizeof(error_)); }
   struct avm_internal_error_info error_;
+
+  void ReadTableSuccess(avm_film_grain_table_t *t,
+                        const std::string &filename) {
+    if (setjmp(error_.jmp)) {
+      FAIL() << "Unexpected failure in avm_film_grain_table_read: "
+             << error_.detail;
+    }
+    error_.setjmp = 1;
+    ASSERT_EQ(AVM_CODEC_OK,
+              avm_film_grain_table_read(t, filename.c_str(), &error_));
+    error_.setjmp = 0;
+  }
+
+  void WriteTableSuccess(const avm_film_grain_table_t *t,
+                         const std::string &filename) {
+    if (setjmp(error_.jmp)) {
+      FAIL() << "Unexpected failure in avm_film_grain_table_write: "
+             << error_.detail;
+    }
+    error_.setjmp = 1;
+    ASSERT_EQ(AVM_CODEC_OK,
+              avm_film_grain_table_write(t, filename.c_str(), &error_));
+    error_.setjmp = 0;
+  }
+
+  bool ReadTableFailure(avm_film_grain_table_t *t, const std::string &filename,
+                        avm_codec_err_t expected_err) {
+    if (setjmp(error_.jmp)) {
+      EXPECT_EQ(expected_err, error_.error_code);
+      return true;
+    }
+    error_.setjmp = 1;
+    avm_film_grain_table_read(t, filename.c_str(), &error_);
+    error_.setjmp = 0;
+    ADD_FAILURE() << "Expected avm_film_grain_table_read to fail and longjmp";
+    return false;
+  }
 };
 
 TEST_F(FilmGrainTableIOTest, ReadMissingFile) {
   avm_film_grain_table_t table;
   memset(&table, 0, sizeof(table));
-  ASSERT_EQ(AVM_CODEC_ERROR, avm_film_grain_table_read(
-                                 &table, "/path/to/missing/file", &error_));
+  ReadTableFailure(&table, "/path/to/missing/file", AVM_CODEC_ERROR);
 }
 
 TEST_F(FilmGrainTableIOTest, ReadTruncatedFile) {
@@ -185,8 +221,8 @@ TEST_F(FilmGrainTableIOTest, ReadTruncatedFile) {
   FILE *file = libavm_test::GetTempOutFile(&grain_file);
   fwrite("deadbeef", 8, 1, file);
   fclose(file);
-  ASSERT_EQ(AVM_CODEC_ERROR,
-            avm_film_grain_table_read(&table, grain_file.c_str(), &error_));
+
+  ReadTableFailure(&table, grain_file, AVM_CODEC_ERROR);
   EXPECT_EQ(0, remove(grain_file.c_str()));
 }
 
@@ -208,13 +244,11 @@ TEST_F(FilmGrainTableIOTest, RoundTripReadWrite) {
   }
   std::string grain_file;
   fclose(libavm_test::GetTempOutFile(&grain_file));
-  ASSERT_EQ(AVM_CODEC_OK,
-            avm_film_grain_table_write(&table, grain_file.c_str(), &error_));
+  WriteTableSuccess(&table, grain_file);
   avm_film_grain_table_free(&table);
 
   memset(&table, 0, sizeof(table));
-  ASSERT_EQ(AVM_CODEC_OK,
-            avm_film_grain_table_read(&table, grain_file.c_str(), &error_));
+  ReadTableSuccess(&table, grain_file);
   for (int i = 0; i < kNumTestVectors; ++i) {
     avm_film_grain_t grain;
     EXPECT_TRUE(avm_film_grain_table_lookup(&table, i * 1000, (i + 1) * 1000,
@@ -238,13 +272,11 @@ TEST_F(FilmGrainTableIOTest, RoundTripSplit) {
   ASSERT_TRUE(avm_film_grain_table_lookup(&table, 0, 1000, false, &grain));
   EXPECT_FALSE(avm_film_grain_table_lookup(&table, 1000, 2000, false, &grain));
   ASSERT_TRUE(avm_film_grain_table_lookup(&table, 2000, 3000, false, &grain));
-  ASSERT_EQ(AVM_CODEC_OK,
-            avm_film_grain_table_write(&table, grain_file.c_str(), &error_));
+  WriteTableSuccess(&table, grain_file);
   avm_film_grain_table_free(&table);
 
   memset(&table, 0, sizeof(table));
-  ASSERT_EQ(AVM_CODEC_OK,
-            avm_film_grain_table_read(&table, grain_file.c_str(), &error_));
+  ReadTableSuccess(&table, grain_file);
   ASSERT_TRUE(avm_film_grain_table_lookup(&table, 0, 1000, false, &grain));
   ASSERT_FALSE(avm_film_grain_table_lookup(&table, 1000, 2000, false, &grain));
   ASSERT_TRUE(avm_film_grain_table_lookup(&table, 2000, 3000, false, &grain));


### PR DESCRIPTION
This fixes following type of build errors on LLVM 22.1.6:

```
error: 'return' will never be executed [-Werror,-Wunreachable-code-return]
```

As a pre-requisite to this:  ensure that `setjmp` is called in `FilmGrainTableIOTest` before `avm_internal_error` is called.

Closes #5002 