### PR TITLE
Propagate error from worker to main thread during tile-MT

### DIFF
--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -3378,7 +3378,9 @@ static avm_codec_err_t encoder_encode(avm_codec_alg_priv_t *ctx,
           &dst_end_time_stamp_la, !img, timestamp_ratio);
       if (status != -1) {
         if (status != AVM_CODEC_OK) {
-          avm_internal_error(&cpi_lap->common.error, AVM_CODEC_ERROR, NULL);
+          avm_internal_error(&cpi_lap->common.error,
+                             cpi->common.error.error_code, "%s",
+                             cpi->common.error.detail);
         }
         cpi_lap->seq_params_locked = 1;
       }
@@ -3412,7 +3414,8 @@ static avm_codec_err_t encoder_encode(avm_codec_alg_priv_t *ctx,
       cx_time += avm_usec_timer_elapsed(&timer);
       if (status == -1) break;
       if (status != AVM_CODEC_OK) {
-        avm_internal_error(&cpi->common.error, AVM_CODEC_ERROR, NULL);
+        avm_internal_error(&cpi->common.error, cpi->common.error.error_code,
+                           "%s", cpi->common.error.detail);
       }
 
       const int mlayer_id = cpi->common.mlayer_id;

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -3378,9 +3378,7 @@ static avm_codec_err_t encoder_encode(avm_codec_alg_priv_t *ctx,
           &dst_end_time_stamp_la, !img, timestamp_ratio);
       if (status != -1) {
         if (status != AVM_CODEC_OK) {
-          avm_internal_error(&cpi_lap->common.error,
-                             cpi->common.error.error_code, "%s",
-                             cpi->common.error.detail);
+          avm_internal_error(&cpi_lap->common.error, status, NULL);
         }
         cpi_lap->seq_params_locked = 1;
       }
@@ -3414,8 +3412,7 @@ static avm_codec_err_t encoder_encode(avm_codec_alg_priv_t *ctx,
       cx_time += avm_usec_timer_elapsed(&timer);
       if (status == -1) break;
       if (status != AVM_CODEC_OK) {
-        avm_internal_error(&cpi->common.error, cpi->common.error.error_code,
-                           "%s", cpi->common.error.detail);
+        avm_internal_error(&cpi->common.error, status, NULL);
       }
 
       const int mlayer_id = cpi->common.mlayer_id;

--- a/av2/encoder/ethread.c
+++ b/av2/encoder/ethread.c
@@ -440,12 +440,25 @@ static int enc_row_mt_worker_hook(void *arg1, void *unused) {
 static int enc_worker_hook(void *arg1, void *unused) {
   EncWorkerData *const thread_data = (EncWorkerData *)arg1;
   AV2_COMP *const cpi = thread_data->cpi;
+  MACROBLOCKD *const xd = &thread_data->td->mb.e_mbd;
+  struct avm_internal_error_info *const error_info = &thread_data->error_info;
   const AV2_COMMON *const cm = &cpi->common;
   const int tile_cols = cm->tiles.cols;
   const int tile_rows = cm->tiles.rows;
   int t;
 
   (void)unused;
+
+  xd->error_info = error_info;
+
+  // The jmp_buf is valid only for the duration of the function that calls
+  // setjmp(). Therefore, this function must reset the 'setjmp' field to 0
+  // before it returns.
+  if (setjmp(error_info->jmp)) {
+    error_info->setjmp = 0;
+    return 0;
+  }
+  error_info->setjmp = 1;
 
   for (t = thread_data->start; t < tile_rows * tile_cols;
        t += cpi->mt_info.num_workers) {
@@ -458,6 +471,7 @@ static int enc_worker_hook(void *arg1, void *unused) {
     av2_encode_tile(cpi, thread_data->td, tile_row, tile_col);
   }
 
+  error_info->setjmp = 0;
   return 1;
 }
 
@@ -674,16 +688,26 @@ static AVM_INLINE void sync_enc_workers(MultiThreadInfo *const mt_info,
                                         AV2_COMMON *const cm, int num_workers) {
   const AVxWorkerInterface *const winterface = avm_get_worker_interface();
   int had_error = mt_info->workers[0].had_error;
+  struct avm_internal_error_info error_info;
+
+  // Read the error_info of main thread.
+  if (had_error) {
+    AVxWorker *const worker = &mt_info->workers[0];
+    error_info = ((EncWorkerData *)worker->data1)->error_info;
+  }
 
   // Encoding ends.
   for (int i = num_workers - 1; i >= 0; i--) {
     AVxWorker *const worker = &mt_info->workers[i];
-    had_error |= !winterface->sync(worker);
+    if (!winterface->sync(worker)) {
+      had_error = 1;
+      error_info = ((EncWorkerData *)worker->data1)->error_info;
+    }
   }
 
   if (had_error)
-    avm_internal_error(&cm->error, AVM_CODEC_ERROR,
-                       "Failed to encode tile data");
+    avm_internal_error(&cm->error, error_info.error_code, "%s",
+                       error_info.detail);
 }
 
 static AVM_INLINE void accumulate_counters_enc_workers(AV2_COMP *cpi,

--- a/av2/encoder/ethread.h
+++ b/av2/encoder/ethread.h
@@ -23,6 +23,7 @@ struct ThreadData;
 typedef struct EncWorkerData {
   struct AV2_COMP *cpi;
   struct ThreadData *td;
+  struct avm_internal_error_info error_info;
   int start;
   int thread_id;
 } EncWorkerData;


### PR DESCRIPTION
This change sets a longjmp target in enc_worker_hook() to propagate error from worker threads to the main thread during tile multi-threading. Also, derives the error_info inside sync_enc_workers() to propagate the exact error details further.

Migrated from libaom:
https://aomedia-review.git.corp.google.com/c/aom/+/176342

#5044 