### PR TITLE
Rework speed features 2 - 5

### DIFF
--- a/av2/av2_dx_iface.c
+++ b/av2/av2_dx_iface.c
@@ -1107,7 +1107,11 @@ static avm_codec_err_t decoder_decode(avm_codec_alg_priv_t *ctx,
 
     res = decode_one(ctx, &data_start, frame_unit_size, user_priv);
 
-    if (res != AVM_CODEC_OK) return res;
+    if (res != AVM_CODEC_OK) {
+      free(frame_worker_data->pbi->obu_list);
+      frame_worker_data->pbi->num_obus_with_frame_unit = 0;
+      return res;
+    }
 
     set_last_frame_unit(frame_worker_data->pbi);
     free(frame_worker_data->pbi->obu_list);

--- a/av2/encoder/compound_type.c
+++ b/av2/encoder/compound_type.c
@@ -121,8 +121,7 @@ static INLINE bool enable_wedge_interinter_search(MACROBLOCK *const x,
 static INLINE bool enable_wedge_interintra_search(MACROBLOCK *const x,
                                                   const AV2_COMP *const cpi) {
   return enable_wedge_search(x, cpi) &&
-         cpi->oxcf.comp_type_cfg.enable_interintra_wedge &&
-         !cpi->sf.inter_sf.disable_wedge_interintra_search;
+         cpi->oxcf.comp_type_cfg.enable_interintra_wedge;
 }
 
 static int8_t estimate_wedge_sign(const AV2_COMP *cpi, const MACROBLOCK *x,
@@ -582,8 +581,7 @@ static int handle_smooth_inter_intra_mode(
     }
     args->inter_intra_mode[mbmi->ref_frame[0]] = *best_interintra_mode;
   }
-  assert(IMPLIES(!cpi->oxcf.comp_type_cfg.enable_smooth_interintra ||
-                     cpi->sf.inter_sf.disable_smooth_interintra,
+  assert(IMPLIES(!cpi->oxcf.comp_type_cfg.enable_smooth_interintra,
                  *best_interintra_mode != II_SMOOTH_PRED));
   // Recompute prediction if required
   bool interintra_mode_reuse = cpi->sf.inter_sf.reuse_inter_intra_mode ||
@@ -634,8 +632,7 @@ static int handle_wedge_inter_intra_mode(
   const AV2_COMMON *const cm = &cpi->common;
   const int bw = block_size_wide[bsize];
   const int try_smooth_interintra =
-      cpi->oxcf.comp_type_cfg.enable_smooth_interintra &&
-      !cpi->sf.inter_sf.disable_smooth_interintra;
+      cpi->oxcf.comp_type_cfg.enable_smooth_interintra;
 
   mbmi->use_wedge_interintra = 1;
   assert(IMPLIES(!mbmi->warp_inter_intra, mbmi->motion_mode == INTERINTRA));
@@ -757,8 +754,7 @@ int av2_handle_inter_intra_mode(const AV2_COMP *const cpi, MACROBLOCK *const x,
   const MOTION_MODE org_motion_mode = mbmi->motion_mode;
   const MOTION_MODE org_warp_inter_intra = mbmi->warp_inter_intra;
   const int try_smooth_interintra =
-      cpi->oxcf.comp_type_cfg.enable_smooth_interintra &&
-      !cpi->sf.inter_sf.disable_smooth_interintra;
+      cpi->oxcf.comp_type_cfg.enable_smooth_interintra;
 
   const int is_wedge_used = av2_is_wedge_used(bsize);
   const int try_wedge_interintra =

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2873,6 +2873,7 @@ static AVM_INLINE PARTITION_TYPE get_forced_partition_type(
 
 static AVM_INLINE void init_allowed_partitions(
     PartitionSearchState *part_search_state, const PartitionCfg *part_cfg,
+    const SPEED_FEATURES *const sf,
     const int bru_skip, const bool *partition_allowed) {
   const PartitionBlkParams *blk_params = &part_search_state->part_blk_params;
   const BLOCK_SIZE bsize = blk_params->bsize;
@@ -2910,6 +2911,7 @@ static AVM_INLINE void init_allowed_partitions(
       is_bsize_geq(vert_subsize, min_partition_size);
 
   part_search_state->partition_3_allowed[HORZ] =
+      !sf->part_sf.disable_ext_partitions &&
       partition_allowed[PARTITION_HORZ_3] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_3),
                    blk_params->min_partition_size) &&
@@ -2917,6 +2919,7 @@ static AVM_INLINE void init_allowed_partitions(
                    blk_params->min_partition_size);
 
   part_search_state->partition_3_allowed[VERT] =
+      !sf->part_sf.disable_ext_partitions &&
       partition_allowed[PARTITION_VERT_3] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_3),
                    blk_params->min_partition_size) &&
@@ -2924,18 +2927,26 @@ static AVM_INLINE void init_allowed_partitions(
                    blk_params->min_partition_size);
 
   part_search_state->partition_4a_allowed[HORZ] =
+      !sf->part_sf.disable_ext_partitions &&
+      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_HORZ_4A] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_4A),
                    blk_params->min_partition_size);
   part_search_state->partition_4b_allowed[HORZ] =
+      !sf->part_sf.disable_ext_partitions &&
+      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_HORZ_4B] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_4B),
                    blk_params->min_partition_size);
   part_search_state->partition_4a_allowed[VERT] =
+      !sf->part_sf.disable_ext_partitions &&
+      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_VERT_4A] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_4A),
                    blk_params->min_partition_size);
   part_search_state->partition_4b_allowed[VERT] =
+      !sf->part_sf.disable_ext_partitions &&
+      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_VERT_4B] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_4B),
                    blk_params->min_partition_size);
@@ -3056,7 +3067,7 @@ static void init_partition_search_state_params(
       pc_tree->region_type, partition_allowed);
 
   init_allowed_partitions(
-      part_search_state, &cpi->oxcf.part_cfg,
+      part_search_state, &cpi->oxcf.part_cfg, &cpi->sf,
       is_bru_not_active_and_not_on_partial_border(cm, mi_col, mi_row, bsize),
       partition_allowed);
 
@@ -6058,7 +6069,7 @@ BEGIN_PARTITION_SEARCH:
         (pc_tree->parent ? pc_tree->parent->region_type : INTRA_REGION), mi_row,
         mi_col, ss_x, ss_y, bsize, &pc_tree->chroma_ref_info);
     init_allowed_partitions(
-        &part_search_state, &cpi->oxcf.part_cfg,
+        &part_search_state, &cpi->oxcf.part_cfg, &cpi->sf,
         is_bru_not_active_and_not_on_partial_border(cm, mi_col, mi_row, bsize),
         partition_allowed);
 #if CONFIG_ML_PART_SPLIT

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2873,8 +2873,8 @@ static AVM_INLINE PARTITION_TYPE get_forced_partition_type(
 
 static AVM_INLINE void init_allowed_partitions(
     PartitionSearchState *part_search_state, const PartitionCfg *part_cfg,
-    const SPEED_FEATURES *const sf,
-    const int bru_skip, const bool *partition_allowed) {
+    const SPEED_FEATURES *const sf, const int bru_skip,
+    const bool *partition_allowed) {
   const PartitionBlkParams *blk_params = &part_search_state->part_blk_params;
   const BLOCK_SIZE bsize = blk_params->bsize;
   if (bru_skip) {

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -6319,9 +6319,7 @@ static AVM_INLINE void rd_pick_skip_mode(
   assert(second_ref_frame != NONE_FRAME);
   const PREDICTION_MODE this_mode = NEAR_NEARMV;
 
-  if ((!cpi->oxcf.ref_frm_cfg.enable_onesided_comp ||
-       cpi->sf.inter_sf.disable_onesided_comp) &&
-      cpi->all_one_sided_refs) {
+  if (!cpi->oxcf.ref_frm_cfg.enable_onesided_comp && cpi->all_one_sided_refs) {
     return;
   }
 
@@ -6877,8 +6875,7 @@ static AVM_INLINE int prune_ref_frame(const AV2_COMP *cpi, const MACROBLOCK *x,
   av2_set_ref_frame(rf, ref_frame);
   const int comp_pred = is_inter_ref_frame(rf[1]);
   if (comp_pred) {
-    if (!cpi->oxcf.ref_frm_cfg.enable_onesided_comp ||
-        cpi->sf.inter_sf.disable_onesided_comp) {
+    if (!cpi->oxcf.ref_frm_cfg.enable_onesided_comp) {
       // Disable all compound references
       if (cpi->all_one_sided_refs) return 1;
       // If both references are on the same side prune
@@ -7647,47 +7644,6 @@ static int compound_skip_by_single_states(
   return 0;
 }
 
-// Check if ref frames of current block matches with given block.
-static INLINE void match_ref_frame(const MB_MODE_INFO *const mbmi,
-                                   const MV_REFERENCE_FRAME *ref_frames,
-                                   int *const is_ref_match) {
-  if (is_inter_block(mbmi, SHARED_PART)) {
-    is_ref_match[0] |= ref_frames[0] == mbmi->ref_frame[0];
-    is_ref_match[1] |= ref_frames[1] == mbmi->ref_frame[0];
-    if (has_second_ref(mbmi)) {
-      is_ref_match[0] |= ref_frames[0] == mbmi->ref_frame[1];
-      is_ref_match[1] |= ref_frames[1] == mbmi->ref_frame[1];
-    }
-  }
-}
-
-// Prune compound mode using ref frames of neighbor blocks.
-static INLINE int compound_skip_using_neighbor_refs(
-    MACROBLOCKD *const xd, const PREDICTION_MODE this_mode,
-    const MV_REFERENCE_FRAME *ref_frames, int prune_compound_using_neighbors) {
-  // Exclude non-extended compound modes from pruning
-  if (this_mode == NEAR_NEARMV || this_mode == NEW_NEWMV ||
-      this_mode == GLOBAL_GLOBALMV)
-    return 0;
-
-  int is_ref_match[2] = { 0 };  // 0 - match for forward refs
-                                // 1 - match for backward refs
-  // Check if ref frames of this block matches with left neighbor.
-  if (xd->left_available)
-    match_ref_frame(xd->left_mbmi, ref_frames, is_ref_match);
-
-  // Check if ref frames of this block matches with above neighbor.
-  if (xd->up_available)
-    match_ref_frame(xd->above_mbmi, ref_frames, is_ref_match);
-
-  // Combine ref frame match with neighbors in forward and backward refs.
-  const int track_ref_match = is_ref_match[0] + is_ref_match[1];
-
-  // Pruning based on ref frame match with neighbors.
-  if (track_ref_match >= prune_compound_using_neighbors) return 0;
-  return 1;
-}
-
 // Update best single mode for the given reference frame based on simple rd.
 static INLINE void update_best_single_mode(InterModeSearchState *search_state,
                                            const PREDICTION_MODE this_mode,
@@ -7982,13 +7938,6 @@ static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, const BLOCK_SIZE bsize,
     }
     if (args->prune_cpd_using_sr_stats_ready &&
         !in_single_ref_cutoff(ref_frame_rd, ref_frame, second_ref_frame))
-      return 1;
-  }
-
-  if (sf->inter_sf.prune_compound_using_neighbors && comp_pred) {
-    if (compound_skip_using_neighbor_refs(
-            xd, this_mode, ref_frames,
-            sf->inter_sf.prune_compound_using_neighbors))
       return 1;
   }
 

--- a/av2/encoder/rdopt_utils.h
+++ b/av2/encoder/rdopt_utils.h
@@ -199,11 +199,6 @@ static INLINE int is_winner_mode_processing_enabled(
         sf->tx_sf.tx_type_search.fast_inter_tx_type_search &&
         !cpi->oxcf.txfm_cfg.use_inter_dct_only)
       return 1;
-  } else {
-    if (sf->tx_sf.tx_type_search.fast_intra_tx_type_search &&
-        !cpi->oxcf.txfm_cfg.use_intra_default_tx_only &&
-        !cpi->oxcf.txfm_cfg.use_intra_dct_only)
-      return 1;
   }
 
   // Check speed feature related to winner mode processing
@@ -315,8 +310,7 @@ static INLINE void set_mode_eval_params(const struct AV2_COMP *cpi,
       break;
     case MODE_EVAL:
       txfm_params->use_default_intra_tx_type =
-          (cpi->sf.tx_sf.tx_type_search.fast_intra_tx_type_search ||
-           cpi->oxcf.txfm_cfg.use_intra_default_tx_only);
+          cpi->oxcf.txfm_cfg.use_intra_default_tx_only;
       txfm_params->use_default_inter_tx_type =
           cpi->sf.tx_sf.tx_type_search.fast_inter_tx_type_search;
       txfm_params->skip_txfm_level =

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -345,9 +345,6 @@ static void set_good_speed_features_framesize_independent(
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
 
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 2 : 1;
-
-    sf->part_sf.disable_uneven_4way_partitions = true;
-    sf->part_sf.disable_ext_partitions = true;
   }
 
   if (speed >= 2) {
@@ -357,6 +354,9 @@ static void set_good_speed_features_framesize_independent(
     // simple_motion_search_split in partition search function and set the
     // speed feature accordingly
     sf->part_sf.simple_motion_search_split = allow_screen_content_tools ? 1 : 2;
+
+    sf->part_sf.disable_uneven_4way_partitions = true;
+    sf->part_sf.disable_ext_partitions = true;
 
     if (cpi->twopass.fr_content_type == FC_HIGHMOTION ||
         cpi->is_screen_content_type) {
@@ -379,17 +379,13 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.selective_ref_frame = 2;
     sf->inter_sf.skip_repeated_newmv = 1;
 
-    sf->interp_sf.use_interp_filter = 1;
     sf->intra_sf.prune_palette_search_level = 1;
-    sf->intra_sf.skip_intra_dip_search = true;
 
     sf->tx_sf.adaptive_tx_type_search_idx = 4;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
     sf->tx_sf.model_based_prune_tx_search_level = 0;
     sf->tx_sf.tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_2;
-    sf->tx_sf.tx_type_search.skip_tx_search = 1;
 
-    sf->rd_sf.disable_tcq = 1;
     sf->rd_sf.perform_coeff_opt = boosted ? 2 : 3;
     sf->rd_sf.tx_domain_dist_level = boosted ? 1 : 2;
     sf->rd_sf.tx_domain_dist_thres_level = 1;
@@ -402,6 +398,14 @@ static void set_good_speed_features_framesize_independent(
   }
 
   if (speed >= 3) {
+    // These features are moved down from speed 2
+    // --- Start ---
+    sf->interp_sf.use_interp_filter = 1;
+    sf->tx_sf.tx_type_search.skip_tx_search = 1;
+    sf->intra_sf.skip_intra_dip_search = true;
+    sf->rd_sf.disable_tcq = 1;
+    // --- End ---
+
     sf->hl_sf.high_precision_mv_usage = CURRENT_Q;
     sf->hl_sf.recode_loop = ALLOW_RECODE_KFARFGF;
 

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -345,6 +345,9 @@ static void set_good_speed_features_framesize_independent(
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
 
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 2 : 1;
+
+    sf->part_sf.disable_uneven_4way_partitions = true;
+    sf->part_sf.disable_ext_partitions = true;
   }
 
   if (speed >= 2) {
@@ -661,6 +664,8 @@ static AVM_INLINE void init_part_sf(PARTITION_SPEED_FEATURES *part_sf) {
   part_sf->prune_split_ml_level = -2;  // default pruning
   part_sf->prune_split_ml_level_inter = -1;
 #endif  // CONFIG_ML_PART_SPLIT
+  part_sf->disable_ext_partitions = false;
+  part_sf->disable_uneven_4way_partitions = false;
 }
 
 static AVM_INLINE void init_mv_sf(MV_SPEED_FEATURES *mv_sf) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -219,7 +219,7 @@ static void set_good_speed_feature_framesize_dependent(
     }
 
     if (is_480p_or_larger) {
-      sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 2;
+      sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 1;
     }
   }
 
@@ -322,8 +322,6 @@ static void set_good_speed_features_framesize_independent(
   sf->tx_sf.model_based_prune_tx_search_level = 1;
   sf->tx_sf.prune_tx_rd_eval_sec_tx_sse = true;
   sf->tx_sf.tx_type_search.use_reduced_intra_txset = 1;
-  sf->tx_sf.tx_type_search.skip_stx_search = 0;
-  sf->tx_sf.tx_type_search.skip_cctx_search = 0;
 
   if (cpi->twopass.fr_content_type == FC_HIGHMOTION ||
       cpi->is_screen_content_type) {
@@ -700,16 +698,12 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->skip_repeated_full_newmv = 0;
   inter_sf->inter_mode_rd_model_estimation = 0;
   inter_sf->prune_compound_using_single_ref = 0;
-  inter_sf->prune_compound_using_neighbors = 0;
   inter_sf->prune_comp_using_best_single_mode_ref = 0;
-  inter_sf->disable_onesided_comp = 0;
   inter_sf->prune_mode_search_simple_translation = 0;
   inter_sf->prune_comp_type_by_comp_avg = 0;
   inter_sf->disable_interinter_wedge_newmv_search = 0;
   inter_sf->enable_interinter_diffwtd_newmv_search = 0;
-  inter_sf->disable_smooth_interintra = 0;
   inter_sf->prune_motion_mode_level = 0;
-  inter_sf->disable_wedge_interintra_search = 0;
   inter_sf->fast_interintra_wedge_search = 0;
   inter_sf->prune_comp_type_by_model_rd = 0;
   inter_sf->perform_best_rd_based_gating_for_chroma = 0;
@@ -749,7 +743,6 @@ static AVM_INLINE void init_tx_sf(TX_SPEED_FEATURES *tx_sf) {
   tx_sf->tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_1;
   tx_sf->tx_type_search.use_skip_flag_prediction = 1;
   tx_sf->tx_type_search.use_reduced_intra_txset = 0;
-  tx_sf->tx_type_search.fast_intra_tx_type_search = 0;
   tx_sf->tx_type_search.fast_inter_tx_type_search = 0;
   tx_sf->tx_type_search.skip_tx_search = 0;
   tx_sf->tx_type_search.prune_tx_type_using_stats = 0;
@@ -1030,9 +1023,6 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
     cpi->common.seq_params.enable_masked_compound &=
         !sf->inter_sf.disable_masked_comp;
 
-    if (sf->inter_sf.disable_wedge_interintra_search) {
-      cpi->common.seq_params.seq_enabled_motion_modes &= ~(1 << INTERINTRA);
-    }
     if (sf->intra_sf.skip_intra_dip_search) {
       cpi->common.seq_params.enable_intra_dip = 0;
     }

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -199,10 +199,6 @@ static void set_good_speed_feature_framesize_dependent(
   if (speed >= 3) {
     sf->part_sf.use_square_partition_only_threshold = BLOCK_128X128;
 
-    if (is_480p_or_larger) {
-      sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 1;
-    }
-
     sf->part_sf.ml_early_term_after_part_split_level = 0;
 
     if (is_720p_or_larger) {
@@ -424,7 +420,6 @@ static void set_good_speed_features_framesize_independent(
     sf->mv_sf.full_pixel_search_level = 1;
     sf->mv_sf.simple_motion_subpel_force_stop = QUARTER_PEL;
     sf->mv_sf.subpel_search_method = SUBPEL_TREE_PRUNED;
-    sf->mv_sf.search_method = DIAMOND;
 
     sf->gm_sf.num_refinement_steps = 0;
 
@@ -436,19 +431,13 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.comp_inter_joint_search_thresh = BLOCK_SIZES_ALL;
     sf->inter_sf.disable_wedge_search_var_thresh = 100;
     sf->inter_sf.fast_interintra_wedge_search = 1;
-    sf->inter_sf.prune_compound_using_neighbors = 1;
     sf->inter_sf.prune_comp_type_by_comp_avg = 2;
     sf->inter_sf.disable_sb_level_mv_cost_upd = 1;
-    // TODO(yunqing): evaluate this speed feature for speed 1 & 2, and combine
-    // it with cpi->sf.disable_wedge_search_var_thresh.
-    sf->inter_sf.disable_wedge_interintra_search = 1;
-    sf->inter_sf.disable_smooth_interintra = boosted ? 0 : 1;
     // TODO(any): Experiment with the early exit mechanism for speeds 0, 1 and 2
     // and clean-up the speed feature
     sf->inter_sf.perform_best_rd_based_gating_for_chroma = 1;
     sf->inter_sf.prune_inter_modes_based_on_tpl = boosted ? 0 : 1;
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 4 : 2;
-    sf->inter_sf.selective_ref_frame = 4;
     sf->inter_sf.skip_repeated_ref_mv = 1;
     sf->inter_sf.skip_repeated_full_newmv = 1;
     // TODO(any): Set this speed feature to 2 after correcting the match
@@ -469,8 +458,6 @@ static void set_good_speed_features_framesize_independent(
     sf->tpl_sf.subpel_force_stop = QUARTER_PEL;
     sf->tpl_sf.search_method = DIAMOND;
 
-    sf->tx_sf.tx_type_search.skip_stx_search = 1;
-    sf->tx_sf.tx_type_search.skip_cctx_search = 1;
     sf->tx_sf.adaptive_tx_type_search_idx = boosted ? 4 : 5;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = boosted ? 4 : 5;
     sf->tx_sf.tx_type_search.use_skip_flag_prediction = 2;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -539,15 +539,10 @@ static void set_good_speed_features_framesize_independent(
         frame_is_intra_only(&cpi->common) ? MULTI_WINNER_MODE_FAST
                                           : MULTI_WINNER_MODE_OFF;
 
-    sf->lpf_sf.disable_lr_filter = 1;
-
     sf->mv_sf.prune_mesh_search = 1;
     sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
 
     sf->tpl_sf.prune_starting_mv = 3;
-
-    sf->winner_mode_sf.dc_blk_pred_level = 1;
-    sf->winner_mode_sf.tx_size_search_level = USE_LARGESTALL;
   }
 
   if (speed >= 6) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -491,12 +491,7 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.txfm_rd_gate_level = boosted ? 0 : 4;
 
     sf->inter_sf.prune_inter_modes_based_on_tpl = boosted ? 0 : 3;
-    sf->inter_sf.prune_compound_using_neighbors = 2;
     sf->inter_sf.prune_comp_using_best_single_mode_ref = 2;
-    sf->inter_sf.disable_smooth_interintra = 1;
-    sf->inter_sf.disable_onesided_comp = 1;
-
-    sf->interp_sf.use_interp_filter = 2;
 
     sf->intra_sf.intra_uv_mode_mask[TX_16X16] = UV_INTRA_DC_H_V_CFL;
     sf->intra_sf.intra_uv_mode_mask[TX_32X32] = UV_INTRA_DC_H_V_CFL;
@@ -508,21 +503,18 @@ static void set_good_speed_features_framesize_independent(
     // presets as well
     sf->intra_sf.skip_intra_in_interframe = 2;
 
-    sf->mv_sf.simple_motion_subpel_force_stop = HALF_PEL;
-
     sf->tpl_sf.prune_starting_mv = 2;
     sf->tpl_sf.subpel_force_stop = HALF_PEL;
     sf->tpl_sf.search_method = FAST_BIGDIA;
 
     sf->tx_sf.tx_type_search.winner_mode_tx_type_pruning = 1;
-    sf->tx_sf.tx_type_search.fast_intra_tx_type_search = 1;
-    sf->tx_sf.tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_3;
+    sf->tx_sf.tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_2;
     sf->tx_sf.tx_type_search.prune_tx_type_est_rd = 1;
 
     sf->rd_sf.perform_coeff_opt = is_boosted_arf2_bwd_type ? 3 : 5;
     sf->rd_sf.perform_coeff_opt_based_on_satd =
         is_boosted_arf2_bwd_type ? 1 : 2;
-    sf->rd_sf.tx_domain_dist_thres_level = 2;
+    sf->rd_sf.tx_domain_dist_thres_level = 1;
 
     // TODO(any): Extend multi-winner mode processing support for inter frames
     sf->winner_mode_sf.multi_winner_mode_type =

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -433,6 +433,9 @@ typedef struct PARTITION_SPEED_FEATURES {
   int prune_split_ml_level_inter;
   int prune_none_with_ml;
 #endif  // CONFIG_ML_PART_SPLIT
+
+  bool disable_ext_partitions;
+  bool disable_uneven_4way_partitions;
 } PARTITION_SPEED_FEATURES;
 
 typedef struct MV_SPEED_FEATURES {

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -146,7 +146,6 @@ enum {
 
 typedef struct {
   TX_TYPE_PRUNE_MODE prune_2d_txfm_mode;
-  int fast_intra_tx_type_search;
   int fast_inter_tx_type_search;
 
   // prune two least frequently chosen transforms for each intra mode
@@ -170,10 +169,6 @@ typedef struct {
   // mode evaluation and disables tx type mode pruning for winner mode
   // processing.
   int winner_mode_tx_type_pruning;
-  // Speed feature to disable intra secondary transform
-  int skip_stx_search;
-  // Speed feature to disable cross chroma component transform
-  int skip_cctx_search;
 } TX_TYPE_SEARCH;
 
 enum {
@@ -602,13 +597,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // the single reference modes, it is one of the two best performers.
   int prune_compound_using_single_ref;
 
-  // Skip extended compound mode using ref frames of above and left neighbor
-  // blocks.
-  // 0 : no pruning
-  // 1 : prune extended compound mode (less aggressiveness)
-  // 2 : prune extended compound mode (high aggressiveness)
-  int prune_compound_using_neighbors;
-
   // Skip extended compound mode when ref frame corresponding to NEWMV does not
   // have NEWMV as single mode winner.
   // 0 : no pruning
@@ -618,9 +606,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
 
   // Based on previous ref_mv_idx search result, prune the following search.
   int prune_ref_mv_idx_search;
-
-  // Disable one sided compound modes.
-  int disable_onesided_comp;
 
   // Prune/gate motion mode evaluation based on token based rd
   // during transform search for inter blocks
@@ -633,9 +618,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
 
   // Prune warpmv with mvd search using previous frame stats.
   int prune_warpmv_prob_thresh;
-
-  // Enable/disable interintra wedge search.
-  int disable_wedge_interintra_search;
 
   // De-couple wedge and mode search during interintra RDO.
   int fast_interintra_wedge_search;
@@ -655,9 +637,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // Enable/disable ME for interinter diffwtd search. PSNR BD-rate gain of
   // ~0.1 on the lowres test set, but ~15% slower computation.
   int enable_interinter_diffwtd_newmv_search;
-
-  // Enable/disable smooth inter-intra mode
-  int disable_smooth_interintra;
 
   // Disable interinter_wedge
   int disable_interinter_wedge;

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -1804,14 +1804,10 @@ get_tx_mask(const AV2_COMP *cpi, MACROBLOCK *x, int plane, int block,
 
     if (cpi->sf.tx_sf.tx_type_search.prune_tx_type_using_stats) {
       // TODO(yunqing): adjust the thresholds.
-      static const int thresh_arr[2][FRAME_UPDATE_TYPES] = {
-        { 10, 15, 15, 10, 15, 15, 15, 0, 0 },
-        { 10, 17, 17, 10, 17, 17, 17, 0, 0 }
-      };
+      static const int thresh_arr[FRAME_UPDATE_TYPES] = { 10, 17, 17, 10, 17,
+                                                          17, 17, 0,  0 };
 
-      const int thresh =
-          thresh_arr[cpi->sf.tx_sf.tx_type_search.prune_tx_type_using_stats - 1]
-                    [update_type];
+      const int thresh = thresh_arr[update_type];
       uint16_t prune = 0;
       int max_prob = -1;
       int max_idx = 0;
@@ -2315,7 +2311,6 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
     xd->enable_ist =
         (is_inter_block(mbmi, xd->tree_type) ? cm->seq_params.enable_inter_ist
                                              : cm->seq_params.enable_ist) &&
-        !cpi->sf.tx_sf.tx_type_search.skip_stx_search &&
         !mbmi->fsc_mode[xd->tree_type == CHROMA_PART] &&
         !xd->lossless[mbmi->segment_id];
 
@@ -2648,8 +2643,7 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
   // Intra mode needs decoded pixels such that the next transform block
   // can use them for prediction. If cctx is enabled, this reconstruction
   // should be done later in search_cctx_type, when cctx type is chosen.
-  if (plane == AVM_PLANE_Y || !is_cctx_allowed(cm, xd) ||
-      cpi->sf.tx_sf.tx_type_search.skip_cctx_search) {
+  if (plane == AVM_PLANE_Y || !is_cctx_allowed(cm, xd)) {
     recon_intra(cpi, x, plane, block, blk_row, blk_col, plane_bsize, tx_size,
                 txb_ctx, skip_trellis, best_tx_type, 0, &rate_cost, best_eob);
     p->dqcoeff = orig_dqcoeff;
@@ -4030,8 +4024,7 @@ int av2_txfm_uvrd(const AV2_COMP *const cpi, MACROBLOCK *x, RD_STATS *rd_stats,
 
   const int skip_trellis = 0;
   int is_cost_valid = 1;
-  if (is_cctx_allowed(&cpi->common, xd) &&
-      !cpi->sf.tx_sf.tx_type_search.skip_cctx_search) {
+  if (is_cctx_allowed(&cpi->common, xd)) {
     RD_STATS this_rd_stats;
     int64_t chroma_ref_best_rd = ref_best_rd;
     if (cpi->sf.inter_sf.perform_best_rd_based_gating_for_chroma && is_inter &&

--- a/test/multi_layer_test.cc
+++ b/test/multi_layer_test.cc
@@ -94,6 +94,7 @@ class MultiLayerTest : public ::libavm_test::CodecTestWithParam<int>,
            start_decoding_tl1_ > 0)) {
         encoder->Control(AV2E_SET_ENABLE_REF_FRAME_MVS, 0);
         encoder->Control(AV2E_SET_ALLOW_REF_FRAME_MVS, 0);
+        encoder->Control(AV2E_SET_ENABLE_CDF_AVERAGING, 0);
       }
       if (cfg_.g_lag_in_frames > 0) {
         int gop_size = (cfg_.g_lag_in_frames - 1) / num_embedded_layers_;


### PR DESCRIPTION
Anchor: research-v15.0.0
CTC: v9
Baseline: speed 0
Configuration: RA 33frames (A2 - A5)
Original (research-v15.0.0)
Speed 1: PSNR-YUV: +0.66% | VMAF: +0.51% | EncTime: 71.38%
Speed 2: PSNR-YUV: +4.46% | VMAF: +5.00% | EncTime: 31.91%
Speed 3: PSNR-YUV: +13.00% | VMAF: +14.41% | EncTime: 16.95%
Speed 4: PSNR-YUV: +16.86% | VMAF: +18.32% | EncTime: 13.32%
Speed 5: PSNR-YUV: +21.24% | VMAF: +23.32% | EncTime: 9.53%
New
Speed 1: PSNR-YUV: +0.66% | VMAF: +0.51% | EncTime: 71.38%
Speed 2: PSNR-YUV: +3.37% | VMAF: +3.51% | EncTime: 32.26%
Speed 3: PSNR-YUV: +8.45% | VMAF: +9.50% | EncTime: 19.44%
Speed 4: PSNR-YUV: +10.48% | VMAF: +11.55% | EncTime: 14.91%
Speed 5: PSNR-YUV: +11.45% | VMAF: +12.80% | EncTime: 13.95%

Configuration: RA 17frames (A1)
Original (research-v15.0.0)
Speed 1: PSNR-YUV: +0.42% | VMAF: +0.35% | EncTime: 82.13%
Speed 2: PSNR-YUV: +5.96% | VMAF: +5.92% | EncTime: 40.46%
Speed 3: PSNR-YUV: +15.80% | VMAF: +16.50% | EncTime: 25.52%
Speed 4: PSNR-YUV: +20.19% | VMAF: +21.10% | EncTime: 22.01%
Speed 5: PSNR-YUV: +25.91% | VMAF: +30.35% | EncTime: 16.90%
New
Speed 1: PSNR-YUV: +0.42% | VMAF: +0.35% | EncTime: 82.13%
Speed 2: PSNR-YUV: +4.27% | VMAF: +4.07% | EncTime: 42.26%
Speed 3: PSNR-YUV: +9.82% | VMAF: +10.11% | EncTime: 29.48%
Speed 4: PSNR-YUV: +12.02% | VMAF: +12.67% | EncTime: 24.22%
Speed 5: PSNR-YUV: +13.34% | VMAF: +13.82% | EncTime: 23.12%
