### PR TITLE
decoder.c: use internal_error correctly

### DIFF
--- a/av2/av2_dx_iface.c
+++ b/av2/av2_dx_iface.c
@@ -1301,7 +1301,8 @@ static avm_codec_err_t ctrl_set_reference(avm_codec_alg_priv_t *ctx,
   av2_ref_frame_t *const data = va_arg(args, av2_ref_frame_t *);
 
   if (data) {
-    avm_image_t *hbd_img = NULL;
+    // Must be declared as `volatile` due to the `setjmp` call below.
+    avm_image_t *volatile hbd_img = NULL;
     av2_ref_frame_t *const frame = data;
     YV12_BUFFER_CONFIG sd;
     AVxWorker *const worker = ctx->frame_worker;
@@ -1315,9 +1316,18 @@ static avm_codec_err_t ctrl_set_reference(avm_codec_alg_priv_t *ctx,
     } else {
       image2yuvconfig(&frame->img, &sd);
     }
-    avm_codec_err_t res =
-        av2_set_reference_dec(&frame_worker_data->pbi->common, frame->idx,
-                              frame->use_external_ref, &sd);
+    avm_codec_err_t res = AVM_CODEC_OK;
+    struct avm_internal_error_info *const error =
+        &frame_worker_data->pbi->common.error;
+    if (setjmp(error->jmp)) {
+      error->setjmp = 0;
+      res = error->error_code;
+    } else {
+      error->setjmp = 1;
+      res = av2_set_reference_dec(&frame_worker_data->pbi->common, frame->idx,
+                                  frame->use_external_ref, &sd);
+      error->setjmp = 0;
+    }
     avm_img_free(hbd_img);
     return res;
   } else {
@@ -1337,7 +1347,18 @@ static avm_codec_err_t ctrl_copy_reference(avm_codec_alg_priv_t *ctx,
       return AVM_CODEC_INVALID_PARAM;
     }
     image2yuvconfig(&frame->img, &sd);
-    return av2_copy_reference_dec(frame_worker_data->pbi, frame->idx, &sd);
+    avm_codec_err_t res = AVM_CODEC_OK;
+    struct avm_internal_error_info *const error =
+        &frame_worker_data->pbi->common.error;
+    if (setjmp(error->jmp)) {
+      error->setjmp = 0;
+      res = error->error_code;
+    } else {
+      error->setjmp = 1;
+      res = av2_copy_reference_dec(frame_worker_data->pbi, frame->idx, &sd);
+      error->setjmp = 0;
+    }
+    return res;
   } else {
     return AVM_CODEC_INVALID_PARAM;
   }

--- a/av2/av2_dx_iface.c
+++ b/av2/av2_dx_iface.c
@@ -1320,14 +1320,13 @@ static avm_codec_err_t ctrl_set_reference(avm_codec_alg_priv_t *ctx,
     struct avm_internal_error_info *const error =
         &frame_worker_data->pbi->common.error;
     if (setjmp(error->jmp)) {
-      error->setjmp = 0;
       res = error->error_code;
     } else {
       error->setjmp = 1;
       res = av2_set_reference_dec(&frame_worker_data->pbi->common, frame->idx,
                                   frame->use_external_ref, &sd);
-      error->setjmp = 0;
     }
+    error->setjmp = 0;
     avm_img_free(hbd_img);
     return res;
   } else {
@@ -1352,12 +1351,11 @@ static avm_codec_err_t ctrl_copy_reference(avm_codec_alg_priv_t *ctx,
         &frame_worker_data->pbi->common.error;
     if (setjmp(error->jmp)) {
       error->setjmp = 0;
-      res = error->error_code;
-    } else {
-      error->setjmp = 1;
-      res = av2_copy_reference_dec(frame_worker_data->pbi, frame->idx, &sd);
-      error->setjmp = 0;
+      return error->error_code;
     }
+    error->setjmp = 1;
+    res = av2_copy_reference_dec(frame_worker_data->pbi, frame->idx, &sd);
+    error->setjmp = 0;
     return res;
   } else {
     return AVM_CODEC_INVALID_PARAM;

--- a/av2/decoder/decoder.c
+++ b/av2/decoder/decoder.c
@@ -498,11 +498,12 @@ avm_codec_err_t av2_copy_reference_dec(AV2Decoder *pbi, int idx,
                                        YV12_BUFFER_CONFIG *sd) {
   AV2_COMMON *cm = &pbi->common;
   const int num_planes = av2_num_planes(cm);
+  // Ensure that avm_internal_error() calls longjmp().
+  assert(cm->error.setjmp);
 
   const YV12_BUFFER_CONFIG *const cfg = get_ref_frame(cm, idx);
   if (cfg == NULL) {
     avm_internal_error(&cm->error, AVM_CODEC_ERROR, "No reference frame");
-    return AVM_CODEC_ERROR;
   }
   if (!equal_dimensions(cfg, sd))
     avm_internal_error(&cm->error, AVM_CODEC_ERROR,
@@ -526,13 +527,13 @@ avm_codec_err_t av2_set_reference_dec(AV2_COMMON *cm, int idx,
                                       YV12_BUFFER_CONFIG *sd) {
   const int num_planes = av2_num_planes(cm);
   YV12_BUFFER_CONFIG *ref_buf = NULL;
-
+  // Ensure that avm_internal_error() calls longjmp().
+  assert(cm->error.setjmp);
   // Get the destination reference buffer.
   ref_buf = get_ref_frame(cm, idx);
 
   if (ref_buf == NULL) {
     avm_internal_error(&cm->error, AVM_CODEC_ERROR, "No reference frame");
-    return AVM_CODEC_ERROR;
   }
 
   if (!use_external_ref) {


### PR DESCRIPTION
Migrated from libaom:
https://aomedia-review.git.corp.google.com/c/aom/+/203641

Also, a similar fix in ctrl_copy_reference().

#5044 