### PR TITLE
Fix sync_enc_workers to read error status of master thread

### DIFF
--- a/av2/encoder/ethread.c
+++ b/av2/encoder/ethread.c
@@ -673,7 +673,7 @@ static AVM_INLINE void launch_enc_workers(MultiThreadInfo *const mt_info,
 static AVM_INLINE void sync_enc_workers(MultiThreadInfo *const mt_info,
                                         AV2_COMMON *const cm, int num_workers) {
   const AVxWorkerInterface *const winterface = avm_get_worker_interface();
-  int had_error = 0;
+  int had_error = mt_info->workers[0].had_error;
 
   // Encoding ends.
   for (int i = num_workers - 1; i >= 0; i--) {


### PR DESCRIPTION
In sync_enc_workers(), winterface->sync() is invoked on the worker threads and the same is used to read the error status of each thread. The sync of master thread was avoided to facilitate FPMT, but its error status still needs to be read to facilitates the error propagation. This CL initializes 'had_error' with the error status of the master thread to fix this issue.

Migrated from libaom:
https://aomedia-review.git.corp.google.com/c/aom/+/176341

#5044 