### PR TITLE
Re-enable row_mt=1 combos in AVxEncoderThreadTestLarge

### DIFF
--- a/test/ethread_test.cc
+++ b/test/ethread_test.cc
@@ -420,11 +420,9 @@ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AVxFirstPassEncoderThreadTest);
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AVxEncoderThreadTest);
 
 // Test cpu_used 0, 1, 3 and 5.
-// TODO(urvang): Once https://github.com/AOMediaCodec/avm/issues/79 is fixed,
-// change last parameter back to (0, 1) to re-enable unit tests with row-mt = 1.
 AV2_INSTANTIATE_TEST_SUITE(AVxEncoderThreadTestLarge,
                            ::testing::Values(::libavm_test::kOnePassGood),
                            ::testing::Values(0, 1, 3, 5),
                            ::testing::Values(1, 6), ::testing::Values(1, 6),
-                           ::testing::Values(0));
+                           ::testing::Values(0, 1));
 }  // namespace


### PR DESCRIPTION
The `row_mt=1` rows of `AVxEncoderThreadTestLarge` were disabled with a TODO referencing issue #79, which has since been fixed and closed.

Verified on current `main` (7802259d5): with `::testing::Values(0, 1)` restored, all 16 `row_mt=1` combos (cpu-used {0, 1, 3, 5} x tile cols/rows {1, 6}) pass, including encode/decode MD5 and frame-size checks across 2, 4, and 64 threads (64-core Threadripper, gcc-15 Release build).

This restores nightly coverage of the encoder row-MT path's thread-count invariance, which currently has none; see also the verification notes posted on issue #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uqub6MtkVTYS2t5ZGcRU92