### PR TITLE
Propagate error from worker to main thread during row-MT

### DIFF
--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -1362,6 +1362,7 @@ static AVM_INLINE void encode_sb_row(AV2_COMP *cpi, ThreadData *td,
   const int mib_size = cm->mib_size;
   const int mib_size_log2 = cm->mib_size_log2;
   const int sb_row = (mi_row - tile_info->mi_row_start) >> mib_size_log2;
+  bool row_mt_exit = false;
 
 #if CONFIG_COLLECT_COMPONENT_TIMING
   start_timing(cpi, encode_sb_time);
@@ -1382,6 +1383,17 @@ static AVM_INLINE void encode_sb_row(AV2_COMP *cpi, ThreadData *td,
   for (int mi_col = tile_info->mi_col_start, sb_col_in_tile = 0;
        mi_col < tile_info->mi_col_end; mi_col += mib_size, sb_col_in_tile++) {
     (*(enc_row_mt->sync_read_ptr))(row_mt_sync, sb_row, sb_col_in_tile);
+
+#if CONFIG_MULTITHREAD
+    if (row_mt_enabled) {
+      pthread_mutex_lock(enc_row_mt->mutex_);
+      row_mt_exit = enc_row_mt->row_mt_exit;
+      pthread_mutex_unlock(enc_row_mt->mutex_);
+    }
+#endif
+    // Exit in case any worker has encountered an error.
+    if (row_mt_exit) return;
+
     av2_reset_is_mi_coded_map(xd, cm->mib_size);
     BruActiveMode sb_active_mode =
         enc_get_cur_sb_active_mode(cm, mi_col, mi_row);

--- a/av2/encoder/encoder.h
+++ b/av2/encoder/encoder.h
@@ -1701,6 +1701,12 @@ typedef struct {
    */
   int thread_id_to_tile_id[MAX_NUM_THREADS];
 
+  /*!
+   * Initialized to false, set to true by the worker thread that encounters an
+   * error in order to abort the processing of other worker threads.
+   */
+  bool row_mt_exit;
+
 #if CONFIG_MULTITHREAD
   /*!
    * Mutex lock used while dispatching jobs.

--- a/av2/encoder/ethread.c
+++ b/av2/encoder/ethread.c
@@ -199,6 +199,7 @@ static void row_mt_mem_alloc(AV2_COMP *cpi, int max_rows, int max_cols,
   enc_row_mt->allocated_tile_rows = tile_rows;
   enc_row_mt->allocated_rows = max_rows;
   enc_row_mt->allocated_cols = max_cols - 1;
+  enc_row_mt->row_mt_exit = false;
 }
 
 void av2_row_mt_mem_dealloc(AV2_COMP *cpi) {
@@ -363,28 +364,80 @@ static int fp_enc_row_mt_worker_hook(void *arg1, void *unused) {
   return 1;
 }
 
+static void set_encoding_done(AV2_COMP *cpi) {
+  AV2_COMMON *const cm = &cpi->common;
+  const int tile_cols = cm->tiles.cols;
+  const int tile_rows = cm->tiles.rows;
+  AV2EncRowMultiThreadInfo *const enc_row_mt = &cpi->mt_info.enc_row_mt;
+  const int mib_size = cm->seq_params.mib_size;
+
+  // In case of row-multithreading, due to top-right dependency, the worker on
+  // an SB row waits for the completion of the encode of the top and top-right
+  // SBs. Hence, in case a thread (main/worker) encounters an error, update that
+  // encoding of every SB row in the frame is complete in order to avoid the
+  // dependent workers of every tile from waiting indefinitely.
+  for (int tile_row = 0; tile_row < tile_rows; tile_row++) {
+    for (int tile_col = 0; tile_col < tile_cols; tile_col++) {
+      TileDataEnc *const this_tile =
+          &cpi->tile_data[tile_row * tile_cols + tile_col];
+      const TileInfo *const tile_info = &this_tile->tile_info;
+      AV2EncRowMultiThreadSync *const row_mt_sync = &this_tile->row_mt_sync;
+      const int sb_cols_in_tile = av2_get_sb_cols_in_tile(cm, *tile_info);
+      for (int mi_row = tile_info->mi_row_start, sb_row_in_tile = 0;
+           mi_row < tile_info->mi_row_end;
+           mi_row += mib_size, sb_row_in_tile++) {
+        enc_row_mt->sync_write_ptr(row_mt_sync, sb_row_in_tile,
+                                   sb_cols_in_tile - 1, sb_cols_in_tile);
+      }
+    }
+  }
+}
+
 static int enc_row_mt_worker_hook(void *arg1, void *unused) {
   EncWorkerData *const thread_data = (EncWorkerData *)arg1;
   AV2_COMP *const cpi = thread_data->cpi;
-  AV2_COMMON *const cm = &cpi->common;
   int thread_id = thread_data->thread_id;
   AV2EncRowMultiThreadInfo *const enc_row_mt = &cpi->mt_info.enc_row_mt;
-  int cur_tile_id = enc_row_mt->thread_id_to_tile_id[thread_id];
 #if CONFIG_MULTITHREAD
   pthread_mutex_t *enc_row_mt_mutex_ = enc_row_mt->mutex_;
 #endif
   (void)unused;
 
+  struct avm_internal_error_info *const error_info = &thread_data->error_info;
+  MACROBLOCKD *const xd = &thread_data->td->mb.e_mbd;
+  xd->error_info = error_info;
+
+  // The jmp_buf is valid only for the duration of the function that calls
+  // setjmp(). Therefore, this function must reset the 'setjmp' field to 0
+  // before it returns.
+  if (setjmp(error_info->jmp)) {
+    error_info->setjmp = 0;
+#if CONFIG_MULTITHREAD
+    pthread_mutex_lock(enc_row_mt_mutex_);
+    enc_row_mt->row_mt_exit = true;
+    pthread_mutex_unlock(enc_row_mt_mutex_);
+#endif
+    set_encoding_done(cpi);
+    return 0;
+  }
+  error_info->setjmp = 1;
+
+  AV2_COMMON *const cm = &cpi->common;
+  int cur_tile_id = enc_row_mt->thread_id_to_tile_id[thread_id];
+
   assert(cur_tile_id != -1);
 
   int end_of_frame = 0;
+  bool row_mt_exit = false;
+
   while (1) {
     int current_mi_row = -1;
 #if CONFIG_MULTITHREAD
     pthread_mutex_lock(enc_row_mt_mutex_);
 #endif
-    if (!get_next_job(&cpi->tile_data[cur_tile_id], &current_mi_row,
-                      cm->mib_size)) {
+    row_mt_exit = enc_row_mt->row_mt_exit;
+    if (!row_mt_exit && !get_next_job(&cpi->tile_data[cur_tile_id],
+                                      &current_mi_row, cm->mib_size)) {
       // No jobs are available for the current tile. Query for the status of
       // other tiles and get the next job if available
       switch_tile_and_get_next_job(cm, cpi->tile_data, &cur_tile_id,
@@ -393,6 +446,10 @@ static int enc_row_mt_worker_hook(void *arg1, void *unused) {
 #if CONFIG_MULTITHREAD
     pthread_mutex_unlock(enc_row_mt_mutex_);
 #endif
+    // When row_mt_exit is set to true, other workers need not pursue any
+    // further jobs.
+    if (row_mt_exit) return 1;
+
     if (end_of_frame == 1) break;
 
     TileDataEnc *const this_tile = &cpi->tile_data[cur_tile_id];
@@ -434,6 +491,7 @@ static int enc_row_mt_worker_hook(void *arg1, void *unused) {
 #endif
   }
 
+  error_info->setjmp = 0;
   return 1;
 }
 


### PR DESCRIPTION
This change sets a longjmp target in enc_row_mt_worker_hook() to propagate error from worker threads to the main thread during row multi-threading. It also handles the error propagation in case of pipelining of loop filter MT after encoding.

Migrated from libaom:
https://aomedia-review.git.corp.google.com/c/aom/+/177341

#5044 