### PR TITLE
Fix setting in multi_layers tests

### DIFF
--- a/test/multi_layer_test.cc
+++ b/test/multi_layer_test.cc
@@ -464,17 +464,6 @@ TEST_P(MultiLayerTest, MultiLayerTest2Embedded) {
   EXPECT_EQ(num_mismatch_, 0);
 }
 
-TEST_P(MultiLayerTest, MultiLayerTest2EmbeddedDecodeBaseOnlyImplicit) {
-  ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
-  num_temporal_layers_ = 1;
-  num_embedded_layers_ = 2;
-  decode_base_only_ = true;
-  drop_tl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
-  ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
-  EXPECT_EQ(num_mismatch_, 0);
-}
-
 TEST_P(MultiLayerTest, MultiLayerTest2EmbeddedDecodeBaseOnlyExplicit) {
   ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
   num_temporal_layers_ = 1;
@@ -492,17 +481,6 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded) {
   num_embedded_layers_ = 3;
   decode_base_only_ = false;
   drop_tl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
-  ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
-  EXPECT_EQ(num_mismatch_, 0);
-}
-
-TEST_P(MultiLayerTest, MultiLayerTest3EmbeddedDecodeBaseOnlyImplicit) {
-  ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
-  num_temporal_layers_ = 1;
-  num_embedded_layers_ = 3;
-  decode_base_only_ = true;
-  drop_sl2_ = false;
   enable_explicit_ref_frame_map_ = false;
   ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
   EXPECT_EQ(num_mismatch_, 0);
@@ -620,7 +598,7 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded3TemporalDropTL2) {
   decode_base_only_ = false;
   drop_tl2_ = true;
   drop_sl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
+  enable_explicit_ref_frame_map_ = true;
   enable_buffer_refresh_test_ = false;
   ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
   EXPECT_EQ(num_mismatch_, 0);
@@ -633,7 +611,7 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded3TemporalDropSL2) {
   decode_base_only_ = false;
   drop_tl2_ = false;
   drop_sl2_ = true;
-  enable_explicit_ref_frame_map_ = false;
+  enable_explicit_ref_frame_map_ = true;
   enable_buffer_refresh_test_ = false;
   ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
   EXPECT_EQ(num_mismatch_, 0);


### PR DESCRIPTION
Update enable_explicit_ref_frame_map_ setting, and remove duplicate tests (since we should set enable_explicit_ref_frame_map_ = true for these tests).

Failures were seen at the lower speed settings (e.g., speed 2), not at the speed 5 setting used in the test.