### PR TITLE
Single-ref NEWMV DRL search speed features

### DIFF
--- a/av2/encoder/motion_search_facade.c
+++ b/av2/encoder/motion_search_facade.c
@@ -382,7 +382,8 @@ void av2_single_motion_search(const AV2_COMP *const cpi, MACROBLOCK *x,
     switch (mbmi->motion_mode) {
       case SIMPLE_TRANSLATION:
         if (cpi->sf.mv_sf.subpel_search_type) {
-          const int try_second = second_best_mv.as_int != INVALID_MV &&
+          const int try_second = !cpi->sf.mv_sf.skip_second_best_subpel &&
+                                 second_best_mv.as_int != INVALID_MV &&
                                  second_best_mv.as_int != best_mv->as_int;
           const int best_mv_var = mv_search_params->find_fractional_mv_step(
               xd, cm, &ms_params, subpel_start_mv, &best_mv->as_mv, &dis,

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -1428,6 +1428,72 @@ static int64_t handle_newmv(const AV2_COMP *const cpi, MACROBLOCK *const x,
                                               mode_info, &start_mv, &best_mv);
 
     } else {
+      // Predictive NEWMV reuse across the DRL. Two triggers select a match:
+      //   Tier 1 (predict_repeated_newmv): match when reference MVs are
+      //     within one full pel.
+      //   Tier 2 (newmv_drl_search_limit): once ref_mv_idx reaches the limit,
+      //     reuse the nearest searched result regardless of distance.
+      const int t1_active = cpi->sf.mv_sf.predict_repeated_newmv != 0;
+      const int drl_limit = cpi->sf.mv_sf.newmv_drl_search_limit;
+      const int t2_active =
+          drl_limit > 0 && mbmi->ref_mv_idx[ref_idx] >= drl_limit;
+      if ((t1_active || t2_active) && !mbmi->use_amvd &&
+          mbmi->ref_mv_idx[ref_idx] > 0) {
+        const MV ref_mv = av2_get_ref_mv(x, ref_idx).as_mv;
+        int near_diff = INT_MAX;
+        int near_idx = -1;
+        for (int idx = 0; idx < mbmi->ref_mv_idx[ref_idx]; ++idx) {
+          if (!args->single_newmv_valid[pb_mv_precision][idx][refs[0]])
+            continue;
+          const MV prev_ref_mv =
+              av2_get_ref_mv_from_stack(ref_idx, mbmi->ref_frame, idx,
+                                        x->mbmi_ext, mbmi)
+                  .as_mv;
+          const int ref_mv_diff = AVMMAX(abs(ref_mv.row - prev_ref_mv.row),
+                                         abs(ref_mv.col - prev_ref_mv.col));
+          if (ref_mv_diff < near_diff) {
+            near_diff = ref_mv_diff;
+            near_idx = idx;
+          }
+        }
+        int best_match = -1;
+        // Reuse the nearest previously-searched ref-mv when Tier 1 (within
+        // one full pel -- (1 << 3) in 1/8-pel units) or Tier 2 (no distance
+        // cap) fires.
+        if (near_idx >= 0 &&
+            ((t1_active && near_diff <= (1 << 3)) || t2_active)) {
+          best_match = near_idx;
+        }
+        if (best_match >= 0) {
+          const int_mv reuse_mv =
+              args->single_newmv[pb_mv_precision][best_match][refs[0]];
+          SubpelMvLimits mv_limits;
+          av2_set_subpel_mv_search_range(&mv_limits, &x->mv_limits, &ref_mv,
+                                         pb_mv_precision);
+          const int is_adaptive_mvd = enable_adaptive_mvd_resolution(cm, mbmi);
+          // The reused MV was searched against a different reference MV, so
+          // check that its MVD relative to the *current* reference MV is
+          // representable at pb_mv_precision (otherwise the decoder would
+          // reconstruct a different MV -- bitstream mismatch).
+          MV reuse_mvd;
+          get_mvd_from_ref_mv(reuse_mv.as_mv, ref_mv, is_adaptive_mvd,
+                              pb_mv_precision, &reuse_mvd);
+          if (av2_is_subpelmv_in_range(&mv_limits, reuse_mv.as_mv) &&
+              is_this_mv_precision_compliant(reuse_mvd, pb_mv_precision)) {
+            *rate_mv =
+                av2_mv_bit_cost(&reuse_mv.as_mv, &ref_mv, pb_mv_precision,
+                                &x->mv_costs, MV_COST_WEIGHT, is_adaptive_mvd);
+            const int cur_idx = get_ref_mv_idx(mbmi, 0);
+            args->single_newmv[pb_mv_precision][cur_idx][refs[0]] = reuse_mv;
+            args->single_newmv_rate[pb_mv_precision][cur_idx][refs[0]] =
+                *rate_mv;
+            args->single_newmv_valid[pb_mv_precision][cur_idx][refs[0]] = 1;
+            cur_mv[0].as_int = reuse_mv.as_int;
+            return 0;
+          }
+        }
+      }
+
       int search_range = INT_MAX;
       if (cpi->sf.mv_sf.reduce_search_range && mbmi->ref_mv_idx[0] > 0) {
         const MV ref_mv = av2_get_ref_mv(x, ref_idx).as_mv;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -344,6 +344,17 @@ static void set_good_speed_features_framesize_independent(
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
 
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 2 : 1;
+
+    // Skip the second-best full-pel candidate's subpel refinement in the
+    // single-ref NEWMV search.
+    sf->mv_sf.skip_second_best_subpel = 1;
+
+    // Predictive single-ref NEWMV reuse across the DRL.
+    sf->mv_sf.predict_repeated_newmv = 1;
+
+    // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
+    // nearest searched result beyond the cap.
+    sf->mv_sf.newmv_drl_search_limit = 2;
   }
 
   if (speed >= 2) {
@@ -655,6 +666,9 @@ static AVM_INLINE void init_mv_sf(MV_SPEED_FEATURES *mv_sf) {
   mv_sf->exhaustive_searches_thresh = 0;
   mv_sf->prune_mesh_search = 0;
   mv_sf->reduce_search_range = 0;
+  mv_sf->skip_second_best_subpel = 0;
+  mv_sf->predict_repeated_newmv = 0;
+  mv_sf->newmv_drl_search_limit = 0;
   mv_sf->search_method = NSTEP;
   mv_sf->simple_motion_subpel_force_stop = EIGHTH_PEL;
   mv_sf->subpel_force_stop = EIGHTH_PEL;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -477,6 +477,21 @@ typedef struct MV_SPEED_FEATURES {
   // Reduce single motion search range based on MV result of prior ref_mv_idx.
   int reduce_search_range;
 
+  // When set, skip the second-best full-pel candidate's subpel refinement in
+  // the single-ref NEWMV search.
+  int skip_second_best_subpel;
+
+  // Predictively reuse single-ref NEWMV results across the DRL.
+  //   0: off
+  //   1: reuse when reference MVs are within one full pel.
+  int predict_repeated_newmv;
+
+  // Cap the DRL depth that runs a fresh single-ref NEWMV motion search;
+  // beyond the cap, reuse the nearest searched result.
+  //   0: off (no cap).
+  //   K: search ref_mv_idx 0..K-1, reuse for ref_mv_idx >= K.
+  int newmv_drl_search_limit;
+
   // Prune mesh search.
   int prune_mesh_search;
 


### PR DESCRIPTION
Adds three single-ref NEWMV DRL search speed features, enabled at speed >= 1:

* mv_sf.skip_second_best_subpel: the subpel search normally refines both the best and the second-best full-pel candidate and keeps the lower-variance result; with this feature set, only the best full-pel candidate is refined.

* mv_sf.predict_repeated_newmv: when a previously searched ref_mv_idx has a reference MV within one full pel of the current one, reuse the cached NEWMV result and only recompute the MV rate, avoiding the full-pel and subpel search entirely.

* mv_sf.newmv_drl_search_limit: once ref_mv_idx reaches the limit, reuse the nearest already-searched result regardless of ref-MV distance instead of running a fresh search. Enabled with a cap of 2. Shares the same search-loop pass as the predict_repeated_newmv reuse.

STATS_CHANGED

Anchor: commit 165345b
Speed 1 (cpu-used=1): FG16 CTC (33 frames, class A1 and A2, RA)
Speed 4 (cpu-used=4): FG16 CTC (33 frames, class A1 and A2, RA)

```
1) Speed 1

  a) Overall performance (all three features combined)

  +------------+------+-------+-------+------+------+------+
  | Class      |    Y |    Cb |    Cr | wAvg | Enc% | Dec% |
  +------------+------+-------+-------+------+------+------+
  | A1         | 0.04 | -0.08 | -0.36 | 0.00 |   99 |  101 |
  | A2         | 0.04 | -0.04 | -0.18 | 0.03 |   98 |  100 |
  | Avg w/o B2 | 0.04 | -0.05 | -0.23 | 0.02 |   98 |  100 |
  +------------+------+-------+-------+------+------+------+

  b) Performance of skip_second_best_subpel only

  +------------+-------+-------+-------+-------+------+------+
  | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
  +------------+-------+-------+-------+-------+------+------+
  | A1         | -0.10 | -0.32 |  0.09 | -0.11 | 99.5 |  101 |
  | A2         | -0.01 | -0.09 | -0.34 | -0.02 | 99.5 |  100 |
  | Avg w/o B2 | -0.04 | -0.16 | -0.21 | -0.05 | 99.5 |  100 |
  +------------+-------+-------+-------+-------+------+------+

  c) Performance of predict_repeated_newmv only

  +------------+-------+-------+-------+-------+------+------+
  | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
  +------------+-------+-------+-------+-------+------+------+
  | A1         |  0.00 | -0.08 |  0.08 |  0.00 |  100 |  100 |
  | A2         | -0.03 | -0.04 | -0.04 | -0.03 |  100 |  100 |
  | Avg w/o B2 | -0.02 | -0.05 | -0.00 | -0.02 |  100 |  100 |
  +------------+-------+-------+-------+-------+------+------+

  d) Performance of newmv_drl_search_limit only

  +------------+------+-------+------+------+------+------+
  | Class      |    Y |    Cb |   Cr | wAvg | Enc% | Dec% |
  +------------+------+-------+------+------+------+------+
  | A1         | 0.05 | -0.17 | 0.09 | 0.03 |   99 |  101 |
  | A2         | 0.00 |  0.36 | 0.01 | 0.02 |   99 |  100 |
  | Avg w/o B2 | 0.01 |  0.20 | 0.03 | 0.02 |   99 |  100 |
  +------------+------+-------+------+------+------+------+

2) Speed 4

  Overall performance (all three features combined)

  +------------+------+-------+-------+------+------+------+
  | Class      |    Y |    Cb |    Cr | wAvg | Enc% | Dec% |
  +------------+------+-------+-------+------+------+------+
  | A1         | 0.01 | -0.13 |  0.07 | 0.00 |   96 |  101 |
  | A2         | 0.05 | -0.13 | -0.25 | 0.03 |   96 |  100 |
  | Avg w/o B2 | 0.04 | -0.13 | -0.15 | 0.02 |   96 |  100 |
  +------------+------+-------+-------+------+------+------+
```