### PR TITLE
Mark error-resilient switch frames as restricted

### DIFF
--- a/av2/encoder/encode_strategy.c
+++ b/av2/encoder/encode_strategy.c
@@ -1277,7 +1277,8 @@ int av2_encode_strategy(AV2_COMP *const cpi, size_t *const size,
     set_ext_overrides(cm, &frame_params, ext_flags);
 
   cm->restricted_prediction_switch =
-      cpi->oxcf.kf_cfg.enable_sframe && cpi->oxcf.kf_cfg.sframe_mode == 0;
+      (cpi->oxcf.kf_cfg.enable_sframe && cpi->oxcf.kf_cfg.sframe_mode == 0) ||
+      cpi->oxcf.tool_cfg.g_error_resilient_mode;
 
   av2_configure_buffer_updates(cpi, frame_update_type);
 

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -5100,7 +5100,8 @@ int av2_encode(AV2_COMP *const cpi, uint8_t *const dest,
   current_frame->tlayer_id = cm->tlayer_id;
   current_frame->mlayer_id = cm->mlayer_id;
   cm->restricted_prediction_switch =
-      cpi->oxcf.kf_cfg.enable_sframe && cpi->oxcf.kf_cfg.sframe_mode == 0;
+      (cpi->oxcf.kf_cfg.enable_sframe && cpi->oxcf.kf_cfg.sframe_mode == 0) ||
+      cpi->oxcf.tool_cfg.g_error_resilient_mode;
   if (current_frame->frame_type == KEY_FRAME) {
     for (int i = 0; i < cm->seq_params.ref_frames; i++) {
       if (cm->ref_frame_map[i] != NULL)


### PR DESCRIPTION
When the encoder is run in error-resilient mode (`--global-error-resilient=1`), switch frames are emitted without their reference frames being marked as restricted. This produces a bitstream that is not AV2-compliant and that decoders reject.
  
This MR sets `restricted_prediction_switch` for error-resilient switch frames as well, so switch frames generated in that mode carry the correct restricted-reference semantics.

In error-resilient mode (`--global-error-resilient=1`), the current AVM encoder converts alt-ref–type frames (which are reordered/future frames) into switch frames. When such a switch is left unconstrained (non-restricted), the encoder can assign it a low display order hint (e.g. 1) while a frame with a higher display order hint (e.g. 4) has already been output, producing a non-monotonic output order. Because a non-restricted switch  does not reset the OrderHint counter, this violates the conformance constraint below (AV2 spec §7.3.6, "Coded extended layer unit"):

``
If monotonic_output_order_flag is equal to 0, it is a requirement of bitstream conformance that within a coded video sequence, for a given value of obu_xlayer_id and obu_mlayer_id, if a coded output frame unit X has an associated OrderHint value equal to ohX, there shall not be a coded output frame unit Y in the same extended layer and embedded layer that appears later than X in output order and has an associated OrderHint value less than or equal to ohX, unless a switch frame with restricted_prediction_switch equal to 1 appears between X and Y in coding order.
``
``
NOTE: The value of OrderHint is reset at the start of a new coded video sequence and at a switch frame with restricted_prediction_switch equal to 1. In both cases, the OrderHint counter is effectively restarted, allowing OrderHint values to be reused in subsequent coded output frame units.
``