### PR TITLE
Remove avm_internal_error calls from av2_cx/dx_iface.c

### DIFF
--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -3619,8 +3619,6 @@ static avm_codec_err_t ctrl_copy_reference(avm_codec_alg_priv_t *ctx,
 
     if (!(frame->img.fmt & AVM_IMG_FMT_HIGHBITDEPTH)) {
       AV2_COMMON *cm = &ctx->cpi->common;
-      avm_internal_error(&cm->error, AVM_CODEC_INVALID_PARAM,
-                         "Incorrect buffer dimensions");
       return cm->error.error_code;
     }
     image2yuvconfig(&frame->img, &sd);
@@ -3676,8 +3674,6 @@ static avm_codec_err_t ctrl_copy_new_frame_image(avm_codec_alg_priv_t *ctx,
 
       if (!(new_img->fmt & AVM_IMG_FMT_HIGHBITDEPTH)) {
         AV2_COMMON *cm = &ctx->cpi->common;
-        avm_internal_error(&cm->error, AVM_CODEC_INVALID_PARAM,
-                           "Incorrect buffer dimensions");
         return cm->error.error_code;
       }
       image2yuvconfig(new_img, &sd);

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -3618,8 +3618,7 @@ static avm_codec_err_t ctrl_copy_reference(avm_codec_alg_priv_t *ctx,
     YV12_BUFFER_CONFIG sd;
 
     if (!(frame->img.fmt & AVM_IMG_FMT_HIGHBITDEPTH)) {
-      AV2_COMMON *cm = &ctx->cpi->common;
-      return cm->error.error_code;
+      ERROR("Incorrect buffer bitdepth");
     }
     image2yuvconfig(&frame->img, &sd);
     av2_copy_reference_enc(ctx->cpi, frame->idx, &sd);
@@ -3673,8 +3672,7 @@ static avm_codec_err_t ctrl_copy_new_frame_image(avm_codec_alg_priv_t *ctx,
       YV12_BUFFER_CONFIG sd;
 
       if (!(new_img->fmt & AVM_IMG_FMT_HIGHBITDEPTH)) {
-        AV2_COMMON *cm = &ctx->cpi->common;
-        return cm->error.error_code;
+        ERROR("Incorrect buffer bitdepth");
       }
       image2yuvconfig(new_img, &sd);
       return av2_copy_new_frame_enc(&ctx->cpi->common, &new_frame, &sd);

--- a/av2/av2_dx_iface.c
+++ b/av2/av2_dx_iface.c
@@ -1334,8 +1334,6 @@ static avm_codec_err_t ctrl_copy_reference(avm_codec_alg_priv_t *ctx,
     FrameWorkerData *const frame_worker_data = (FrameWorkerData *)worker->data1;
     if (!(frame->img.fmt & AVM_IMG_FMT_HIGHBITDEPTH)) {
       AV2_COMMON *cm = &frame_worker_data->pbi->common;
-      avm_internal_error(&cm->error, AVM_CODEC_INVALID_PARAM,
-                         "Incorrect buffer dimensions");
       return cm->error.error_code;
     }
     image2yuvconfig(&frame->img, &sd);
@@ -1391,8 +1389,6 @@ static avm_codec_err_t ctrl_copy_new_frame_image(avm_codec_alg_priv_t *ctx,
       YV12_BUFFER_CONFIG sd;
       if (!(img->fmt & AVM_IMG_FMT_HIGHBITDEPTH)) {
         AV2_COMMON *cm = &frame_worker_data->pbi->common;
-        avm_internal_error(&cm->error, AVM_CODEC_INVALID_PARAM,
-                           "Incorrect buffer dimensions");
         return cm->error.error_code;
       }
       image2yuvconfig(img, &sd);

--- a/av2/av2_dx_iface.c
+++ b/av2/av2_dx_iface.c
@@ -1333,8 +1333,8 @@ static avm_codec_err_t ctrl_copy_reference(avm_codec_alg_priv_t *ctx,
     AVxWorker *const worker = ctx->frame_worker;
     FrameWorkerData *const frame_worker_data = (FrameWorkerData *)worker->data1;
     if (!(frame->img.fmt & AVM_IMG_FMT_HIGHBITDEPTH)) {
-      AV2_COMMON *cm = &frame_worker_data->pbi->common;
-      return cm->error.error_code;
+      set_error_detail(ctx, "Incorrect buffer bitdepth");
+      return AVM_CODEC_INVALID_PARAM;
     }
     image2yuvconfig(&frame->img, &sd);
     return av2_copy_reference_dec(frame_worker_data->pbi, frame->idx, &sd);
@@ -1388,8 +1388,8 @@ static avm_codec_err_t ctrl_copy_new_frame_image(avm_codec_alg_priv_t *ctx,
     if (av2_get_frame_to_show(frame_worker_data->pbi, &new_frame) == 0) {
       YV12_BUFFER_CONFIG sd;
       if (!(img->fmt & AVM_IMG_FMT_HIGHBITDEPTH)) {
-        AV2_COMMON *cm = &frame_worker_data->pbi->common;
-        return cm->error.error_code;
+        set_error_detail(ctx, "Incorrect buffer bitdepth");
+        return AVM_CODEC_INVALID_PARAM;
       }
       image2yuvconfig(img, &sd);
       return av2_copy_new_frame_dec(&frame_worker_data->pbi->common, &new_frame,


### PR DESCRIPTION
`setjmp` is not called at these places, so error should be returned instead.

#5002 