### PR TITLE
Fix accidental disabling of masked compound in REFINE_ALL mode

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -4113,7 +4113,7 @@ static int process_compound_inter_mode(
       is_any_masked_compound_used(bsize) &&
       cm->seq_params.enable_masked_compound &&
       (!mbmi->refinemv_flag || !switchable_refinemv_flag(cm, mbmi)) &&
-      !opfl_allowed_cur_pred_mode(cm, xd, mbmi);
+      mbmi->mode < NEAR_NEARMV_OPTFLOW;
   int mode_search_mask =
       (1 << COMPOUND_AVERAGE) | (1 << COMPOUND_WEDGE) | (1 << COMPOUND_DIFFWTD);
 


### PR DESCRIPTION
In REFINE_ALL mode, the encoder incorrectly disabled the search for masked compound modes (WEDGE and DIFFWTD) for regular compound modes such as NEW_NEWMV.

This issue was introduced in commit 7085cf3c75 ("CWG-F107 Fix OPFL issues and remove DAMR") after v10 anchor. There, the condition for masked_compound_used in process_compound_inter_mode(), which checked !opfl_allowed_cur_pred_mode(). Since mbmi->interinter_comp.type is initialized to COMPOUND_AVERAGE by default during the search, opfl_allowed_cur_pred_mode() returned true for regular modes in REFINE_ALL mode, incorrectly setting masked_compound_used to 0 and skipping the masked compound search.

This patch fixes the issue by changing the condition to check if the mode is a regular compound mode (mbmi->mode < NEAR_NEARMV_OPTFLOW) instead of using opfl_allowed_cur_pred_mode(). This ensures that masked compound is only disabled for explicit OPTFLOW modes (in REFINE_SWITCHABLE mode) and remains enabled for regular compound modes in REFINE_ALL mode.

This resolves a significant coding loss regression with --enable-opfl-refine=2

RA CTC on v15
Before the fix: +0.72% at 91.9% encoding time
After the fix: +0.25% at 98.1% encoding time