### PR TITLE
Fixed an error that occurred when compiling the executable file (#5068)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -911,7 +911,8 @@ foreach(avm_app ${AVM_APP_TARGETS})
   target_link_libraries(${avm_app} ${AVM_LIB_LINK_TYPE} avm)
 endforeach()
 
-if(ENABLE_EXAMPLES
+if(ENABLE_APPS
+   OR ENABLE_EXAMPLES
    OR ENABLE_TESTS
    OR ENABLE_TOOLS)
   if(CONFIG_LIBYUV)


### PR DESCRIPTION
This fixes app-only builds where ENABLE_APPS=ON but ENABLE_TESTS,
ENABLE_EXAMPLES, and ENABLE_TOOLS are OFF. avmdec/avmenc still need
libyuv/webm include paths and object sources.

Verified locally:
```
cmake --build build_fast --target avmdec -j8
cmake --build build_fast --target avmenc -j8
```

Fixes #5068 