### PR TITLE
Disable AVM encoder row-mt

### DIFF
--- a/av2/arg_defs.c
+++ b/av2/arg_defs.c
@@ -325,7 +325,7 @@ const av2_codec_arg_definitions_t g_av2_codec_arg_defs = {
   .cpu_used_av2 = ARG_DEF(NULL, "cpu-used", 1, "Speed setting (0..9)"),
   .rowmtarg =
       ARG_DEF(NULL, "row-mt", 1,
-              "Enable row based multi-threading (0: off, 1: on (default))"),
+              "Enable row based multi-threading (0: off (default), 1: on)"),
   .tile_cols =
       ARG_DEF(NULL, "tile-columns", 1, "Number of tile columns to use, log2"),
   .tile_rows =

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -382,7 +382,7 @@ static struct av2_extracfg default_extra_cfg = {
   0,  // noise_sensitivity
   0,  // sharpness
   0,  // static_thresh
-  1,  // row_mt
+  0,  // row_mt
   0,  // tile_columns
   0,  // tile_rows
   1,  // enable_tpl_model


### PR DESCRIPTION
AVM encoder row-mt implementation mostly inherits from AV1 but isn't throughly tested/re-developed, here we disable it for now.

Fix #5046