### PR TITLE
Apply Zizmor

### DIFF
--- a/.github/workflows/build-job-reusable.yaml
+++ b/.github/workflows/build-job-reusable.yaml
@@ -58,10 +58,11 @@ jobs:
       AVM_BUILD_CONFIG: ${{ inputs.avm-build-config }}
       PARENT_JOB_NAME: ${{ inputs.parent-job-name }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 50
           lfs: true
+          persist-credentials: false
 
       - uses: ./.github/actions/common-setup
         with:
@@ -69,9 +70,11 @@ jobs:
           extra-env-vars: ${{ inputs.extra-env-vars }}
 
       - name: Run before-script
-        run: ${{ inputs.before-script }}
+        run: ${INPUTS_BEFORE_SCRIPT}
+        env:
+          INPUTS_BEFORE_SCRIPT: ${{ inputs.before-script }}
 
-      - uses: actions/cache/restore@v5
+      - uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ccache
           key: non-existent
@@ -179,13 +182,13 @@ jobs:
         run: |
           ccache --show-stats
 
-      - uses: actions/cache/save@v5
+      - uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ccache
           key: ${{ inputs.parent-job-name }}-${{ inputs.avm-build-config }}-${{ github.run_id }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ success() && inputs.artifact-paths != '' }}
         with:
           name: ${{ inputs.parent-job-name }}-${{ inputs.avm-build-config }}

--- a/.github/workflows/build-job-reusable.yaml
+++ b/.github/workflows/build-job-reusable.yaml
@@ -70,9 +70,7 @@ jobs:
           extra-env-vars: ${{ inputs.extra-env-vars }}
 
       - name: Run before-script
-        run: ${INPUTS_BEFORE_SCRIPT}
-        env:
-          INPUTS_BEFORE_SCRIPT: ${{ inputs.before-script }}
+        run: ${{ inputs.before-script }}
 
       - uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:

--- a/.github/workflows/common-builds-reusable.yaml
+++ b/.github/workflows/common-builds-reusable.yaml
@@ -302,10 +302,11 @@ jobs:
     container:
       image: ${{ inputs.container-image }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 50
           lfs: true
+          persist-credentials: false
 
       - uses: ./.github/actions/common-setup
 
@@ -326,7 +327,7 @@ jobs:
           cmake --build avm_docs_build --target docs
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success()
         with:
           name: documentation
@@ -353,14 +354,15 @@ jobs:
       CCACHE_COMPILERCHECK: content
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 50
           lfs: true
+          persist-credentials: false
 
       - uses: ./.github/actions/common-setup
 
-      - uses: actions/cache/restore@v5
+      - uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ccache
           key: non-existent
@@ -427,13 +429,13 @@ jobs:
         run: |
           ccache --show-stats
 
-      - uses: actions/cache/save@v5
+      - uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ccache
           key: ${{ github.job }}-${{ matrix.avm-sanitizer-type }}-${{ github.run_id }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: avm-sanitizers-${{ matrix.avm-sanitizer-type }}
@@ -465,15 +467,16 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       CCACHE_COMPILERCHECK: content
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 50
           fetch-tags: true
           lfs: true
+          persist-credentials: false
 
       - uses: ./.github/actions/common-setup
 
-      - uses: actions/cache/restore@v5
+      - uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ccache
           key: non-existent
@@ -502,13 +505,13 @@ jobs:
         run: |
           ccache --show-stats
 
-      - uses: actions/cache/save@v5
+      - uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ccache
           key: ${{ github.job }}-${{ github.run_id }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success()
         with:
           name: example-build

--- a/.github/workflows/common-test-data-reusable.yaml
+++ b/.github/workflows/common-test-data-reusable.yaml
@@ -26,10 +26,11 @@ jobs:
     env:
       LIBAVM_TEST_DATA_PATH: ${{ github.workspace }}/libavm-test-data
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 50
           lfs: true
+          persist-credentials: false
 
       - uses: ./.github/actions/common-setup
 
@@ -39,7 +40,7 @@ jobs:
           cmake --build avm_testdata --target testdata
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success()
         with:
           name: "${{ github.job }}"

--- a/.github/workflows/sanitizer-job-reusable.yaml
+++ b/.github/workflows/sanitizer-job-reusable.yaml
@@ -61,10 +61,11 @@ jobs:
       AVM_SANITIZER_TYPE: ${{ inputs.avm-sanitizer-type }}
       USE_LARGE_TESTS: ${{ inputs.use-large-tests }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 50
           lfs: true
+          persist-credentials: false
 
       - uses: ./.github/actions/common-setup
         with:
@@ -72,12 +73,12 @@ jobs:
           extra-env-vars: ${{ inputs.extra-env-vars }}
 
       - name: Get sanitizer build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: avm-sanitizers-${{ inputs.avm-sanitizer-type }}
 
       - name: Get test data
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: test-data
           path: libavm-test-data
@@ -95,7 +96,9 @@ jobs:
           done
 
       - name: Run before-script
-        run: ${{ inputs.before-script }}
+        run: ${INPUTS_BEFORE_SCRIPT}
+        env:
+          INPUTS_BEFORE_SCRIPT: ${{ inputs.before-script }}
 
       - name: Run sanitizer
         run: |
@@ -227,7 +230,7 @@ jobs:
           exit ${exit_code}
 
       - name: Upload logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ always() }}
         with:
           name: sanitizer-${{ inputs.avm-sanitizer-type }}-logs

--- a/.github/workflows/sanitizer-job-reusable.yaml
+++ b/.github/workflows/sanitizer-job-reusable.yaml
@@ -96,9 +96,7 @@ jobs:
           done
 
       - name: Run before-script
-        run: ${INPUTS_BEFORE_SCRIPT}
-        env:
-          INPUTS_BEFORE_SCRIPT: ${{ inputs.before-script }}
+        run: ${{ inputs.before-script }}
 
       - name: Run sanitizer
         run: |


### PR DESCRIPTION
See https://github.com/zizmorcore/zizmor.

We pin GitHub Actions used in CI workflows to git hashes instead of version tags. 

Similar change was also made to libavif's CI workflows in PR AOMediaCodec/libavif#1515 at the suggestion of Google's security team. The rationale is described in issue AOMediaCodec/libavif#1514.

<details>

<summary><code>zizmor --fix=all --gh-token=$(gh auth token) .github/workflows</code> output</summary>

```
 INFO zizmor: \U0001f308 zizmor v1.25.2
 WARN collect_inputs: zizmor::registry::input: failed to validate file://.github/workflows/pull_request.yaml as workflow: input does not match expected validation schema
 WARN collect_inputs: zizmor::registry::input: failed to validate file://.github/workflows/nightly.yaml as workflow: input does not match expected validation schema
 INFO audit: zizmor: \U0001f308 completed .github/workflows/build-job-reusable.yaml
 INFO audit: zizmor: \U0001f308 completed .github/workflows/common-builds-reusable.yaml
 INFO audit: zizmor: \U0001f308 completed .github/workflows/common-test-data-reusable.yaml
 INFO audit: zizmor: \U0001f308 completed .github/workflows/sanitizer-job-reusable.yaml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/build-job-reusable.yaml:61:9
   |
61 |         - uses: actions/checkout@v5
   |  _________^
62 | |         with:
63 | |           fetch-depth: 50
64 | |           lfs: true
   | |___________________^ does not set persist-credentials: false
   |
   = note: audit confidence \u2192 Low
   = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> .github/workflows/build-job-reusable.yaml:72:18
   |
72 |         run: ${{ inputs.before-script }}
   |         ---      ^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |         |
   |         this run block
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/build-job-reusable.yaml:61:15
   |
61 |       - uses: actions/checkout@v5
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/build-job-reusable.yaml:74:15
   |
74 |       - uses: actions/cache/restore@v5
   |               ^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/build-job-reusable.yaml:182:15
    |
182 |       - uses: actions/cache/save@v5
    |               ^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/build-job-reusable.yaml:188:15
    |
188 |         uses: actions/upload-artifact@v7
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-images]: unpinned image references
  --> .github/workflows/build-job-reusable.yaml:51:18
   |
51 |       image: ${{ inputs.container-image }}
   |                  ^^^^^^^^^^^^^^^^^^^^^^ container image may be unpinned
   |
   = note: audit confidence \u2192 Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/common-builds-reusable.yaml:305:9
    |
305 |         - uses: actions/checkout@v5
    |  _________^
306 | |         with:
307 | |           fetch-depth: 50
308 | |           lfs: true
    | |___________________^ does not set persist-credentials: false
    |
    = note: audit confidence \u2192 Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/common-builds-reusable.yaml:356:9
    |
356 |         - uses: actions/checkout@v5
    |  _________^
357 | |         with:
358 | |           fetch-depth: 50
359 | |           lfs: true
    | |___________________^ does not set persist-credentials: false
    |
    = note: audit confidence \u2192 Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/common-builds-reusable.yaml:468:9
    |
468 |         - uses: actions/checkout@v5
    |  _________^
469 | |         with:
470 | |           fetch-depth: 50
471 | |           fetch-tags: true
472 | |           lfs: true
    | |___________________^ does not set persist-credentials: false
    |
    = note: audit confidence \u2192 Low
    = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/common-builds-reusable.yaml:23:3
   |
23 | /   build-generic-gnu:
24 | |     name: Build (generic-gnu)
25 | |     uses: ./.github/workflows/build-job-reusable.yaml
26 | |     if: (!cancelled())
...  |
45 | |           - inspection-accounting
46 | |           - no-examples
   | |                       ^
   | |                       |
   | |_______________________this job
   |                         default permissions used due to no permissions: block
   |
   = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/common-builds-reusable.yaml:48:3
   |
48 | /   build-x86_64-linux-gcc:
49 | |     name: Build (x86_64-linux-gcc)
50 | |     uses: ./.github/workflows/build-job-reusable.yaml
51 | |     if: (!cancelled())
...  |
72 | |           - debug
73 | |           - enable-12bit-profile
   | |                                ^
   | |                                |
   | |________________________________this job
   |                                  default permissions used due to no permissions: block
   |
   = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/common-builds-reusable.yaml:75:3
   |
75 | /   build-entropy-stats:
76 | |     name: Build (entropy-stats)
77 | |     uses: ./.github/workflows/build-job-reusable.yaml
78 | |     if: (!cancelled())
...  |
90 | |         avm-build-config:
91 | |           - entropy-stats
   | |                         ^
   | |                         |
   | |_________________________this job
   |                           default permissions used due to no permissions: block
   |
   = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:93:3
    |
 93 | /   build-bitstream-mismatch-debug:
 94 | |     name: Build (bitstream-mismatch-debug)
 95 | |     uses: ./.github/workflows/build-job-reusable.yaml
 96 | |     if: (!cancelled())
...   |
105 | |         avm-build-config:
106 | |           - bitstream-mismatch-debug
    | |                                    ^
    | |                                    |
    | |____________________________________this job
    |                                      default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:108:3
    |
108 | /   build-enable-12bit-profile:
109 | |     name: Build (enable-12bit-profile)
110 | |     uses: ./.github/workflows/build-job-reusable.yaml
111 | |     if: (!cancelled())
...   |
120 | |         avm-build-config:
121 | |           - enable-12bit-profile
    | |                                ^
    | |                                |
    | |________________________________this job
    |                                  default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:123:3
    |
123 | /   build-x86-linux-gcc:
124 | |     name: Build (x86-linux-gcc)
125 | |     uses: ./.github/workflows/build-job-reusable.yaml
126 | |     if: (!cancelled())
...   |
147 | |           - no-examples
148 | |           - debug
    | |                 ^
    | |                 |
    | |_________________this job
    |                   default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:150:3
    |
150 | /   build-aarch64-linux-gcc:
151 | |     name: Build (aarch64-linux-gcc)
152 | |     uses: ./.github/workflows/build-job-reusable.yaml
153 | |     if: (!cancelled())
...   |
173 | |           - inspection-accounting
174 | |           - no-examples
    | |                       ^
    | |                       |
    | |_______________________this job
    |                         default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:176:3
    |
176 | /   build-armv7-linux-gcc:
177 | |     name: Build (armv7-linux-gcc)
178 | |     uses: ./.github/workflows/build-job-reusable.yaml
179 | |     if: (!cancelled())
...   |
199 | |           - inspection-accounting
200 | |           - no-examples
    | |                       ^
    | |                       |
    | |_______________________this job
    |                         default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:202:3
    |
202 | /   build-ppc-linux-gcc:
203 | |     name: Build (ppc-linux-gcc)
204 | |     uses: ./.github/workflows/build-job-reusable.yaml
205 | |     if: (!cancelled())
...   |
226 | |           - no-examples
227 | |           - debug
    | |                 ^
    | |                 |
    | |_________________this job
    |                   default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:229:3
    |
229 | /   build-x86-mingw-gcc:
230 | |     name: Build (x86-mingw-gcc)
231 | |     uses: ./.github/workflows/build-job-reusable.yaml
232 | |     if: (!cancelled())
...   |
251 | |           - nasm
252 | |           - no-examples
    | |                       ^
    | |                       |
    | |_______________________this job
    |                         default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:254:3
    |
254 | /   build-x86_64-mingw-gcc:
255 | |     name: Build (x86_64-mingw-gcc)
256 | |     uses: ./.github/workflows/build-job-reusable.yaml
257 | |     if: (!cancelled())
...   |
276 | |           - nasm
277 | |           - no-examples
    | |                       ^
    | |                       |
    | |_______________________this job
    |                         default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/common-builds-reusable.yaml:279:3
    |
279 | /   build-x86_64-clang:
280 | |     name: Build (x86_64-clang)
281 | |     uses: ./.github/workflows/build-job-reusable.yaml
282 | |     if: (!cancelled())
...   |
294 | |           - debug
295 | |           - release
    | |                   ^
    | |                   |
    | |___________________this job
    |                     default permissions used due to no permissions: block
    |
    = note: audit confidence \u2192 Medium

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:305:15
    |
305 |       - uses: actions/checkout@v5
    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:329:15
    |
329 |         uses: actions/upload-artifact@v7
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:356:15
    |
356 |       - uses: actions/checkout@v5
    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:363:15
    |
363 |       - uses: actions/cache/restore@v5
    |               ^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:430:15
    |
430 |       - uses: actions/cache/save@v5
    |               ^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:436:15
    |
436 |         uses: actions/upload-artifact@v7
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:468:15
    |
468 |       - uses: actions/checkout@v5
    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:476:15
    |
476 |       - uses: actions/cache/restore@v5
    |               ^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:505:15
    |
505 |       - uses: actions/cache/save@v5
    |               ^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/common-builds-reusable.yaml:511:15
    |
511 |         uses: actions/upload-artifact@v7
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-images]: unpinned image references
   --> .github/workflows/common-builds-reusable.yaml:303:18
    |
303 |       image: ${{ inputs.container-image }}
    |                  ^^^^^^^^^^^^^^^^^^^^^^ container image may be unpinned
    |
    = note: audit confidence \u2192 Low

error[unpinned-images]: unpinned image references
   --> .github/workflows/common-builds-reusable.yaml:342:18
    |
342 |       image: ${{ inputs.container-image }}
    |                  ^^^^^^^^^^^^^^^^^^^^^^ container image may be unpinned
    |
    = note: audit confidence \u2192 Low

error[unpinned-images]: unpinned image references
   --> .github/workflows/common-builds-reusable.yaml:462:18
    |
462 |       image: ${{ inputs.container-image }}
    |                  ^^^^^^^^^^^^^^^^^^^^^^ container image may be unpinned
    |
    = note: audit confidence \u2192 Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/common-test-data-reusable.yaml:29:9
   |
29 |         - uses: actions/checkout@v5
   |  _________^
30 | |         with:
31 | |           fetch-depth: 50
32 | |           lfs: true
   | |___________________^ does not set persist-credentials: false
   |
   = note: audit confidence \u2192 Low
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/common-test-data-reusable.yaml:29:15
   |
29 |       - uses: actions/checkout@v5
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/common-test-data-reusable.yaml:42:15
   |
42 |         uses: actions/upload-artifact@v7
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-images]: unpinned image references
  --> .github/workflows/common-test-data-reusable.yaml:25:18
   |
25 |       image: ${{ inputs.container-image }}
   |                  ^^^^^^^^^^^^^^^^^^^^^^ container image may be unpinned
   |
   = note: audit confidence \u2192 Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/sanitizer-job-reusable.yaml:64:9
   |
64 |         - uses: actions/checkout@v5
   |  _________^
65 | |         with:
66 | |           fetch-depth: 50
67 | |           lfs: true
   | |___________________^ does not set persist-credentials: false
   |
   = note: audit confidence \u2192 Low
   = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> .github/workflows/sanitizer-job-reusable.yaml:98:18
   |
98 |         run: ${{ inputs.before-script }}
   |         ---      ^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |         |
   |         this run block
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/sanitizer-job-reusable.yaml:64:15
   |
64 |       - uses: actions/checkout@v5
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/sanitizer-job-reusable.yaml:75:15
   |
75 |         uses: actions/download-artifact@v8
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> .github/workflows/sanitizer-job-reusable.yaml:80:15
   |
80 |         uses: actions/download-artifact@v8
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence \u2192 High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/sanitizer-job-reusable.yaml:230:15
    |
230 |         uses: actions/upload-artifact@v7
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence \u2192 High
    = note: this finding has an auto-fix

error[unpinned-images]: unpinned image references
  --> .github/workflows/sanitizer-job-reusable.yaml:51:18
   |
51 |       image: ${{ inputs.container-image }}
   |                  ^^^^^^^^^^^^^^^^^^^^^^ container image may be unpinned
   |
   = note: audit confidence \u2192 Low

60 findings (14 suppressed, 28 unsafe fixes): 0 informational, 0 low, 18 medium, 28 high

Fix Summary
Successfully applied fixes to 4 files:
  .github/workflows/common-builds-reusable.yaml: 13 fixes
  .github/workflows/sanitizer-job-reusable.yaml: 6 fixes
  .github/workflows/build-job-reusable.yaml: 6 fixes
  .github/workflows/common-test-data-reusable.yaml: 3 fixes
```

</details>
