### PR TITLE
Preserve xlayer contexts across MSDO ID changes

### DIFF
--- a/av2/decoder/obu.c
+++ b/av2/decoder/obu.c
@@ -372,8 +372,10 @@ static void save_msdo_config(const AV2Decoder *pbi, MsdoConfig *config) {
 }
 
 /*!
- * \brief Compare two MSDO configurations
- * \return true if configurations are identical, false otherwise
+ * \brief Compare MSDO fields that define a coded multistream video sequence
+ * boundary. Stream IDs are intentionally excluded because they may change at
+ * a random access point without starting a new coded multistream sequence.
+ * \return true if the sequence-defining fields are identical, false otherwise
  */
 static bool msdo_config_equal(const MsdoConfig *a, const MsdoConfig *b) {
   if (a->multistream_profile_idc != b->multistream_profile_idc) return false;
@@ -384,15 +386,29 @@ static bool msdo_config_equal(const MsdoConfig *a, const MsdoConfig *b) {
   return true;
 }
 
-avm_codec_err_t flush_all_xlayer_frames(struct AV2Decoder *pbi, AV2_COMMON *cm,
-                                        bool release_dpb) {
+static int find_msdo_stream_index(const MsdoConfig *config, int xlayer_id) {
+  for (int i = 0; i < config->num_streams; ++i) {
+    if (config->stream_ids[i] == xlayer_id) return i;
+  }
+  return -1;
+}
+
+static bool msdo_stream_ids_equal(const MsdoConfig *a, const MsdoConfig *b) {
+  if (a->num_streams != b->num_streams) return false;
+  return memcmp(a->stream_ids, b->stream_ids,
+                a->num_streams * sizeof(a->stream_ids[0])) == 0;
+}
+
+static avm_codec_err_t flush_xlayer_frames(struct AV2Decoder *pbi,
+                                           AV2_COMMON *cm, bool release_dpb,
+                                           const int *xlayer_id_map) {
   BufferPool *const pool = cm->buffer_pool;
   int saved_xlayer_id = cm->xlayer_id;
   avm_codec_err_t err = AVM_CODEC_OK;
 
   for (int xlayer = 0; xlayer < AVM_MAX_NUM_STREAMS; xlayer++) {
     if (xlayer == GLOBAL_XLAYER_ID) continue;  // Global context is not a stream
-    if (pbi->xlayer_id_map[xlayer] > 0) {
+    if (xlayer_id_map[xlayer] > 0) {
       if (xlayer != cm->xlayer_id) {
         av2_store_xlayer_context(pbi, cm, cm->xlayer_id);
         cm->xlayer_id = xlayer;
@@ -421,6 +437,56 @@ avm_codec_err_t flush_all_xlayer_frames(struct AV2Decoder *pbi, AV2_COMMON *cm,
   return err;
 }
 
+avm_codec_err_t flush_all_xlayer_frames(struct AV2Decoder *pbi, AV2_COMMON *cm,
+                                        bool release_dpb) {
+  return flush_xlayer_frames(pbi, cm, release_dpb, pbi->xlayer_id_map);
+}
+
+avm_codec_err_t av2_remap_msdo_stream_contexts(AV2Decoder *pbi, AV2_COMMON *cm,
+                                               const MsdoConfig *old_config,
+                                               const MsdoConfig *new_config) {
+  int removed_xlayer_map[AVM_MAX_NUM_STREAMS] = { 0 };
+  for (int i = 0; i < old_config->num_streams; ++i) {
+    const int xlayer_id = old_config->stream_ids[i];
+    if (find_msdo_stream_index(new_config, xlayer_id) < 0) {
+      removed_xlayer_map[xlayer_id] = pbi->xlayer_id_map[xlayer_id];
+    }
+  }
+
+  avm_codec_err_t err = flush_xlayer_frames(pbi, cm, true, removed_xlayer_map);
+  if (err != AVM_CODEC_OK) return err;
+
+  StreamInfo *new_stream_info = (StreamInfo *)avm_malloc(
+      new_config->num_streams * sizeof(*new_stream_info));
+  if (new_stream_info == NULL) {
+    avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
+                       "Memory allocation failed for pbi->stream_info\n");
+  }
+  memset(new_stream_info, 0,
+         new_config->num_streams * sizeof(*new_stream_info));
+
+  for (int i = 0; i < new_config->num_streams; ++i) {
+    const int old_index =
+        find_msdo_stream_index(old_config, new_config->stream_ids[i]);
+    if (old_index >= 0) {
+      new_stream_info[i] = pbi->stream_info[old_index];
+    } else {
+      init_stream_info(&new_stream_info[i]);
+    }
+  }
+
+  avm_free(pbi->stream_info);
+  pbi->stream_info = new_stream_info;
+
+  for (int i = 0; i < old_config->num_streams; ++i) {
+    const int xlayer_id = old_config->stream_ids[i];
+    if (find_msdo_stream_index(new_config, xlayer_id) < 0) {
+      pbi->xlayer_id_map[xlayer_id] = 0;
+    }
+  }
+  return AVM_CODEC_OK;
+}
+
 static uint32_t read_multi_stream_decoder_operation_obu(
     AV2Decoder *pbi, struct avm_read_bit_buffer *rb) {
   AV2_COMMON *const cm = &pbi->common;
@@ -438,6 +504,7 @@ static uint32_t read_multi_stream_decoder_operation_obu(
     has_previous = true;
   }
 
+  MsdoConfig new_config = { 0 };
   const int num_streams =
       avm_rb_read_literal(rb, 3) + 2;  // read number of streams
   if (num_streams > AVM_MAX_NUM_STREAMS) {
@@ -445,15 +512,15 @@ static uint32_t read_multi_stream_decoder_operation_obu(
         &cm->error, AVM_CODEC_UNSUP_BITSTREAM,
         "The number of streams cannot exceed the max value (4).");
   }
-  cm->num_streams = num_streams;
+  new_config.num_streams = num_streams;
 
-  pbi->common.msdo_params.multistream_profile_idc =
+  new_config.multistream_profile_idc =
       avm_rb_read_literal(rb, PROFILE_BITS);  // read profile of multistream
 
-  pbi->common.msdo_params.multistream_level_idx =
+  new_config.multistream_level_idx =
       avm_rb_read_literal(rb, LEVEL_BITS);  // read level of multistream
 
-  pbi->common.msdo_params.multistream_tier_idx =
+  new_config.multistream_tier_idx =
       avm_rb_read_bit(rb);  // read tier of multistream
 
   const int multistream_even_allocation_flag =
@@ -466,7 +533,8 @@ static uint32_t read_multi_stream_decoder_operation_obu(
   }
 
   for (int i = 0; i < num_streams; i++) {
-    cm->stream_ids[i] = avm_rb_read_literal(rb, XLAYER_BITS);  // read stream ID
+    new_config.stream_ids[i] =
+        avm_rb_read_literal(rb, XLAYER_BITS);  // read stream ID
     const int substream_profile_idc =
         avm_rb_read_literal(rb, PROFILE_BITS);  // read profile of multistream
     (void)substream_profile_idc;
@@ -480,13 +548,16 @@ static uint32_t read_multi_stream_decoder_operation_obu(
     (void)substream_tier_idx;
   }
 
-  cm->msdo_params.msdo_doh_constraint_flag = avm_rb_read_bit(rb);
+  const int msdo_doh_constraint_flag = avm_rb_read_bit(rb);
 
   // Check if configuration changed
-  MsdoConfig new_config;
-  save_msdo_config(pbi, &new_config);
   bool config_changed =
       !has_previous || !msdo_config_equal(&prev_config, &new_config);
+  // Stream IDs can change without starting a new coded multistream sequence,
+  // so preserve contexts for IDs that remain present instead of resetting all
+  // stream contexts.
+  bool stream_ids_changed =
+      has_previous && !msdo_stream_ids_equal(&prev_config, &new_config);
 
   // Flush remaining frames from all active streams before switching config
   if (pbi->stream_info != NULL && config_changed) {
@@ -499,7 +570,21 @@ static uint32_t read_multi_stream_decoder_operation_obu(
     for (int i = 0; i < AVM_MAX_NUM_STREAMS; i++) {
       pbi->xlayer_id_map[i] = 0;
     }
+  } else if (pbi->stream_info != NULL && stream_ids_changed) {
+    if (av2_remap_msdo_stream_contexts(pbi, cm, &prev_config, &new_config) !=
+        AVM_CODEC_OK) {
+      return 0;
+    }
   }
+
+  // Apply the new configuration after flushing contexts that use the old
+  // stream ID-to-index mapping.
+  cm->num_streams = new_config.num_streams;
+  cm->msdo_params.multistream_profile_idc = new_config.multistream_profile_idc;
+  cm->msdo_params.multistream_level_idx = new_config.multistream_level_idx;
+  cm->msdo_params.multistream_tier_idx = new_config.multistream_tier_idx;
+  memcpy(cm->stream_ids, new_config.stream_ids, sizeof(cm->stream_ids));
+  cm->msdo_params.msdo_doh_constraint_flag = msdo_doh_constraint_flag;
 
   // Only allocate if stream_info is NULL (first time OR after freeing due to
   // config change)

--- a/av2/decoder/obu.h
+++ b/av2/decoder/obu.h
@@ -16,6 +16,14 @@
 #include "avm_dsp/bitreader_buffer.h"
 #include "av2/decoder/decoder.h"
 
+// Remap per-stream decoder contexts by xlayer ID after the MSDO stream ID list
+// changes. Contexts for retained IDs are preserved, removed IDs are flushed,
+// and new IDs are initialized.
+avm_codec_err_t av2_remap_msdo_stream_contexts(struct AV2Decoder *pbi,
+                                               AV2_COMMON *cm,
+                                               const MsdoConfig *old_config,
+                                               const MsdoConfig *new_config);
+
 // Flush remaining frames from all active xlayer streams, switching context
 // as needed. Decreases ref counts on all flushed frames. Restores the
 // original xlayer context on return.

--- a/test/sub_bitstream_extraction_test.cc
+++ b/test/sub_bitstream_extraction_test.cc
@@ -13,7 +13,11 @@
 #include "third_party/googletest/src/googletest/include/gtest/gtest.h"
 
 #include "av2/decoder/annexF.h"
+extern "C" {
+#include "av2/decoder/obu.h"
+}
 #include "avm/avmdx.h"
+#include "avm_mem/avm_mem.h"
 #include "test/codec_factory.h"
 #include "test/encode_test_driver.h"
 #include "test/y4m_video_source.h"
@@ -73,6 +77,80 @@ TEST_F(SBEApiTest, ProcessMsdoSetsMultistream) {
   EXPECT_EQ(sbe_.num_xlayers_present, 2);
   // Global OBUs should be retained
   EXPECT_EQ(sbe_.retention_map[GLOBAL_XLAYER_ID][0][0], 1);
+}
+
+class MsdoStreamContextTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pbi_ = static_cast<AV2Decoder *>(avm_memalign(32, sizeof(*pbi_)));
+    ASSERT_NE(pbi_, nullptr);
+    memset(pbi_, 0, sizeof(*pbi_));
+    pbi_->stream_info =
+        static_cast<StreamInfo *>(avm_calloc(3, sizeof(StreamInfo)));
+    ASSERT_NE(pbi_->stream_info, nullptr);
+    pbi_->common.xlayer_id = GLOBAL_XLAYER_ID;
+  }
+
+  void TearDown() override {
+    avm_free(pbi_->stream_info);
+    avm_free(pbi_);
+  }
+
+  static MsdoConfig MakeConfig(int id0, int id1, int id2) {
+    MsdoConfig config = {};
+    config.num_streams = 3;
+    config.stream_ids[0] = id0;
+    config.stream_ids[1] = id1;
+    config.stream_ids[2] = id2;
+    return config;
+  }
+
+  AV2Decoder *pbi_;
+};
+
+TEST_F(MsdoStreamContextTest, PreservesContextsForRetainedStreamIds) {
+  const MsdoConfig config_a = MakeConfig(0, 2, 4);
+  const MsdoConfig config_b = MakeConfig(0, 1, 3);
+  const MsdoConfig config_c = MakeConfig(0, 1, 2);
+
+  pbi_->stream_info[0].random_access_point_index_buf = 100;
+  pbi_->stream_info[1].random_access_point_index_buf = 102;
+  pbi_->stream_info[2].random_access_point_index_buf = 104;
+  pbi_->xlayer_id_map[0] = 1;
+
+  ASSERT_EQ(
+      av2_remap_msdo_stream_contexts(pbi_, &pbi_->common, &config_a, &config_b),
+      AVM_CODEC_OK);
+  EXPECT_EQ(pbi_->stream_info[0].random_access_point_index_buf, 100u);
+  EXPECT_EQ(pbi_->stream_info[1].random_access_point_index_buf, UINT64_MAX);
+  EXPECT_EQ(pbi_->stream_info[2].random_access_point_index_buf, UINT64_MAX);
+  EXPECT_EQ(pbi_->xlayer_id_map[0], 1);
+
+  pbi_->stream_info[1].random_access_point_index_buf = 101;
+  pbi_->stream_info[2].random_access_point_index_buf = 103;
+
+  ASSERT_EQ(
+      av2_remap_msdo_stream_contexts(pbi_, &pbi_->common, &config_b, &config_c),
+      AVM_CODEC_OK);
+  EXPECT_EQ(pbi_->stream_info[0].random_access_point_index_buf, 100u);
+  EXPECT_EQ(pbi_->stream_info[1].random_access_point_index_buf, 101u);
+  EXPECT_EQ(pbi_->stream_info[2].random_access_point_index_buf, UINT64_MAX);
+}
+
+TEST_F(MsdoStreamContextTest, MovesRetainedContextToItsNewSlot) {
+  const MsdoConfig config_a = MakeConfig(0, 2, 4);
+  const MsdoConfig config_b = MakeConfig(0, 4, 2);
+
+  pbi_->stream_info[0].random_access_point_index_buf = 100;
+  pbi_->stream_info[1].random_access_point_index_buf = 102;
+  pbi_->stream_info[2].random_access_point_index_buf = 104;
+
+  ASSERT_EQ(
+      av2_remap_msdo_stream_contexts(pbi_, &pbi_->common, &config_a, &config_b),
+      AVM_CODEC_OK);
+  EXPECT_EQ(pbi_->stream_info[0].random_access_point_index_buf, 100u);
+  EXPECT_EQ(pbi_->stream_info[1].random_access_point_index_buf, 104u);
+  EXPECT_EQ(pbi_->stream_info[2].random_access_point_index_buf, 102u);
 }
 
 TEST_F(SBEApiTest, ProcessGlobalLcrSetsMultistream) {


### PR DESCRIPTION
## Problem

`stream_info[]` is indexed by the position of an xlayer ID in the current MSDO `stream_ids[]` array.

When the stream ID list changes, the decoder updates `cm->stream_ids` without remapping the existing contexts. This can associate a context with a different xlayer.

For example:

`(0, 2, 4) -> (0, 1, 3) -> (0, 1, 2)`

With the current implementation:

- xlayer 1 can inherit xlayer 2 context.
- xlayer 3 can inherit xlayer 4 context.
- xlayer 2 can later inherit xlayer 3 context.

The [AV2 v1.0 specification](https://github.com/AOMediaCodec/av2-spec/blob/main/v1.0.0/20260528_38f28e7_AV2_Spec_v1.0.0.pdf) allows `sub_xlayer_id` values to change at a random access point without starting a new coded multistream video sequence. Therefore, contexts belonging to xlayer IDs that remain present must not be reset.

Random access points do not need to be aligned across extended layers. For example, during an MSDO transition from `(0, 1, 3)` to `(0, 1, 2)`, xlayer 2 may enter at a random access point while retained xlayers 0 and 1 remain mid-sequence and continue decoding inter frames. Resetting every stream context at this transition would invalidate the DPB references required by xlayers 0 and 1 and break their subsequent inter-frame decoding.

## Changes

- Parse a new MSDO into a temporary configuration before updating `cm->stream_ids`.
- Detect changes to the MSDO stream ID list separately from coded multistream video sequence configuration changes.
- Remap `stream_info[]` by xlayer ID instead of array position.
- Preserve contexts for xlayer IDs that remain present.
- Flush and release contexts for removed xlayer IDs.
- Initialize fresh contexts for newly added xlayer IDs.
- Keep the existing full reset behavior for changes that start a new coded multistream video sequence.

For the example above:

- `(0, 2, 4) -> (0, 1, 3)`: preserve xlayer 0; initialize 1 and 3.
- `(0, 1, 3) -> (0, 1, 2)`: preserve xlayers 0 and 1; initialize 2.
- If a retained xlayer moves to another array position, its context moves with the xlayer ID.

## Tests

Added regression tests covering:

- Context preservation across `(0, 2, 4) -> (0, 1, 3) -> (0, 1, 2)`.
- Context remapping when retained xlayer IDs change array positions.
- Initialization of newly added xlayer IDs.

Validation:

- Debug `test_libavm` build passed.
- `SBEApiTest.*:MsdoStreamContextTest.*`: 19 tests passed.

## Context

This builds on the redundant MSDO handling introduced in #4718 and the configuration-transition flushing added in #4840. Neither change remaps per-stream contexts when only the MSDO `sub_xlayer_id` list changes.