### PR TITLE
Fix RDO mode skipping corruption with reduced reference frames

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -6693,8 +6693,11 @@ static AVM_INLINE void init_mode_skip_mask(mode_skip_mask_t *mask,
   int min_pred_mv_sad = INT_MAX;
   MV_REFERENCE_FRAME ref_frame;
   for (ref_frame = 0; ref_frame < cm->ref_frames_info.num_total_refs;
-       ++ref_frame)
-    min_pred_mv_sad = AVMMIN(min_pred_mv_sad, x->pred_mv_sad[ref_frame]);
+       ++ref_frame) {
+    if (cm->ref_frame_flags & (1 << ref_frame)) {
+      min_pred_mv_sad = AVMMIN(min_pred_mv_sad, x->pred_mv_sad[ref_frame]);
+    }
+  }
 
   min_pred_mv_sad = AVMMIN(min_pred_mv_sad, x->pred_mv_sad[TIP_FRAME_INDEX]);
 
@@ -6823,8 +6826,8 @@ static AVM_INLINE void set_params_rd_pick_inter_mode(
   for (ref_frame = 0; ref_frame < INTER_REFS_PER_FRAME; ++ref_frame) {
     x->mbmi_ext->mode_context[ref_frame] = 0;
     mbmi_ext->ref_mv_count[ref_frame] = UINT8_MAX;
+    x->pred_mv_sad[ref_frame] = INT_MAX;
     if ((cm->ref_frame_flags & (1 << ref_frame))) {
-      x->pred_mv_sad[ref_frame] = INT_MAX;
       if (mbmi->partition != PARTITION_NONE &&
           mbmi->partition != PARTITION_SPLIT) {
         if (skip_ref_frame_mask & ((uint64_t)1 << ref_frame) &&

--- a/test/multi_layer_test.cc
+++ b/test/multi_layer_test.cc
@@ -83,6 +83,16 @@ class MultiLayerTest : public ::libavm_test::CodecTestWithParam<int>,
       if (enable_explicit_ref_frame_map_) {
         encoder->Control(AV2E_SET_ENABLE_EXPLICIT_REF_FRAME_MAP, 1);
       }
+      // Forced sequential buffer refresh is not temporally scalable when TMVP
+      // is enabled. If the decoder drops TL1 frames, its DPB will diverge from
+      // the encoder's DPB (missing TL1 refreshes). This divergence leads to
+      // different reference ranking and motion vector scaling parameters,
+      // causing decode failures. Thus, we must disable TMVP for these test
+      // cases.
+      if (enable_buffer_refresh_test_ && num_temporal_layers_ > 1) {
+        encoder->Control(AV2E_SET_ENABLE_REF_FRAME_MVS, 0);
+        encoder->Control(AV2E_SET_ALLOW_REF_FRAME_MVS, 0);
+      }
       if (cfg_.g_lag_in_frames > 0) {
         int gop_size = (cfg_.g_lag_in_frames - 1) / num_embedded_layers_;
         if (pyramid_level_one_) {


### PR DESCRIPTION
When some reference frames are disabled, the encoder was making incorrect mode skipping decisions because it was using uninitialized or stale MV SAD values in x->pred_mv_sad from these disabled reference frames. This corrupted the RDO skipping logic, leading to suboptimal encoding with --max-reference-frames < 7

This fixes this issue by properly intializing the SAD values and adding a check to ensure that only enabled reference frames are considered when calculating min_pred_mv_sad.

In MultiLayerTest, TMVP is disabled because the test drops TL1 frames and causes the DPB to diverge at encoder and decoder, leading to TMVP mismatches. The test passes before because the encoder issue accidentally avoids using the TMVP, which hided the test issue. Since this is a test issue, not an encoder issue, we turn off TMVP in the test.

Coding performance with 17 frames on A4 and A5 with different --max-reference-frames

          Before   After
refs=7    +0.00    +0.00
refs=6    +0.47    +0.06
refs=5    +0.57    +0.13
refs=4    +0.61    +0.16
refs=3    +0.70    +0.24