### PR TITLE
Remove avm_read_obu_header and av2_get_fwd_txfm_cfg from exports

### DIFF
--- a/av2/exports_test
+++ b/av2/exports_test
@@ -1,2 +1,1 @@
-text av2_get_fwd_txfm_cfg
 text av2_rtcd

--- a/avm/exports_dec
+++ b/avm/exports_dec
@@ -6,4 +6,3 @@ text avm_codec_peek_stream_info
 text avm_codec_set_frame_buffer_functions
 text avm_obu_type_is_valid
 text avm_obu_type_to_string
-text avm_read_obu_header


### PR DESCRIPTION
These functions no longer exist.

Closes #5047 