### PR TITLE
Add 12-bit profile (Main_444C_12_IP2)

### DIFF
--- a/.github/workflows/build-job-reusable.yaml
+++ b/.github/workflows/build-job-reusable.yaml
@@ -126,7 +126,7 @@ jobs:
               CMAKE_FLAGS="${CMAKE_FLAGS} -DCONFIG_BITSTREAM_DEBUG=1 -DCONFIG_MISMATCH_DEBUG=1"
               ;;
             enable-12bit-profile)
-              CMAKE_FLAGS="${CMAKE_FLAGS} -DCONFIG_TESTONLY_12BIT_SUPPORT=1"
+              CMAKE_FLAGS="${CMAKE_FLAGS} -DCONFIG_12BIT_PROFILE=1"
               ;;
             nasm)
               CMAKE_FLAGS="${CMAKE_FLAGS} -DENABLE_NASM=1"

--- a/.github/workflows/build-job-reusable.yaml
+++ b/.github/workflows/build-job-reusable.yaml
@@ -125,9 +125,6 @@ jobs:
             bitstream-mismatch-debug)
               CMAKE_FLAGS="${CMAKE_FLAGS} -DCONFIG_BITSTREAM_DEBUG=1 -DCONFIG_MISMATCH_DEBUG=1"
               ;;
-            enable-12bit-profile)
-              CMAKE_FLAGS="${CMAKE_FLAGS} -DCONFIG_12BIT_PROFILE=1"
-              ;;
             nasm)
               CMAKE_FLAGS="${CMAKE_FLAGS} -DENABLE_NASM=1"
               ;;

--- a/.github/workflows/common-builds-reusable.yaml
+++ b/.github/workflows/common-builds-reusable.yaml
@@ -70,7 +70,6 @@ jobs:
           - nasm
           - no-examples
           - debug
-          - enable-12bit-profile
 
   build-entropy-stats:
     name: Build (entropy-stats)
@@ -104,21 +103,6 @@ jobs:
       matrix:
         avm-build-config:
           - bitstream-mismatch-debug
-
-  build-enable-12bit-profile:
-    name: Build (enable-12bit-profile)
-    uses: ./.github/workflows/build-job-reusable.yaml
-    if: (!cancelled())
-    with:
-      avm-build-config: ${{ matrix.avm-build-config }}
-      parent-job-name: build-enable-12bit-profile
-      runner: ${{ inputs.runner }}
-      container-image: ${{ inputs.container-image }}
-      show-github-context: true
-    strategy:
-      matrix:
-        avm-build-config:
-          - enable-12bit-profile
 
   build-x86-linux-gcc:
     name: Build (x86-linux-gcc)

--- a/apps/avmenc.c
+++ b/apps/avmenc.c
@@ -2161,7 +2161,7 @@ int main(int argc, const char **argv_) {
 
 #if CONFIG_12BIT_PROFILE
       if (stream->config.cfg.g_bit_depth > 10) {
-        stream->config.cfg.g_profile = MAIN_4xx_12_IP2;
+        stream->config.cfg.g_profile = MAIN_444C_12_IP2;
         profile_updated = 1;
       }
 #endif  // CONFIG_12BIT_PROFILE

--- a/apps/avmenc.c
+++ b/apps/avmenc.c
@@ -2159,12 +2159,12 @@ int main(int argc, const char **argv_) {
         }
       }
 
-#if CONFIG_TESTONLY_12BIT_SUPPORT
+#if CONFIG_12BIT_PROFILE
       if (stream->config.cfg.g_bit_depth > 10) {
-        stream->config.cfg.g_profile = TEST_ONLY_12BIT_PROFILE;
+        stream->config.cfg.g_profile = MAIN_4xx_12_IP2;
         profile_updated = 1;
       }
-#endif  // CONFIG_TESTONLY_12BIT_SUPPORT
+#endif  // CONFIG_12BIT_PROFILE
 
       // Force encoder to use 16-bit pipeline for 8-bit video/image
       if (profile_updated && !global.quiet) {

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -867,10 +867,10 @@ static avm_codec_err_t validate_img(avm_codec_alg_priv_t *ctx,
     case AVM_IMG_FMT_I42016: break;
     case AVM_IMG_FMT_I444:
     case AVM_IMG_FMT_I44416:
-      // MAIN_444_10_IP1 and MAIN_4xx_12_IP2 are the profiles that support 444
+      // MAIN_444_10_IP1 and MAIN_444C_12_IP2 are the profiles that support 444
       if (ctx->cfg.g_profile != (unsigned int)MAIN_444_10_IP1 &&
 #if CONFIG_12BIT_PROFILE
-          ctx->cfg.g_profile != (unsigned int)MAIN_4xx_12_IP2 &&
+          ctx->cfg.g_profile != (unsigned int)MAIN_444C_12_IP2 &&
 #endif  // CONFIG_12BIT_PROFILE
           !ctx->cfg.monochrome) {
         ERROR("Invalid image format. I444 images not supported in profile.");
@@ -880,7 +880,7 @@ static avm_codec_err_t validate_img(avm_codec_alg_priv_t *ctx,
     case AVM_IMG_FMT_I42216:
       if (ctx->cfg.g_profile != (unsigned int)MAIN_422_10_IP1
 #if CONFIG_12BIT_PROFILE
-          && ctx->cfg.g_profile != (unsigned int)MAIN_4xx_12_IP2
+          && ctx->cfg.g_profile != (unsigned int)MAIN_444C_12_IP2
 #endif  // CONFIG_12BIT_PROFILE
       ) {
         ERROR("Invalid image format. I422 images not supported in profile.");

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -666,13 +666,13 @@ static avm_codec_err_t validate_config(avm_codec_alg_priv_t *ctx,
   RANGE_CHECK(cfg, g_timebase.num, 1, cfg->g_timebase.den);
 
   RANGE_CHECK_HI(cfg, g_profile, MAX_PROFILES - 1);
-#if !CONFIG_TESTONLY_12BIT_SUPPORT
+#if !CONFIG_12BIT_PROFILE
   RANGE_CHECK(cfg, g_bit_depth, AVM_BITS_8, AVM_BITS_10);
   RANGE_CHECK(cfg, g_input_bit_depth, AVM_BITS_8, AVM_BITS_10);
 #else
   RANGE_CHECK(cfg, g_bit_depth, AVM_BITS_8, AVM_BITS_12);
   RANGE_CHECK(cfg, g_input_bit_depth, AVM_BITS_8, AVM_BITS_12);
-#endif  // !CONFIG_TESTONLY_12BIT_SUPPORT
+#endif  // !CONFIG_12BIT_PROFILE
 
   const int min_quantizer =
       (-(int)(cfg->g_bit_depth - AVM_BITS_8) * MAXQ_OFFSET);
@@ -860,10 +860,6 @@ static avm_codec_err_t validate_config(avm_codec_alg_priv_t *ctx,
 
 static avm_codec_err_t validate_img(avm_codec_alg_priv_t *ctx,
                                     const avm_image_t *img) {
-#if CONFIG_TESTONLY_12BIT_SUPPORT
-  if (ctx->cfg.g_profile == TEST_ONLY_12BIT_PROFILE) return AVM_CODEC_OK;
-#endif  // CONFIG_TESTONLY_12BIT_SUPPORT
-
   switch (img->fmt) {
     case AVM_IMG_FMT_YV12:
     case AVM_IMG_FMT_I420:
@@ -871,15 +867,22 @@ static avm_codec_err_t validate_img(avm_codec_alg_priv_t *ctx,
     case AVM_IMG_FMT_I42016: break;
     case AVM_IMG_FMT_I444:
     case AVM_IMG_FMT_I44416:
-      // MAIN_444_10_IP1 is the only profile that support 444
+      // MAIN_444_10_IP1 and MAIN_4xx_12_IP2 are the profiles that support 444
       if (ctx->cfg.g_profile != (unsigned int)MAIN_444_10_IP1 &&
+#if CONFIG_12BIT_PROFILE
+          ctx->cfg.g_profile != (unsigned int)MAIN_4xx_12_IP2 &&
+#endif  // CONFIG_12BIT_PROFILE
           !ctx->cfg.monochrome) {
         ERROR("Invalid image format. I444 images not supported in profile.");
       }
       break;
     case AVM_IMG_FMT_I422:
     case AVM_IMG_FMT_I42216:
-      if (ctx->cfg.g_profile != (unsigned int)MAIN_422_10_IP1) {
+      if (ctx->cfg.g_profile != (unsigned int)MAIN_422_10_IP1
+#if CONFIG_12BIT_PROFILE
+          && ctx->cfg.g_profile != (unsigned int)MAIN_4xx_12_IP2
+#endif  // CONFIG_12BIT_PROFILE
+      ) {
         ERROR("Invalid image format. I422 images not supported in profile.");
       }
       break;

--- a/av2/common/annexA.c
+++ b/av2/common/annexA.c
@@ -320,15 +320,14 @@ int av2_check_profile_interop_conformance(
 // picture_size_profile_factor_table[] in level.c, and bitrate_profile_factor[]
 // in timing.c).
 //
-// NOTE: This return value is NOT always the spec's ProfileScalingFactor from
-// Table A.2. It coincides with it for profiles 0..4 (0, 0, 0, 1, 2), but
-// profile MAIN_444C_12_IP2 (idc 5) has spec ProfileScalingFactor 2 -- the same
-// as profile MAIN_444_10_IP1 (idc 4) -- while requiring DIFFERENT PicSize and
-// Bitrate factors (36 / 3.0 vs 30 / 2.5). Since a single ProfileScalingFactor
-// value cannot select two different factor rows, profile 5 is given its own
-// row index (3) here. All callers use this value only as a table index, never
-// as the literal ProfileScalingFactor.
-int get_profile_scaling_factor(int seq_profile_idc) {
+// NOTE: This is a table row index, NOT the spec's ProfileScalingFactor from
+// Table A.2. The two coincide for profiles 0..4 (0, 0, 0, 1, 2), but profile
+// MAIN_444C_12_IP2 (idc 5) has spec ProfileScalingFactor 2 -- the same as
+// profile MAIN_444_10_IP1 (idc 4) -- while requiring DIFFERENT PicSize and
+// Bitrate factors (36 / 3.0 vs 30 / 2.5). Since one ProfileScalingFactor value
+// cannot select two different factor rows, profile 5 is given its own row
+// index (3) here.
+int get_profile_factor_table_row_index(int seq_profile_idc) {
   if (seq_profile_idc == MAIN_420_10_IP0 ||
       seq_profile_idc == MAIN_420_10_IP1 ||
       seq_profile_idc == MAIN_420_10_IP2) {

--- a/av2/common/annexA.c
+++ b/av2/common/annexA.c
@@ -27,7 +27,8 @@
  *       0         | C_Main_420_10       | Main    | 8, 10       |  4:0:0, 4:2:0
  *       1         | C_Main_422_10       | Main    | 8, 10       |  4:0:0, 4:2:0, 4:2:2
  *       2         | C_Main_444_10       | Main    | 8, 10       |  4:0:0, 4:2:0, 4:4:4
- *       3-63      | Reserved            | -       | -           |
+ *       3         | C_Main_4xx_12       | Main    | 8, 10, 12   |  4:0:0, 4:2:0, 4:2:2, 4:4:4
+ *       4-63      | Reserved            | -       | -           |
  *
  * Notes:
  * - ConfigurationID: Identifies the multi-sequence configuration (6-bit value)
@@ -40,6 +41,7 @@ typedef enum {
   C_MAIN_420_10 = 0,  // Main toolset, 8/10-bit, 4:0:0/4:2:0
   C_MAIN_422_10 = 1,  // Main toolset, 8/10-bit, 4:0:0/4:2:0/4:2:2
   C_MAIN_444_10 = 2,  // Main toolset, 8/10-bit, 4:0:0/4:2:0/4:4:4
+  C_MAIN_4xx_12 = 3,  // Main toolset, 8/10/12-bit, 4:0:0/4:2:0/4:2:2/4:4:4
 } AV2_CONFIGURATION_LABEL;
 
 /* clang-format off */
@@ -49,9 +51,18 @@ typedef enum {
 //===========================================================================
  *  Configuration Label    |   seq_profile_idc    |    chroma_format_idc    |    bit_depth_idc
  * ------------------------|----------------------|-------------------------|---------------
- *   C_Main_420_10         | 0..2, 31             | 0 or 1                  | 0 or 1
- *   C_Main_422_10         | 0..3, 31             | 0, 1, 3                 | 0 or 1
- *   C_Main_444_10         | 0..2, 4, 31          | 0, 1, 2                 | 0 or 1
+ *   C_Main_420_10         | 0..2, 31             | CHROMA_FORMAT_400,      | 0 or 1
+ *                         |                      | CHROMA_FORMAT_420       |
+ *   C_Main_422_10         | 0..3, 31             | CHROMA_FORMAT_400,      | 0 or 1
+ *                         |                      | CHROMA_FORMAT_420,      |
+ *                         |                      | CHROMA_FORMAT_422       |
+ *   C_Main_444_10         | 0..2, 4, 31          | CHROMA_FORMAT_400,      | 0 or 1
+ *                         |                      | CHROMA_FORMAT_420,      |
+ *                         |                      | CHROMA_FORMAT_444       |
+ *   C_Main_4xx_12         | 0..5, 31             | CHROMA_FORMAT_400,      | 0..2
+ *                         |                      | CHROMA_FORMAT_420,      |
+ *                         |                      | CHROMA_FORMAT_422,      |
+ *                         |                      | CHROMA_FORMAT_444       |
  *
  * Notes:
  * - seq_profile_idc: Allowed profile values
@@ -82,14 +93,10 @@ typedef enum {
 } INTEROP_POINTS;
 
 static const int seq_profile_max_mlayer_cnt[MAX_PROFILES] = {
-  1,
-  2,
+  1, 2, 3, 2, 2,
+#if CONFIG_12BIT_PROFILE
   3,
-  2,
-  2,
-#if CONFIG_TESTONLY_12BIT_SUPPORT
-  MAX_NUM_MLAYERS,
-#endif  // CONFIG_TESTONLY_12BIT_SUPPORT
+#endif  // CONFIG_12BIT_PROFILE
 };
 
 /* clang-format off */
@@ -117,7 +124,12 @@ static const int seq_profile_max_mlayer_cnt[MAX_PROFILES] = {
  *                                                       CHROMA_FORMAT_420
  *                                                       CHROMA_FORMAT_444
  * ---------------------------------------------------------------------------------------------------------------------
- *  Reserved                         5-30
+ *  Main_4xx_12_IP2                   5                  CHROMA_FORMAT_400          0, 1, or 2                    2
+ *                                                       CHROMA_FORMAT_420
+ *                                                       CHROMA_FORMAT_422
+ *                                                       CHROMA_FORMAT_444
+ * ---------------------------------------------------------------------------------------------------------------------
+ *  Reserved                         6-30
  * ---------------------------------------------------------------------------------------------------------------------
  *  Configurable                      31                 CHROMA_FORMAT_400          0 or 1                        -
  *                                                       CHROMA_FORMAT_420
@@ -143,11 +155,19 @@ static INLINE int av2_get_max_mlayer_cnt_from_profile(int seq_profile_idc) {
   return seq_profile_max_mlayer_cnt[seq_profile_idc];
 }
 
-static int check_bit_depth_8_10(int bit_depth) {
-  if (bit_depth != AVM_BITS_8 && bit_depth != AVM_BITS_10) {
-    return 0;
+static int check_bit_depth(int bit_depth, BITSTREAM_PROFILE profile) {
+  (void)profile;
+  // All profiles support 8-bit and 10-bit. Profile MAIN_4xx_12_IP2
+  // additionally supports 12-bit.
+  if (bit_depth == AVM_BITS_8 || bit_depth == AVM_BITS_10) {
+    return 1;
   }
-  return 1;
+#if CONFIG_12BIT_PROFILE
+  if (profile == MAIN_4xx_12_IP2 && bit_depth == AVM_BITS_12) {
+    return 1;
+  }
+#endif  // CONFIG_12BIT_PROFILE
+  return 0;
 }
 
 static avm_codec_err_t check_chroma_format(int monochrome, int is_420,
@@ -184,10 +204,6 @@ int av2_check_profile_interop_conformance(
   const uint8_t monochrome = seq_params->monochrome;
   const int seq_max_mcount = seq_params->seq_max_mlayer_cnt;
 
-#if CONFIG_TESTONLY_12BIT_SUPPORT
-  if (profile == TEST_ONLY_12BIT_PROFILE && bit_depth == AVM_BITS_12) return 1;
-#endif  // CONFIG_TESTONLY_12BIT_SUPPORT
-
   uint32_t chroma_format_idc = CHROMA_FORMAT_420;
   avm_codec_err_t err = av2_get_chroma_format_idc(
       seq_params->subsampling_x, seq_params->subsampling_y, monochrome,
@@ -204,8 +220,7 @@ int av2_check_profile_interop_conformance(
   const int is_422 = (chroma_format_idc == CHROMA_FORMAT_422);
   const int is_444 = (chroma_format_idc == CHROMA_FORMAT_444);
 
-  // All profiles support 8-bit and 10-bit only
-  int is_valid_bit_depth = check_bit_depth_8_10(bit_depth);
+  int is_valid_bit_depth = check_bit_depth(bit_depth, profile);
   if (!is_valid_bit_depth) {
     return 0;
   }
@@ -255,14 +270,20 @@ int av2_check_profile_interop_conformance(
             (int)profile);
       }
       break;
+#if CONFIG_12BIT_PROFILE
+    case MAIN_4xx_12_IP2:
+      // Supports all chroma formats (4:0:0/4:2:0/4:2:2/4:4:4) at 8/10/12-bit
+      break;
+#endif  // CONFIG_12BIT_PROFILE
     case CONFIGURABLE: {
       // Supports all chroma formats
     } break;
     default:
-      // Profile 5+ - reserved/unsupported
+      // Reserved/unsupported
       return 0;
   }
-  // Check if Max mlayer count is valid for IP profiles (seq_profile_idc <=2)
+  // Check that the max mlayer count is within the profile's interoperability
+  // point limit
   err = check_mlayer_count(profile, seq_max_mcount);
   if (err != AVM_CODEC_OK) {
     avm_internal_error(
@@ -287,11 +308,26 @@ int av2_check_profile_interop_conformance(
  * ------------------------------------------------------------------------------------------------------------------
  * 4                                           | 2                    | 30                   | 2.5                  |
  * ------------------------------------------------------------------------------------------------------------------
+ * 5                                           | 2                    | 36                   | 3.0                  |
+ * ------------------------------------------------------------------------------------------------------------------
  * 31                                          | -                    | -                    | -                    |
  * ------------------------------------------------------------------------------------------------------------------
  */
 /* clang-format on */
 
+// Returns the row index used to look up a profile's factors in the
+// PicSize/Bitrate factor tables (see bitrate_profile_factor_table[] and
+// picture_size_profile_factor_table[] in level.c, and bitrate_profile_factor[]
+// in timing.c).
+//
+// NOTE: This return value is NOT always the spec's ProfileScalingFactor from
+// Table A.2. It coincides with it for profiles 0..4 (0, 0, 0, 1, 2), but
+// profile MAIN_4xx_12_IP2 (idc 5) has spec ProfileScalingFactor 2 -- the same
+// as profile MAIN_444_10_IP1 (idc 4) -- while requiring DIFFERENT PicSize and
+// Bitrate factors (36 / 3.0 vs 30 / 2.5). Since a single ProfileScalingFactor
+// value cannot select two different factor rows, profile 5 is given its own
+// row index (3) here. All callers use this value only as a table index, never
+// as the literal ProfileScalingFactor.
 int get_profile_scaling_factor(int seq_profile_idc) {
   if (seq_profile_idc == MAIN_420_10_IP0 ||
       seq_profile_idc == MAIN_420_10_IP1 ||
@@ -306,6 +342,12 @@ int get_profile_scaling_factor(int seq_profile_idc) {
   if (seq_profile_idc == MAIN_444_10_IP1) {
     return 2;
   }
+
+#if CONFIG_12BIT_PROFILE
+  if (seq_profile_idc == MAIN_4xx_12_IP2) {
+    return 3;
+  }
+#endif  // CONFIG_12BIT_PROFILE
 
   // Default for invalid combinations and Configurable profile
   return 0;

--- a/av2/common/annexA.c
+++ b/av2/common/annexA.c
@@ -27,7 +27,7 @@
  *       0         | C_Main_420_10       | Main    | 8, 10       |  4:0:0, 4:2:0
  *       1         | C_Main_422_10       | Main    | 8, 10       |  4:0:0, 4:2:0, 4:2:2
  *       2         | C_Main_444_10       | Main    | 8, 10       |  4:0:0, 4:2:0, 4:4:4
- *       3         | C_Main_4xx_12       | Main    | 8, 10, 12   |  4:0:0, 4:2:0, 4:2:2, 4:4:4
+ *       3         | C_Main_444C_12      | Main    | 8, 10, 12   |  4:0:0, 4:2:0, 4:2:2, 4:4:4
  *       4-63      | Reserved            | -       | -           |
  *
  * Notes:
@@ -38,10 +38,10 @@
 /* clang-format on */
 
 typedef enum {
-  C_MAIN_420_10 = 0,  // Main toolset, 8/10-bit, 4:0:0/4:2:0
-  C_MAIN_422_10 = 1,  // Main toolset, 8/10-bit, 4:0:0/4:2:0/4:2:2
-  C_MAIN_444_10 = 2,  // Main toolset, 8/10-bit, 4:0:0/4:2:0/4:4:4
-  C_MAIN_4xx_12 = 3,  // Main toolset, 8/10/12-bit, 4:0:0/4:2:0/4:2:2/4:4:4
+  C_MAIN_420_10 = 0,   // Main toolset, 8/10-bit, 4:0:0/4:2:0
+  C_MAIN_422_10 = 1,   // Main toolset, 8/10-bit, 4:0:0/4:2:0/4:2:2
+  C_MAIN_444_10 = 2,   // Main toolset, 8/10-bit, 4:0:0/4:2:0/4:4:4
+  C_MAIN_444C_12 = 3,  // Main toolset, 8/10/12-bit, 4:0:0/4:2:0/4:2:2/4:4:4
 } AV2_CONFIGURATION_LABEL;
 
 /* clang-format off */
@@ -59,7 +59,7 @@ typedef enum {
  *   C_Main_444_10         | 0..2, 4, 31          | CHROMA_FORMAT_400,      | 0 or 1
  *                         |                      | CHROMA_FORMAT_420,      |
  *                         |                      | CHROMA_FORMAT_444       |
- *   C_Main_4xx_12         | 0..5, 31             | CHROMA_FORMAT_400,      | 0..2
+ *   C_Main_444C_12        | 0..5, 31             | CHROMA_FORMAT_400,      | 0..2
  *                         |                      | CHROMA_FORMAT_420,      |
  *                         |                      | CHROMA_FORMAT_422,      |
  *                         |                      | CHROMA_FORMAT_444       |
@@ -124,7 +124,7 @@ static const int seq_profile_max_mlayer_cnt[MAX_PROFILES] = {
  *                                                       CHROMA_FORMAT_420
  *                                                       CHROMA_FORMAT_444
  * ---------------------------------------------------------------------------------------------------------------------
- *  Main_4xx_12_IP2                   5                  CHROMA_FORMAT_400          0, 1, or 2                    2
+ *  Main_444C_12_IP2                  5                  CHROMA_FORMAT_400          0, 1, or 2                    2
  *                                                       CHROMA_FORMAT_420
  *                                                       CHROMA_FORMAT_422
  *                                                       CHROMA_FORMAT_444
@@ -157,13 +157,13 @@ static INLINE int av2_get_max_mlayer_cnt_from_profile(int seq_profile_idc) {
 
 static int check_bit_depth(int bit_depth, BITSTREAM_PROFILE profile) {
   (void)profile;
-  // All profiles support 8-bit and 10-bit. Profile MAIN_4xx_12_IP2
+  // All profiles support 8-bit and 10-bit. Profile MAIN_444C_12_IP2
   // additionally supports 12-bit.
   if (bit_depth == AVM_BITS_8 || bit_depth == AVM_BITS_10) {
     return 1;
   }
 #if CONFIG_12BIT_PROFILE
-  if (profile == MAIN_4xx_12_IP2 && bit_depth == AVM_BITS_12) {
+  if (profile == MAIN_444C_12_IP2 && bit_depth == AVM_BITS_12) {
     return 1;
   }
 #endif  // CONFIG_12BIT_PROFILE
@@ -271,7 +271,7 @@ int av2_check_profile_interop_conformance(
       }
       break;
 #if CONFIG_12BIT_PROFILE
-    case MAIN_4xx_12_IP2:
+    case MAIN_444C_12_IP2:
       // Supports all chroma formats (4:0:0/4:2:0/4:2:2/4:4:4) at 8/10/12-bit
       break;
 #endif  // CONFIG_12BIT_PROFILE
@@ -322,7 +322,7 @@ int av2_check_profile_interop_conformance(
 //
 // NOTE: This return value is NOT always the spec's ProfileScalingFactor from
 // Table A.2. It coincides with it for profiles 0..4 (0, 0, 0, 1, 2), but
-// profile MAIN_4xx_12_IP2 (idc 5) has spec ProfileScalingFactor 2 -- the same
+// profile MAIN_444C_12_IP2 (idc 5) has spec ProfileScalingFactor 2 -- the same
 // as profile MAIN_444_10_IP1 (idc 4) -- while requiring DIFFERENT PicSize and
 // Bitrate factors (36 / 3.0 vs 30 / 2.5). Since a single ProfileScalingFactor
 // value cannot select two different factor rows, profile 5 is given its own
@@ -344,7 +344,7 @@ int get_profile_scaling_factor(int seq_profile_idc) {
   }
 
 #if CONFIG_12BIT_PROFILE
-  if (seq_profile_idc == MAIN_4xx_12_IP2) {
+  if (seq_profile_idc == MAIN_444C_12_IP2) {
     return 3;
   }
 #endif  // CONFIG_12BIT_PROFILE

--- a/av2/common/annexA.h
+++ b/av2/common/annexA.h
@@ -46,8 +46,10 @@ int av2_check_profile_interop_conformance(
 //==========================================
 // Profile Scaling and Bitrate Functions
 //===========================================
-// Gets profile scaling factor CWG-G004
-int get_profile_scaling_factor(int seq_profile_idc);
+// Gets the row index for a profile's PicSize/Bitrate factors (Table A.2,
+// CWG-G004). See the definition in annexA.c for why this is not the spec's
+// ProfileScalingFactor.
+int get_profile_factor_table_row_index(int seq_profile_idc);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/av2/common/enums.h
+++ b/av2/common/enums.h
@@ -275,7 +275,7 @@ enum {
   MAIN_444_10_IP1 = 4,
 #if CONFIG_12BIT_PROFILE
   // 12-bit profile: all chroma formats (4:0:0/4:2:0/4:2:2/4:4:4), IOP2
-  MAIN_4xx_12_IP2 = 5,
+  MAIN_444C_12_IP2 = 5,
 #endif  // CONFIG_12BIT_PROFILE
   RESERVED_PROFILES_START,
   CONFIGURABLE = 31,

--- a/av2/common/enums.h
+++ b/av2/common/enums.h
@@ -273,10 +273,10 @@ enum {
   MAIN_420_10_IP2 = 2,
   MAIN_422_10_IP1 = 3,
   MAIN_444_10_IP1 = 4,
-#if CONFIG_TESTONLY_12BIT_SUPPORT
-  // Fake profile value only for testing 12-bit. Not defined in AV2 spec.
-  TEST_ONLY_12BIT_PROFILE,
-#endif  // CONFIG_TESTONLY_12BIT_SUPPORT
+#if CONFIG_12BIT_PROFILE
+  // 12-bit profile: all chroma formats (4:0:0/4:2:0/4:2:2/4:4:4), IOP2
+  MAIN_4xx_12_IP2 = 5,
+#endif  // CONFIG_12BIT_PROFILE
   RESERVED_PROFILES_START,
   CONFIGURABLE = 31,
   MAX_PROFILES,

--- a/av2/common/enums.h
+++ b/av2/common/enums.h
@@ -274,7 +274,7 @@ enum {
   MAIN_422_10_IP1 = 3,
   MAIN_444_10_IP1 = 4,
 #if CONFIG_12BIT_PROFILE
-  // 12-bit profile: all chroma formats (4:0:0/4:2:0/4:2:2/4:4:4), IOP2
+  // 12-bit profile: all chroma formats (4:0:0/4:2:0/4:2:2/4:4:4), IP2
   MAIN_444C_12_IP2 = 5,
 #endif  // CONFIG_12BIT_PROFILE
   RESERVED_PROFILES_START,

--- a/av2/common/level.c
+++ b/av2/common/level.c
@@ -507,9 +507,9 @@ static double get_max_bitrate(const AV2LevelSpec *const level_spec, int tier,
   const double bitrate_basis =
       (tier ? level_spec->high_mbps / scale : level_spec->main_mbps / scale) *
       1e6;
-  const int profile_scaling_factor = get_profile_scaling_factor(profile);
+  const int profile_factor_row = get_profile_factor_table_row_index(profile);
   double bitrate_profile_factor =
-      bitrate_profile_factor_table[profile_scaling_factor];
+      bitrate_profile_factor_table[profile_factor_row];
   return bitrate_basis * bitrate_profile_factor;
 }
 
@@ -522,9 +522,9 @@ static double get_max_compressed_size(const AV2LevelSpec *const level_spec,
   const double min_comp_basis =
       (tier ? level_spec->high_cr : level_spec->main_cr);
 
-  const int profile_scaling_factor = get_profile_scaling_factor(profile);
+  const int profile_factor_row = get_profile_factor_table_row_index(profile);
   double picture_size_profile_factor =
-      picture_size_profile_factor_table[profile_scaling_factor];
+      picture_size_profile_factor_table[profile_factor_row];
 
   double max_compressed_size =
       ((long long)(frame_parsing_time * level_spec->max_decode_rate *
@@ -547,9 +547,9 @@ static double get_max_frame_symbol_count(const AV2LevelSpec *const level_spec,
   const double min_comp_basis =
       (tier ? level_spec->high_cr : level_spec->main_cr);
 
-  const int profile_scaling_factor = get_profile_scaling_factor(profile);
+  const int profile_factor_row = get_profile_factor_table_row_index(profile);
   double picture_size_profile_factor =
-      picture_size_profile_factor_table[profile_scaling_factor];
+      picture_size_profile_factor_table[profile_factor_row];
   double scale = multi_stream_scaling_x == 0 ? 1 : multi_stream_scaling_x;
   double max_frame_symbol_count =
       frame_parsing_time * (level_spec->max_decode_rate / scale) *
@@ -1586,9 +1586,9 @@ double av2_get_compression_ratio(const AV2_COMMON *const cm,
   const SequenceHeader *const seq_params = &cm->seq_params;
   const BITSTREAM_PROFILE profile = seq_params->seq_profile_idc;
 
-  const int profile_scaling_factor = get_profile_scaling_factor(profile);
+  const int profile_factor_row = get_profile_factor_table_row_index(profile);
   const int picture_size_profile_factor =
-      (int)picture_size_profile_factor_table[profile_scaling_factor];
+      (int)picture_size_profile_factor_table[profile_factor_row];
   encoded_frame_size =
       (encoded_frame_size > 129 ? encoded_frame_size - 128 : 1);
   const size_t uncompressed_frame_size =

--- a/av2/common/level.c
+++ b/av2/common/level.c
@@ -485,8 +485,9 @@ static const char *level_fail_messages[TARGET_LEVEL_FAIL_IDS] = {
   "The presentation interval is too small.",
 };
 
-static const double bitrate_profile_factor_table[] = { 1.0, 1.667, 2.5 };
-static const double picture_size_profile_factor_table[] = { 15.0, 20.0, 30.0 };
+static const double bitrate_profile_factor_table[] = { 1.0, 1.667, 2.5, 3.0 };
+static const double picture_size_profile_factor_table[] = { 15.0, 20.0, 30.0,
+                                                            36.0 };
 
 static const char level_string[SEQ_LEVEL_MAX + 1][9] = {
   "2.0",      "2.1",      "3.0",      "3.1",      "4.0",      "4.1",

--- a/av2/common/quant_common.c
+++ b/av2/common/quant_common.c
@@ -101,7 +101,7 @@ int av2_q_clamped(int qindex, int delta, int base_dc_delta_q,
     q_clamped = clamp(qindex + base_dc_delta_q + delta, 1,
                       bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
                       : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                 : MAXQ);
+                                                 : MAXQ_12_BITS);
   return q_clamped;
 }
 // Add the deltaq offset value
@@ -145,7 +145,7 @@ static int32_t get_q(int qindex, int delta, avm_bit_depth_t bit_depth) {
   const int q_clamped = clamp(qindex + delta, 1,
                               bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
                               : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                         : MAXQ);
+                                                         : MAXQ_12_BITS);
   return qlookup(q_clamped);
 }
 
@@ -168,7 +168,7 @@ int av2_get_qindex(const struct segmentation *seg, int segment_id,
     return clamp(seg_qindex, 0,
                  bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
                  : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                            : MAXQ);
+                                            : MAXQ_12_BITS);
   } else {
     return base_qindex;
   }

--- a/av2/common/quant_common.h
+++ b/av2/common/quant_common.h
@@ -34,11 +34,14 @@ extern "C" {
 #define QINDEX_BITS_UNEXT 8
 #define MAXQ_8_BITS 255
 #define MAXQ_OFFSET 24
-#define MAXQ (255 + 4 * MAXQ_OFFSET)
-#define MAXQ_10_BITS (255 + 2 * MAXQ_OFFSET)
+#define MAXQ_10_BITS (MAXQ_8_BITS + 2 * MAXQ_OFFSET)
+#define MAXQ_12_BITS (MAXQ_8_BITS + 4 * MAXQ_OFFSET)
+// Maximum quantizer irrespective of the bit depth (spec: MAXQ_BITS).
+#define MAXQ MAXQ_12_BITS
 #define QINDEX_RANGE (MAXQ - MINQ + 1)
 #define QINDEX_RANGE_8_BITS (MAXQ_8_BITS - MINQ + 1)
 #define QINDEX_RANGE_10_BITS (MAXQ_10_BITS - MINQ + 1)
+#define QINDEX_RANGE_12_BITS (MAXQ_12_BITS - MINQ + 1)
 
 // Total number of QM sets stored
 #define QM_LEVEL_BITS 4

--- a/av2/common/timing.c
+++ b/av2/common/timing.c
@@ -52,7 +52,7 @@ static int32_t high_kbps[1 << LEVEL_BITS] = {
 
 /* BitrateProfileFactor */
 static int bitrate_profile_factor[1 << PROFILE_BITS] = {
-  1, 2, 3, 0, 0, 0, 0, 0
+  1, 2, 3, 3, 0, 0, 0, 0
 };
 
 int64_t av2_max_level_bitrate(BITSTREAM_PROFILE seq_profile, int seq_level_idx,

--- a/av2/common/timing.c
+++ b/av2/common/timing.c
@@ -50,13 +50,15 @@ static int32_t high_kbps[1 << LEVEL_BITS] = {
   UNDEFINED_RATE, UNDEFINED_RATE, UNDEFINED_RATE, UNDEFINED_RATE
 };
 
-/* BitrateProfileFactor. A zero entry indicates an unsupported profile: callers
- * treat a zero bitrate as "profile, level, and tier combination not
- * supported". */
+/* BitrateProfileFactor, indexed by the profile's factor table row
+ * (see get_profile_factor_table_row_index() in annexA.c).
+ * A zero entry indicates an unsupported profile. */
 static int bitrate_profile_factor[1 << PROFILE_BITS] = {
   1, 2, 3, 3, 0, 0, 0, 0
 };
 
+// Callers treat a zero bitrate as "profile, level, and tier combination not
+// supported".
 int64_t av2_max_level_bitrate(BITSTREAM_PROFILE seq_profile, int seq_level_idx,
                               int seq_tier) {
   int64_t bitrate;

--- a/av2/common/timing.c
+++ b/av2/common/timing.c
@@ -50,7 +50,9 @@ static int32_t high_kbps[1 << LEVEL_BITS] = {
   UNDEFINED_RATE, UNDEFINED_RATE, UNDEFINED_RATE, UNDEFINED_RATE
 };
 
-/* BitrateProfileFactor */
+/* BitrateProfileFactor. A zero entry indicates an unsupported profile: callers
+ * treat a zero bitrate as "profile, level, and tier combination not
+ * supported". */
 static int bitrate_profile_factor[1 << PROFILE_BITS] = {
   1, 2, 3, 3, 0, 0, 0, 0
 };

--- a/av2/common/timing.c
+++ b/av2/common/timing.c
@@ -59,14 +59,14 @@ int64_t av2_max_level_bitrate(BITSTREAM_PROFILE seq_profile, int seq_level_idx,
                               int seq_tier) {
   int64_t bitrate;
 
-  int profile_scaling_factor = get_profile_scaling_factor(seq_profile);
+  int profile_factor_row = get_profile_factor_table_row_index(seq_profile);
 
   if (seq_tier) {
-    bitrate = high_kbps[seq_level_idx] *
-              bitrate_profile_factor[profile_scaling_factor];
+    bitrate =
+        high_kbps[seq_level_idx] * bitrate_profile_factor[profile_factor_row];
   } else {
-    bitrate = main_kbps[seq_level_idx] *
-              bitrate_profile_factor[profile_scaling_factor];
+    bitrate =
+        main_kbps[seq_level_idx] * bitrate_profile_factor[profile_factor_row];
   }
 
   return bitrate * 1000;

--- a/av2/decoder/decodemv.c
+++ b/av2/decoder/decodemv.c
@@ -1499,7 +1499,7 @@ static void read_delta_q_params(AV2_COMMON *const cm, MACROBLOCKD *const xd,
         clamp(xd->current_base_qindex, 1,
               cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
               : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                        : MAXQ);
+                                                        : MAXQ_12_BITS);
   }
 }
 

--- a/av2/encoder/aq_cyclicrefresh.c
+++ b/av2/encoder/aq_cyclicrefresh.c
@@ -43,10 +43,10 @@ CYCLIC_REFRESH *av2_cyclic_refresh_alloc(int mi_rows, int mi_cols,
   assert(bit_depth == AVM_BITS_8 ? (MAXQ_8_BITS <= (QINDEX_RANGE_8_BITS - 1))
          : bit_depth == AVM_BITS_10
              ? (MAXQ_10_BITS <= (QINDEX_RANGE_10_BITS - 1))
-             : (MAXQ <= (QINDEX_RANGE - 1)));
+             : (MAXQ_12_BITS <= (QINDEX_RANGE_12_BITS - 1)));
   const uint16_t qinit = bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
                          : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                    : MAXQ;
+                                                    : MAXQ_12_BITS;
   for (int i = 0; i < mi_rows * mi_cols; ++i) cr->last_coded_q_map[i] = qinit;
 
   cr->avg_frame_low_motion = 0.0;
@@ -430,7 +430,7 @@ void av2_cyclic_refresh_setup(AV2_COMP *const cpi) {
         cr->last_coded_q_map[i] =
             cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
             : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                      : MAXQ;
+                                                      : MAXQ_12_BITS;
 
       cr->sb_index = 0;
     }
@@ -480,7 +480,7 @@ void av2_cyclic_refresh_setup(AV2_COMP *const cpi) {
         0,
         cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
         : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                  : MAXQ);
+                                                  : MAXQ_12_BITS);
 
     cr->rdmult = av2_compute_rd_mult(cpi, qindex2);
 

--- a/av2/encoder/encodeframe_utils.c
+++ b/av2/encoder/encodeframe_utils.c
@@ -1080,7 +1080,7 @@ int av2_get_q_for_deltaq_objective(AV2_COMP *const cpi, BLOCK_SIZE bsize,
   qindex =
       AVMMIN(qindex, cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
                      : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                               : MAXQ);
+                                                               : MAXQ_12_BITS);
   qindex = AVMMAX(qindex, MINQ);
 
   return qindex;

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -1029,7 +1029,7 @@ static void init_config(struct AV2_COMP *cpi, AV2EncoderConfig *oxcf) {
       seq_params->subsampling_x = 0;
       seq_params->subsampling_y = 0;
 #if CONFIG_12BIT_PROFILE
-    } else if (seq_params->seq_profile_idc == MAIN_4xx_12_IP2) {
+    } else if (seq_params->seq_profile_idc == MAIN_444C_12_IP2) {
       seq_params->subsampling_x = oxcf->input_cfg.chroma_subsampling_x;
       seq_params->subsampling_y = oxcf->input_cfg.chroma_subsampling_y;
 #endif  // CONFIG_12BIT_PROFILE

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -1028,11 +1028,11 @@ static void init_config(struct AV2_COMP *cpi, AV2EncoderConfig *oxcf) {
     } else if (seq_params->seq_profile_idc == MAIN_444_10_IP1) {
       seq_params->subsampling_x = 0;
       seq_params->subsampling_y = 0;
-#if CONFIG_TESTONLY_12BIT_SUPPORT
-    } else if (seq_params->seq_profile_idc == TEST_ONLY_12BIT_PROFILE) {
+#if CONFIG_12BIT_PROFILE
+    } else if (seq_params->seq_profile_idc == MAIN_4xx_12_IP2) {
       seq_params->subsampling_x = oxcf->input_cfg.chroma_subsampling_x;
       seq_params->subsampling_y = oxcf->input_cfg.chroma_subsampling_y;
-#endif  // CONFIG_TESTONLY_12BIT_SUPPORT
+#endif  // CONFIG_12BIT_PROFILE
     } else {
       assert(0 && "Invalid seq_params->seq_profile_idc");
     }

--- a/av2/encoder/firstpass.c
+++ b/av2/encoder/firstpass.c
@@ -273,7 +273,7 @@ static int find_fp_qindex(avm_bit_depth_t bit_depth) {
   return av2_find_qindex(FIRST_PASS_Q, bit_depth, 0,
                          bit_depth == AVM_BITS_8    ? QINDEX_RANGE_8_BITS - 1
                          : bit_depth == AVM_BITS_10 ? QINDEX_RANGE_10_BITS - 1
-                                                    : QINDEX_RANGE - 1);
+                                                    : QINDEX_RANGE_12_BITS - 1);
 }
 
 static double raw_motion_error_stdev(int *raw_motion_err_list,

--- a/av2/encoder/ratectrl.c
+++ b/av2/encoder/ratectrl.c
@@ -1080,7 +1080,7 @@ static int apply_tcq_qp_offset(const AV2_COMP *cpi, int qp_tcq) {
   }
   int max_qp = bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
                : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                          : MAXQ;
+                                          : MAXQ_12_BITS;
   return clamp(qp_tcq + tcq_qp_offset_shift, 0, max_qp);
 }
 

--- a/av2/encoder/rd.c
+++ b/av2/encoder/rd.c
@@ -646,7 +646,7 @@ static void init_me_luts_bd(int *bit16lut, int range,
 void av2_init_me_luts(void) {
   init_me_luts_bd(sad_per_bit_lut_8, QINDEX_RANGE_8_BITS, AVM_BITS_8);
   init_me_luts_bd(sad_per_bit_lut_10, QINDEX_RANGE_10_BITS, AVM_BITS_10);
-  init_me_luts_bd(sad_per_bit_lut_12, QINDEX_RANGE, AVM_BITS_12);
+  init_me_luts_bd(sad_per_bit_lut_12, QINDEX_RANGE_12_BITS, AVM_BITS_12);
 }
 
 static const int rd_boost_factor[16] = { 64, 32, 32, 32, 24, 16, 12, 12,
@@ -700,6 +700,10 @@ int av2_get_deltaq_offset(const AV2_COMP *cpi, int qindex, double beta) {
                            cpi->common.seq_params.bit_depth);
   int newq = (int)rint(q / sqrt(beta));
   int orig_qindex = qindex;
+  const int max_qindex =
+      cpi->common.seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
+      : cpi->common.seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
+                                                        : MAXQ_12_BITS;
   if (newq < q) {
     do {
       qindex--;
@@ -711,11 +715,7 @@ int av2_get_deltaq_offset(const AV2_COMP *cpi, int qindex, double beta) {
       qindex++;
       q = av2_dc_quant_QTX(qindex, 0, cpi->common.seq_params.base_y_dc_delta_q,
                            cpi->common.seq_params.bit_depth);
-    } while (newq > q &&
-             (qindex <
-              (cpi->common.seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-               : cpi->common.seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                                 : MAXQ)));
+    } while (newq > q && qindex < max_qindex);
   }
   return qindex - orig_qindex;
 }
@@ -814,7 +814,7 @@ static void set_block_thresholds(const AV2_COMMON *cm, RD_OPT *rd) {
               0,
               cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
               : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                        : MAXQ);
+                                                        : MAXQ_12_BITS);
 
     const int q = compute_rd_thresh_factor(
         qindex, cm->seq_params.base_y_dc_delta_q, cm->seq_params.bit_depth);

--- a/cmake/avm_config_defaults.cmake
+++ b/cmake/avm_config_defaults.cmake
@@ -108,7 +108,7 @@ set_avm_config_var(DECODE_WIDTH_LIMIT 0 "Set limit for decode width.")
 set_avm_config_var(CONFIG_TUNE_VMAF 0 "Enable encoding tuning for VMAF.")
 
 # 12 - bit support.
-set_avm_config_var(CONFIG_TESTONLY_12BIT_SUPPORT 0
+set_avm_config_var(CONFIG_TESTONLY_12BIT_SUPPORT 1
                    "Enables 12-bit test-only profile not yet supported in AV2.")
 
 # AV2 experiment flags.

--- a/cmake/avm_config_defaults.cmake
+++ b/cmake/avm_config_defaults.cmake
@@ -110,7 +110,7 @@ set_avm_config_var(CONFIG_TUNE_VMAF 0 "Enable encoding tuning for VMAF.")
 # 12 - bit support.
 set_avm_config_var(
   CONFIG_12BIT_PROFILE 1
-  "Enables the 12-bit profile (Main_4xx_12_IP2) from AV2 Annex A.")
+  "Enables the 12-bit profile (Main_444C_12_IP2) from AV2 Annex A.")
 
 # AV2 experiment flags.
 set_avm_config_var(CONFIG_SPEED_STATS 0 "AV2 experiment flag.")

--- a/cmake/avm_config_defaults.cmake
+++ b/cmake/avm_config_defaults.cmake
@@ -108,8 +108,9 @@ set_avm_config_var(DECODE_WIDTH_LIMIT 0 "Set limit for decode width.")
 set_avm_config_var(CONFIG_TUNE_VMAF 0 "Enable encoding tuning for VMAF.")
 
 # 12 - bit support.
-set_avm_config_var(CONFIG_TESTONLY_12BIT_SUPPORT 1
-                   "Enables 12-bit test-only profile not yet supported in AV2.")
+set_avm_config_var(
+  CONFIG_12BIT_PROFILE 1
+  "Enables the 12-bit profile (Main_4xx_12_IP2) from AV2 Annex A.")
 
 # AV2 experiment flags.
 set_avm_config_var(CONFIG_SPEED_STATS 0 "AV2 experiment flag.")

--- a/test/end_to_end_test.cc
+++ b/test/end_to_end_test.cc
@@ -76,14 +76,14 @@ const TestVideoParam kTestVectors[] = {
     MAIN_422_10_IP1 },
   { "park_joy_90p_10_444.y4m", 10, AVM_IMG_FMT_I44416, AVM_BITS_10,
     MAIN_444_10_IP1 },
-#if CONFIG_TESTONLY_12BIT_SUPPORT
+#if CONFIG_12BIT_PROFILE
   { "park_joy_90p_12_420.y4m", 12, AVM_IMG_FMT_I42016, AVM_BITS_12,
-    TEST_ONLY_12BIT_PROFILE },
+    MAIN_4xx_12_IP2 },
   { "park_joy_90p_12_422.y4m", 12, AVM_IMG_FMT_I42216, AVM_BITS_12,
-    TEST_ONLY_12BIT_PROFILE },
+    MAIN_4xx_12_IP2 },
   { "park_joy_90p_12_444.y4m", 12, AVM_IMG_FMT_I44416, AVM_BITS_12,
-    TEST_ONLY_12BIT_PROFILE },
-#endif  // CONFIG_TESTONLY_12BIT_SUPPORT
+    MAIN_4xx_12_IP2 },
+#endif  // CONFIG_12BIT_PROFILE
 };
 
 // Encoding modes tested

--- a/test/end_to_end_test.cc
+++ b/test/end_to_end_test.cc
@@ -78,11 +78,11 @@ const TestVideoParam kTestVectors[] = {
     MAIN_444_10_IP1 },
 #if CONFIG_12BIT_PROFILE
   { "park_joy_90p_12_420.y4m", 12, AVM_IMG_FMT_I42016, AVM_BITS_12,
-    MAIN_4xx_12_IP2 },
+    MAIN_444C_12_IP2 },
   { "park_joy_90p_12_422.y4m", 12, AVM_IMG_FMT_I42216, AVM_BITS_12,
-    MAIN_4xx_12_IP2 },
+    MAIN_444C_12_IP2 },
   { "park_joy_90p_12_444.y4m", 12, AVM_IMG_FMT_I44416, AVM_BITS_12,
-    MAIN_4xx_12_IP2 },
+    MAIN_444C_12_IP2 },
 #endif  // CONFIG_12BIT_PROFILE
 };
 


### PR DESCRIPTION
This PR enables the 12-bit profile by default and brings its implementation into conformance with AV2 Spec Draft with 12-bit support: https://github.com/AOMediaCodec/av2-spec-internal/pull/776.

1. Enable CONFIG_TESTONLY_12BIT_SUPPORT by default
-   Flips the 12-bit config default from 0 to 1 so 12-bit encode/decode is built in by default. (Superseded by the rename below; the flag is now CONFIG_12BIT_PROFILE.)

2. Align MAIN_4xx_12_IP2 profile with AV2 spec Annex A
- Renames CONFIG_TESTONLY_12BIT_SUPPORT to CONFIG_12BIT_PROFILE, and the profile enum TEST_ONLY_12BIT_PROFILE to Main_444C_12_IP2 (spec Main_444C_12_IP2, seq_profile_idc = 5).
- Accepts 8/10/12-bit and all chroma formats (4:0:0/4:2:0/4:2:2/4:4:4) for profile 5, per Table A.1 (previously 8/10-bit were rejected).
- Sets the max embedded-layer count for profile 5 to 3, matching its IOP2 limit (Table A.3).
- Gives profile 5 its own PicSize/Bitrate factor row (36 / 3.0) per Table A.2.
- Updates the in-code Annex A profile/config tables (A.1/A.2/A.5/A.6) and comments, including the bit_depth_idc mapping.