### PR TITLE
Fix encoder crash at low (negative) QP for trellis related function

### DIFF
--- a/av2/encoder/trellis_quant.c
+++ b/av2/encoder/trellis_quant.c
@@ -396,7 +396,7 @@ void av2_pre_quant_c(tran_low_t tqc, struct prequant_t *pqData,
   tran_low_t abs_tqc = abs(tqc);
 
   tran_low_t qIdx = (int)AVMMAX(
-      1, AVMMIN(((1 << 16) - 1),
+      1, AVMMIN(INT16_MAX,
                 ((int64_t)abs_tqc * quant_ptr[scan_pos != 0] + add) >> shift));
   pqData->qIdx = qIdx;
 

--- a/av2/encoder/x86/trellis_quant_avx2.c
+++ b/av2/encoder/x86/trellis_quant_avx2.c
@@ -200,7 +200,7 @@ void av2_pre_quant_avx2(tran_low_t tqc, struct prequant_t *pqData,
   int32_t abs_tqc = abs(tqc);
 
   int32_t qIdx = (int)AVMMAX(
-      1, AVMMIN(((1 << 16) - 1),
+      1, AVMMIN(INT16_MAX,
                 ((int64_t)abs_tqc * quant_ptr[scan_pos != 0] + add) >> shift));
   pqData->qIdx = qIdx;
 


### PR DESCRIPTION
Two encoder-only trellis bugs:

1. Clamp base_ctx/mid_ctx to LF_SIG_COEF_CONTEXTS-2 / LF_LEVEL_CONTEXTS-2 in C and AVX2. base_diag_ctx + (coef & 0xF) could reach 47, exceeding the 33-entry context table. The -2 margin keeps the AVX2 [ctx][1] 8-byte loads in bounds.

2. av2_pre_quant clamped qIdx to (1<<16)-1, but prequant_t::qIdx is int16_t — values >= 32768 sign-truncate to negative and produce wild pointers downstream. Tighten the clamp to INT16_MAX in C and AVX2.

Decoder unaffected; bitstreams remain spec-compliant.

I think this bugfix should impact also 8-bit and 10-bit very low QP (negative QPs), but so far I only verified on 12bit sequences with negative QP setting.

Issue can bre reproduced: Waterfall / ParkJoy / NocturneDance 3840x2160 yuv422p12 at qp=-41 or qp=-16.