### PR TITLE
trellis_first_pos(): avoid integer wrap-around

### DIFF
--- a/av2/encoder/trellis_quant.c
+++ b/av2/encoder/trellis_quant.c
@@ -590,9 +590,9 @@ void trellis_first_pos(const tcq_param_t *p, int scan_pos, tcq_ctx_t *tcq_ctx,
       tcq_ctx->lev_new[col][i] = 0;
     }
     tcq_ctx->lev_new[col][state0] =
-        AVMMIN(decision[state0].absLevel, MAX_VAL_BR_CTX);
+        AVMMIN(AVMMAX(0, decision[state0].absLevel), MAX_VAL_BR_CTX);
     tcq_ctx->lev_new[col][state1] =
-        AVMMIN(decision[state1].absLevel, MAX_VAL_BR_CTX);
+        AVMMIN(AVMMAX(0, decision[state1].absLevel), MAX_VAL_BR_CTX);
     if ((col == 0 && row != 0) || row == height - 1) {
       av2_update_nbr_diagonal(tcq_ctx, row, col, bwl);
     }


### PR DESCRIPTION
Similar to the fix in `av2_update_states_c()` in commit https://github.com/AOMediaCodec/avm/pull/5020/changes/2b81e251406e66aa0ed79d5ea8969dae65e98913

#5025 