### PR TITLE
Validate bridge_frame_ref_idx read from bitstream

### DIFF
--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -8043,6 +8043,7 @@ static int read_uncompressed_header(AV2Decoder *pbi, OBU_TYPE obu_type,
     const int bridge_frame_ref_idx =
         avm_rb_read_literal(rb, seq_params->ref_frames_log2);
 
+    // Check reference is valid.
     if (bridge_frame_ref_idx >= seq_params->ref_frames) {
       avm_internal_error(
           &cm->error, AVM_CODEC_UNSUP_BITSTREAM,

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -8040,8 +8040,22 @@ static int read_uncompressed_header(AV2Decoder *pbi, OBU_TYPE obu_type,
 
   if (obu_type == OBU_BRIDGE_FRAME) {
     cm->bridge_frame_info.is_bridge_frame = 1;
-    cm->bridge_frame_info.bridge_frame_ref_idx =
+    const int bridge_frame_ref_idx =
         avm_rb_read_literal(rb, seq_params->ref_frames_log2);
+
+    if (bridge_frame_ref_idx >= seq_params->ref_frames) {
+      avm_internal_error(
+          &cm->error, AVM_CODEC_UNSUP_BITSTREAM,
+          "Bridge frame ref idx must be less than %d but is set to %d",
+          seq_params->ref_frames, bridge_frame_ref_idx);
+    }
+    RefCntBuffer *const bridge_frame_ref =
+        cm->ref_frame_map[bridge_frame_ref_idx];
+    if (bridge_frame_ref == NULL) {
+      avm_internal_error(&cm->error, AVM_CODEC_UNSUP_BITSTREAM,
+                         "Buffer does not contain a decoded frame");
+    }
+    cm->bridge_frame_info.bridge_frame_ref_idx = bridge_frame_ref_idx;
   } else {
     cm->bridge_frame_info.is_bridge_frame = 0;
     cm->bridge_frame_info.bridge_frame_ref_idx = INVALID_IDX;


### PR DESCRIPTION
read_uncompressed_header() should validate the bridge_frame_ref_idx
value read from the bitstream in the same way read_show_existing_frame()
validates the existing_frame_idx (called frame_to_show_map_idx in the
spec) value read from the bitstream, except that bridge_frame_ref_idx
can point to a restricted reference frame.

Fixes https://github.com/AOMediaCodec/avm/issues/5073.