### PR TITLE
Move equal_dimensions_and_border to yv12config.h

### DIFF
--- a/av2/decoder/decoder.c
+++ b/av2/decoder/decoder.c
@@ -514,14 +514,6 @@ avm_codec_err_t av2_copy_reference_dec(AV2Decoder *pbi, int idx,
   return cm->error.error_code;
 }
 
-static int equal_dimensions_and_border(const YV12_BUFFER_CONFIG *a,
-                                       const YV12_BUFFER_CONFIG *b) {
-  return a->y_height == b->y_height && a->y_width == b->y_width &&
-         a->uv_height == b->uv_height && a->uv_width == b->uv_width &&
-         a->y_stride == b->y_stride && a->uv_stride == b->uv_stride &&
-         a->border == b->border;
-}
-
 avm_codec_err_t av2_set_reference_dec(AV2_COMMON *cm, int idx,
                                       int use_external_ref,
                                       YV12_BUFFER_CONFIG *sd) {

--- a/av2/decoder/decoder.c
+++ b/av2/decoder/decoder.c
@@ -537,7 +537,7 @@ avm_codec_err_t av2_set_reference_dec(AV2_COMMON *cm, int idx,
       avm_yv12_copy_frame(sd, ref_buf, num_planes);
     }
   } else {
-    if (!equal_dimensions_and_border(ref_buf, sd)) {
+    if (!avm_equal_dimensions_and_border(ref_buf, sd)) {
       avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                          "Incorrect buffer dimensions");
     } else {
@@ -562,7 +562,7 @@ avm_codec_err_t av2_copy_new_frame_dec(AV2_COMMON *cm,
                                        YV12_BUFFER_CONFIG *sd) {
   const int num_planes = av2_num_planes(cm);
 
-  if (!equal_dimensions_and_border(new_frame, sd))
+  if (!avm_equal_dimensions_and_border(new_frame, sd))
     avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                        "Incorrect buffer dimensions");
   else

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -5543,7 +5543,7 @@ avm_codec_err_t av2_copy_new_frame_enc(AV2_COMMON *cm,
                                        YV12_BUFFER_CONFIG *new_frame,
                                        YV12_BUFFER_CONFIG *sd) {
   const int num_planes = av2_num_planes(cm);
-  if (!equal_dimensions_and_border(new_frame, sd))
+  if (!avm_equal_dimensions_and_border(new_frame, sd))
     avm_internal_error(&cm->error, AVM_CODEC_ERROR,
                        "Incorrect buffer dimensions");
   else

--- a/av2/encoder/encoder_utils.h
+++ b/av2/encoder/encoder_utils.h
@@ -831,14 +831,6 @@ static AVM_INLINE void copy_frame_prob_info(AV2_COMP *cpi) {
   }
 }
 
-static AVM_INLINE int equal_dimensions_and_border(const YV12_BUFFER_CONFIG *a,
-                                                  const YV12_BUFFER_CONFIG *b) {
-  return a->y_height == b->y_height && a->y_width == b->y_width &&
-         a->uv_height == b->uv_height && a->uv_width == b->uv_width &&
-         a->y_stride == b->y_stride && a->uv_stride == b->uv_stride &&
-         a->border == b->border;
-}
-
 static AVM_INLINE int combine_prior_with_tpl_boost(double min_factor,
                                                    double max_factor,
                                                    int prior_boost,

--- a/avm_scale/yv12config.h
+++ b/avm_scale/yv12config.h
@@ -202,15 +202,11 @@ void avm_remove_metadata_from_frame_buffer(YV12_BUFFER_CONFIG *ybf);
  */
 int avm_copy_metadata_to_frame_buffer(YV12_BUFFER_CONFIG *ybf,
                                       const avm_metadata_array_t *arr);
-static INLINE int equal_dimensions_and_border(
-    const YV12_BUFFER_CONFIG *a,
-    const YV12_BUFFER_CONFIG *b) {
-  return a->y_height == b->y_height &&
-         a->y_width == b->y_width &&
-         a->uv_height == b->uv_height &&
-         a->uv_width == b->uv_width &&
-         a->y_stride == b->y_stride &&
-         a->uv_stride == b->uv_stride &&
+static INLINE int equal_dimensions_and_border(const YV12_BUFFER_CONFIG *a,
+                                              const YV12_BUFFER_CONFIG *b) {
+  return a->y_height == b->y_height && a->y_width == b->y_width &&
+         a->uv_height == b->uv_height && a->uv_width == b->uv_width &&
+         a->y_stride == b->y_stride && a->uv_stride == b->uv_stride &&
          a->border == b->border;
 }
 

--- a/avm_scale/yv12config.h
+++ b/avm_scale/yv12config.h
@@ -203,7 +203,7 @@ void avm_remove_metadata_from_frame_buffer(YV12_BUFFER_CONFIG *ybf);
 int avm_copy_metadata_to_frame_buffer(YV12_BUFFER_CONFIG *ybf,
                                       const avm_metadata_array_t *arr);
 static INLINE int avm_equal_dimensions_and_border(const YV12_BUFFER_CONFIG *a,
-                                              const YV12_BUFFER_CONFIG *b) {
+                                                  const YV12_BUFFER_CONFIG *b) {
   return a->y_height == b->y_height && a->y_width == b->y_width &&
          a->uv_height == b->uv_height && a->uv_width == b->uv_width &&
          a->y_stride == b->y_stride && a->uv_stride == b->uv_stride &&

--- a/avm_scale/yv12config.h
+++ b/avm_scale/yv12config.h
@@ -202,6 +202,17 @@ void avm_remove_metadata_from_frame_buffer(YV12_BUFFER_CONFIG *ybf);
  */
 int avm_copy_metadata_to_frame_buffer(YV12_BUFFER_CONFIG *ybf,
                                       const avm_metadata_array_t *arr);
+static INLINE int equal_dimensions_and_border(
+    const YV12_BUFFER_CONFIG *a,
+    const YV12_BUFFER_CONFIG *b) {
+  return a->y_height == b->y_height &&
+         a->y_width == b->y_width &&
+         a->uv_height == b->uv_height &&
+         a->uv_width == b->uv_width &&
+         a->y_stride == b->y_stride &&
+         a->uv_stride == b->uv_stride &&
+         a->border == b->border;
+}
 
 #ifdef __cplusplus
 }

--- a/avm_scale/yv12config.h
+++ b/avm_scale/yv12config.h
@@ -202,7 +202,7 @@ void avm_remove_metadata_from_frame_buffer(YV12_BUFFER_CONFIG *ybf);
  */
 int avm_copy_metadata_to_frame_buffer(YV12_BUFFER_CONFIG *ybf,
                                       const avm_metadata_array_t *arr);
-static INLINE int equal_dimensions_and_border(const YV12_BUFFER_CONFIG *a,
+static INLINE int avm_equal_dimensions_and_border(const YV12_BUFFER_CONFIG *a,
                                               const YV12_BUFFER_CONFIG *b) {
   return a->y_height == b->y_height && a->y_width == b->y_width &&
          a->uv_height == b->uv_height && a->uv_width == b->uv_width &&


### PR DESCRIPTION

## Summary

Move `equal_dimensions_and_border()` to `avm_scale/yv12config.h` and remove the duplicate implementations from:

- av2/decoder/decoder.c
- av2/encoder/encoder_utils.h

Closes #5030 

This consolidates the helper into a single shared definition associated with `YV12_BUFFER_CONFIG` and eliminates duplicate code.

## Testing

- Verified only a single definition remains via `git grep`.
- Existing call sites continue to use the shared helper.