### PR TITLE
Destroy codec context in case of an error

### DIFF
--- a/apps/avmenc.c
+++ b/apps/avmenc.c
@@ -85,7 +85,10 @@ static void warn_or_exit_on_errorv(avm_codec_ctx_t *ctx, int fatal,
 
     if (detail) fprintf(stderr, "    %s\n", detail);
 
-    if (fatal) exit(EXIT_FAILURE);
+    if (fatal) {
+      avm_codec_destroy(ctx);
+      exit(EXIT_FAILURE);
+    }
   }
 }
 


### PR DESCRIPTION
This CL destroys the codec context in case of an
error by calling aom_codec_destroy() inside
warn_or_exit_on_errorv().

Migrated from libaom:
https://aomedia-review.git.corp.google.com/c/aom/+/178221

#5044 