### PR TITLE
Remove unreachable return statements after avm_internal_error calls. 

### DIFF
--- a/av2/common/ccso.c
+++ b/av2/common/ccso.c
@@ -374,13 +374,11 @@ void av2_apply_ccso_filter_for_row(AV2_COMMON *cm, MACROBLOCKD *xd,
       avm_internal_error(
           &cm->error, AVM_CODEC_ERROR,
           "Invalid BRU activity in CCSO: only active SB can be filtered");
-      return;
     }
     if (cm->bridge_frame_info.is_bridge_frame) {
       avm_internal_error(
           &cm->error, AVM_CODEC_ERROR,
           "Invalid Bridge frame activity in CCSO: can not be filtered");
-      return;
     }
 
     if (cm->features.has_lossless_segment) {
@@ -533,7 +531,6 @@ void apply_ccso_filter(AV2_COMMON *cm, MACROBLOCKD *xd, int plane,
                   avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                                      "Invalid BRU activity in CCSO: only "
                                      "active SB can be filtered");
-                  return;
                 }
                 if (cm->features.has_lossless_segment) {
                   ccso_filter_block_hbd_wo_buf_4x4_c(

--- a/av2/common/reconinter.c
+++ b/av2/common/reconinter.c
@@ -1972,7 +1972,6 @@ void av2_build_one_bawp_inter_predictor(
     avm_internal_error(
         (struct avm_internal_error_info *)&cm->error, AVM_CODEC_ERROR,
         "Inter BAWP template cannot outside the valid reference range");
-    return;
   } else {
     uint16_t *recon_buf = xd->plane[plane].dst.buf;
     int recon_stride = xd->plane[plane].dst.stride;

--- a/av2/common/restoration.c
+++ b/av2/common/restoration.c
@@ -1216,7 +1216,6 @@ static void pc_wiener_stripe_highbd(const RestorationUnitInfo *rui,
       avm_internal_error(
           rui->error, AVM_CODEC_ERROR,
           "Invalid BRU activity in LR: only active SB can be filtered");
-      return;
     }
     MB_MODE_INFO **mbmi_ptr_procunit = rui->mbmi_ptr + mi_offset_x;
 
@@ -1590,7 +1589,6 @@ static void wiener_nsfilter_stripe_highbd(const RestorationUnitInfo *rui,
       avm_internal_error(
           rui->error, AVM_CODEC_ERROR,
           "Invalid BRU activity in LR: only active SB can be filtered");
-      return;
     }
     MB_MODE_INFO **mbmi_ptr_procunit = rui->mbmi_ptr + mi_offset_x;
     apply_wienerns_class_id_highbd(

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -2676,7 +2676,6 @@ static AVM_INLINE void decode_restoration_mode(AV2_COMMON *cm,
         avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                            "Invalid RU size, RU size shall not be smaller than "
                            "stripe height which is 64 for 422 format");
-        return;
       }
     }
     cm->rst_info[2].restoration_unit_size =
@@ -2697,7 +2696,6 @@ static AVM_INLINE void decode_restoration_mode(AV2_COMMON *cm,
           &cm->error, AVM_CODEC_ERROR,
           "Invalid RU size, RU size shall be an integer divisor of tiles "
           "width or height, except right-most and bottom tiles");
-      return;
     }
   }
 
@@ -2710,7 +2708,6 @@ static AVM_INLINE void decode_restoration_mode(AV2_COMMON *cm,
           &cm->error, AVM_CODEC_ERROR,
           "Invalid RU size, RU size shall be an integer divisor of tiles "
           "width or height, except right-most and bottom tiles");
-      return;
     }
   }
 
@@ -7212,7 +7209,6 @@ static int read_show_existing_frame(AV2Decoder *pbi, bool is_regular_obu,
       avm_internal_error(&cm->error, AVM_CODEC_UNSUP_BITSTREAM,
                          "the reference frame should be a hidden frame when "
                          "derive_sef_order_hint is true");
-      return 0;
     }
     current_frame->order_hint = cm->cur_frame->order_hint =
         frame_to_show->order_hint;
@@ -7737,7 +7733,6 @@ static void handle_sequence_header(AV2Decoder *pbi, OBU_TYPE obu_type,
                          "Sequence Header changed at OBU_OPEN_LOOP_KEY when "
                          "pbi->random_accessed %d",
                          pbi->random_accessed);
-      return;
     }
   }
 
@@ -9516,20 +9511,17 @@ static int32_t read_tile_indices_in_tilegroup(AV2Decoder *pbi,
     avm_internal_error(&cm->error, AVM_CODEC_CORRUPT_FRAME,
                        "tg_start (%d) must be equal to %d", *start_tile,
                        pbi->next_start_tile);
-    return -1;
   }
   if (*start_tile > *end_tile) {
     avm_internal_error(
         &cm->error, AVM_CODEC_CORRUPT_FRAME,
         "tg_end (%d) must be greater than or equal to tg_start (%d)", *end_tile,
         *start_tile);
-    return -1;
   }
   if (*end_tile >= num_tiles) {
     avm_internal_error(&cm->error, AVM_CODEC_CORRUPT_FRAME,
                        "tg_end (%d) must be less than NumTiles (%d)", *end_tile,
                        num_tiles);
-    return -1;
   }
   pbi->next_start_tile = (*end_tile == num_tiles - 1) ? 0 : *end_tile + 1;
 

--- a/av2/decoder/obu_buf.c
+++ b/av2/decoder/obu_buf.c
@@ -56,7 +56,6 @@ uint32_t av2_read_buffer_removal_timing_obu(struct AV2Decoder *pbi,
           "No matching operating point set OBU found for br_ops_id = %d. "
           "Bitstream conformance requires an OPS OBU with ops_id = %d.",
           brt_info->br_ops_id, brt_info->br_ops_id);
-      return 0;
     }
     // It is a requirement of bitstream conformance that br_ops_cnt[br_ops_id]
     // when present shall be equal to the value of ops_cnt of the corresponding
@@ -69,7 +68,6 @@ uint32_t av2_read_buffer_removal_timing_obu(struct AV2Decoder *pbi,
           "OBU (%d) and Operating Point set OBU (%d).",
           brt_info->br_ops_cnt[brt_info->br_ops_id],
           pbi->ops_list[xlayer_id][brt_info->br_ops_id].ops_cnt);
-      return 0;
     }
     // decoder model
     for (int i = 0; i < brt_info->br_ops_cnt[brt_info->br_ops_id]; i++) {

--- a/av2/encoder/bitstream.c
+++ b/av2/encoder/bitstream.c
@@ -6824,7 +6824,6 @@ size_t av2_write_banding_hints_metadata(
                                         &payload_size) != 0) {
     avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                        "Error encoding banding hints metadata");
-    return 0;
   }
 
   avm_metadata_t *metadata =
@@ -6833,7 +6832,6 @@ size_t av2_write_banding_hints_metadata(
   if (!metadata) {
     avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
                        "Error allocating banding hints metadata");
-    return 0;
   }
 
   // Set up metadata fields
@@ -6903,7 +6901,6 @@ size_t av2_write_metadata_user_data_unregistered(AV2_COMP *const cpi,
     avm_internal_error(
         &cpi->common.error, AVM_CODEC_ERROR,
         "User data unregistered payload must be at least 16 bytes (UUID)");
-    return 0;
   }
 
   avm_metadata_t *metadata =
@@ -6912,7 +6909,6 @@ size_t av2_write_metadata_user_data_unregistered(AV2_COMP *const cpi,
   if (!metadata) {
     avm_internal_error(&cpi->common.error, AVM_CODEC_MEM_ERROR,
                        "Error allocating user data unregistered metadata");
-    return 0;
   }
   size_t total_bytes_written = 0;
   OBU_TYPE obu_type = cpi->oxcf.tool_cfg.use_short_metadata

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -5245,7 +5245,6 @@ int av2_encode(AV2_COMP *const cpi, uint8_t *const dest,
         if (cm->bridge_frame_info.bridge_frame_ref_idx == INVALID_IDX) {
           avm_internal_error(&cm->error, AVM_CODEC_CORRUPT_FRAME,
                              "Cannot find bridge frame reference frame");
-          return AVM_CODEC_ERROR;
         }
         cm->bridge_frame_info.bridge_frame_overwrite_flag = 1;
         cm->current_frame.refresh_frame_flags =
@@ -5291,7 +5290,6 @@ static int apply_denoise_2d(AV2_COMP *cpi, YV12_BUFFER_CONFIG *sd,
     if (!cpi->denoise_and_model) {
       avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
                          "Error allocating denoise and model");
-      return -1;
     }
   }
   if (!cpi->film_grain_table) {
@@ -5299,7 +5297,6 @@ static int apply_denoise_2d(AV2_COMP *cpi, YV12_BUFFER_CONFIG *sd,
     if (!cpi->film_grain_table) {
       avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
                          "Error allocating grain table");
-      return -1;
     }
     memset(cpi->film_grain_table, 0, sizeof(*cpi->film_grain_table));
   }


### PR DESCRIPTION
This fixes following type of build errors on LLVM 22.1.6:

```
error: 'return' will never be executed [-Werror,-Wunreachable-code-return]
```

Related: Ensure that setjmp is called before avm_internal_error in FilmGrainTableIOTest.

Closes #5002 