### PR TITLE
Fix a potential leak in aom_film_grain_table_read

### DIFF
--- a/avm_dsp/grain_table.c
+++ b/avm_dsp/grain_table.c
@@ -289,13 +289,14 @@ avm_codec_err_t avm_film_grain_table_read(
                            "Unable to allocate grain table entry");
       }
       memset(entry, 0, sizeof(*entry));
-      grain_table_entry_read(file, error_info, entry);
       entry->next = NULL;
 
       if (prev_entry) prev_entry->next = entry;
       if (!t->head) t->head = entry;
       t->tail = entry;
       prev_entry = entry;
+
+      grain_table_entry_read(file, error_info, entry);
     }
   }
 


### PR DESCRIPTION
If grain_table_entry_read() calls aom_internal_error(), `entry` will be leaked. To avoid this leak, add `entry` to `t` before calling grain_table_entry_read().

Cherry-picked from libaom:
https://aomedia-review.git.corp.google.com/c/aom/+/213222