### PR TITLE
Fix setting in multi_layers tests

### DIFF
--- a/test/multi_layer_test.cc
+++ b/test/multi_layer_test.cc
@@ -464,17 +464,6 @@ TEST_P(MultiLayerTest, MultiLayerTest2Embedded) {
   EXPECT_EQ(num_mismatch_, 0);
 }
 
-TEST_P(MultiLayerTest, MultiLayerTest2EmbeddedDecodeBaseOnlyImplicit) {
-  ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
-  num_temporal_layers_ = 1;
-  num_embedded_layers_ = 2;
-  decode_base_only_ = true;
-  drop_tl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
-  ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
-  EXPECT_EQ(num_mismatch_, 0);
-}
-
 TEST_P(MultiLayerTest, MultiLayerTest2EmbeddedDecodeBaseOnlyExplicit) {
   ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
   num_temporal_layers_ = 1;

--- a/test/multi_layer_test.cc
+++ b/test/multi_layer_test.cc
@@ -592,7 +592,7 @@ TEST_P(MultiLayerTest, MultiLayerTest2Embedded2TemporaSframe) {
   num_embedded_layers_ = 2;
   decode_base_only_ = false;
   drop_tl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
+  enable_explicit_ref_frame_map_ = true;
   enable_buffer_refresh_test_ = true;
   enable_s_frame_ = true;
   cfg_.enable_sframe = 1;

--- a/test/multi_layer_test.cc
+++ b/test/multi_layer_test.cc
@@ -486,17 +486,6 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded) {
   EXPECT_EQ(num_mismatch_, 0);
 }
 
-TEST_P(MultiLayerTest, MultiLayerTest3EmbeddedDecodeBaseOnlyImplicit) {
-  ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
-  num_temporal_layers_ = 1;
-  num_embedded_layers_ = 3;
-  decode_base_only_ = true;
-  drop_sl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
-  ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
-  EXPECT_EQ(num_mismatch_, 0);
-}
-
 TEST_P(MultiLayerTest, MultiLayerTest3EmbeddedDecodeBaseOnlyExplicit) {
   ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
   num_temporal_layers_ = 1;
@@ -609,7 +598,7 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded3TemporalDropTL2) {
   decode_base_only_ = false;
   drop_tl2_ = true;
   drop_sl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
+  enable_explicit_ref_frame_map_ = true;
   enable_buffer_refresh_test_ = false;
   ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
   EXPECT_EQ(num_mismatch_, 0);
@@ -622,7 +611,7 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded3TemporalDropSL2) {
   decode_base_only_ = false;
   drop_tl2_ = false;
   drop_sl2_ = true;
-  enable_explicit_ref_frame_map_ = false;
+  enable_explicit_ref_frame_map_ = true;
   enable_buffer_refresh_test_ = false;
   ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
   EXPECT_EQ(num_mismatch_, 0);


### PR DESCRIPTION
For the MultiLayerTest2Embedded2TemporaSframe test, which has dynamic layer dropping,
the flag enable_explicit_ref_frame_map_ should be set to true, to avoid DPB desync.

Failures were seen at the lower speed settings (e.g., speed 2), not at the speed 5 setting used in the test.