### PR TITLE
Fix the spelling error "decoderm" (#5029)

### DIFF
--- a/avm/avm.h
+++ b/avm/avm.h
@@ -53,7 +53,7 @@ enum avm_com_control_id {
                                av2_ref_frame_t* parameter */
   AV2_SET_REFERENCE = 129,  /**< write a frame into a reference buffer,
                                av2_ref_frame_t* parameter */
-  AV2_COPY_REFERENCE = 130, /**< get a copy of reference frame from the decoderm
+  AV2_COPY_REFERENCE = 130, /**< get a copy of reference frame from the decoder
                                av2_ref_frame_t* parameter */
   AVM_COMMON_CTRL_ID_MAX,
 


### PR DESCRIPTION
(cherry picked from commit d962849cd6927f2876c3cfb85388a6c413628dd4)