### PR TITLE
Hybrid search of multi way transform in rough search and winner mode search

### DIFF
--- a/av2/encoder/block.h
+++ b/av2/encoder/block.h
@@ -37,7 +37,8 @@ extern "C" {
 //! Number of intra winner modes kept
 #define MAX_WINNER_MODE_COUNT_INTRA 3
 //! Number of inter winner modes kept
-#define MAX_WINNER_MODE_COUNT_INTER 1
+#define MAX_WINNER_MODE_COUNT_INTER 3
+
 //! Number of txfm hash records kept for the partition block.
 #define RD_RECORD_BUFFER_LEN 8
 //! Number of txfm hash records kept for the txfm block.
@@ -772,6 +773,13 @@ typedef struct {
    * Flag to enable/disable DC block prediction.
    */
   unsigned int predict_dc_level;
+  /*! \brief Flag to enable/disable multi-way partition for transform.
+   *
+   * 0 means mode default.
+   * 1 means mode eval
+   * 2 means mode winner
+   */
+  int eval_mode_type;
 } TxfmSearchParams;
 
 /*!\cond */

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -6851,7 +6851,8 @@ static AVM_INLINE MB_MODE_INFO *get_winner_mode_stats(
     MACROBLOCK *x, MB_MODE_INFO *best_mbmode, RD_STATS *best_rd_cost,
     int best_rate_y, int best_rate_uv, RD_STATS **winner_rd_cost,
     int *winner_rate_y, int *winner_rate_uv, PREDICTION_MODE *winner_mode,
-    MULTI_WINNER_MODE_TYPE multi_winner_mode_type, int mode_idx) {
+    MULTI_WINNER_MODE_TYPE multi_winner_mode_type, int mode_idx,
+    const AV2_COMMON *const cm, BLOCK_SIZE bsize) {
   MB_MODE_INFO *winner_mbmi;
   if (multi_winner_mode_type) {
     assert(mode_idx >= 0 && mode_idx < x->winner_mode_count);
@@ -6862,12 +6863,30 @@ static AVM_INLINE MB_MODE_INFO *get_winner_mode_stats(
     *winner_rate_y = winner_mode_stat->rate_y;
     *winner_rate_uv = winner_mode_stat->rate_uv;
     *winner_mode = winner_mode_stat->mode;
+    MACROBLOCKD *xd = &x->e_mbd;
+    if (is_warp_mode(winner_mbmi->motion_mode)) {
+      if (!winner_mbmi->wm_params[0].invalid)
+        assign_warpmv(cm, xd->submi, bsize, &winner_mbmi->wm_params[0],
+                      xd->mi_row, xd->mi_col, 0);
+      if (!winner_mbmi->wm_params[1].invalid)
+        assign_warpmv(cm, xd->submi, bsize, &winner_mbmi->wm_params[1],
+                      xd->mi_row, xd->mi_col, 1);
+    }
   } else {
     winner_mbmi = best_mbmode;
     *winner_rd_cost = best_rd_cost;
     *winner_rate_y = best_rate_y;
     *winner_rate_uv = best_rate_uv;
     *winner_mode = best_mbmode->mode;
+    MACROBLOCKD *xd = &x->e_mbd;
+    if (is_warp_mode(winner_mbmi->motion_mode)) {
+      if (!winner_mbmi->wm_params[0].invalid)
+        assign_warpmv(cm, xd->submi, bsize, &winner_mbmi->wm_params[0],
+                      xd->mi_row, xd->mi_col, 0);
+      if (!winner_mbmi->wm_params[1].invalid)
+        assign_warpmv(cm, xd->submi, bsize, &winner_mbmi->wm_params[1],
+                      xd->mi_row, xd->mi_col, 1);
+    }
   }
   return winner_mbmi;
 }
@@ -6910,7 +6929,7 @@ static AVM_INLINE void refine_winner_mode_tx(
     MB_MODE_INFO *winner_mbmi = get_winner_mode_stats(
         x, best_mbmode, rd_cost, best_rate_y, best_rate_uv, &winner_rd_stats,
         &winner_rate_y, &winner_rate_uv, &winner_mode,
-        cpi->sf.winner_mode_sf.multi_winner_mode_type, mode_idx);
+        cpi->sf.winner_mode_sf.multi_winner_mode_type, mode_idx, cm, bsize);
 
     if (xd->lossless[winner_mbmi->segment_id] == 0 &&
         winner_mode != MODE_INVALID &&
@@ -6922,6 +6941,11 @@ static AVM_INLINE void refine_winner_mode_tx(
       const int skip_ctx = av2_get_skip_txfm_context(xd);
 
       *mbmi = *winner_mbmi;
+      struct macroblockd_plane *p = xd->plane;
+      const BUFFER_SET orig_dst = {
+        { p[0].dst.buf, p[1].dst.buf, p[2].dst.buf },
+        { p[0].dst.stride, p[1].dst.stride, p[2].dst.stride },
+      };
 
       set_ref_ptrs(cm, xd, mbmi->ref_frame[0], mbmi->ref_frame[1]);
 
@@ -6937,15 +6961,14 @@ static AVM_INLINE void refine_winner_mode_tx(
       if (is_inter_mode(mbmi->mode)) {
         const int mi_row = xd->mi_row;
         const int mi_col = xd->mi_col;
-        av2_enc_build_inter_predictor(cm, xd, mi_row, mi_col, NULL, bsize, 0,
-                                      av2_num_planes(cm) - 1);
+        av2_enc_build_inter_predictor(cm, xd, mi_row, mi_col, &orig_dst, bsize,
+                                      0, av2_num_planes(cm) - 1);
 
         av2_subtract_plane(x, bsize, 0, cm->width, cm->height);
         if (txfm_params->tx_mode_search_type == TX_MODE_SELECT &&
             !xd->lossless[mbmi->segment_id]) {
           av2_pick_recursive_tx_size_type_yrd(cpi, x, &rd_stats_y, bsize, 1,
                                               INT64_MAX);
-          assert(rd_stats_y.rate != INT_MAX);
         } else {
           av2_pick_uniform_tx_size_type_yrd(cpi, x, &rd_stats_y, bsize,
                                             INT64_MAX);
@@ -8021,7 +8044,7 @@ static INLINE bool in_single_ref_cutoff(const int64_t *ref_frame_rd,
 }
 
 static AVM_INLINE void evaluate_motion_mode_for_winner_candidates(
-    const AV2_COMP *const cpi, MACROBLOCK *const x, RD_STATS *const rd_cost,
+    AV2_COMP *const cpi, MACROBLOCK *const x, RD_STATS *const rd_cost,
     HandleInterModeArgs *const args, TileDataEnc *const tile_data,
     PICK_MODE_CONTEXT *const ctx,
     struct buf_2d yv12_mb[SINGLE_REF_FRAMES][MAX_MB_PLANE],
@@ -9262,12 +9285,18 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
 
   int winner_mode_count =
       cpi->sf.winner_mode_sf.multi_winner_mode_type ? x->winner_mode_count : 1;
-  // In effect only when fast tx search speed features are enabled.
-  refine_winner_mode_tx(cpi, x, rd_cost, bsize, ctx, &search_state.best_mbmode,
-                        yv12_mb, search_state.best_rate_y,
-                        search_state.best_rate_uv, &search_state.best_skip2,
-                        winner_mode_count);
 
+  if (!(winner_mode_count == 1 && search_state.best_mode_skippable)) {
+    // In effect only when fast tx search speed features are enabled.
+    refine_winner_mode_tx(cpi, x, rd_cost, bsize, ctx,
+                          &search_state.best_mbmode, yv12_mb,
+                          search_state.best_rate_y, search_state.best_rate_uv,
+                          &search_state.best_skip2, winner_mode_count);
+  }
+
+  if (search_state.best_rd != rd_cost->rdcost) {
+    search_state.best_rd = rd_cost->rdcost;
+  }
   // Initialize default mode evaluation params
   set_mode_eval_params(cpi, x, DEFAULT_EVAL);
 

--- a/av2/encoder/rdopt_utils.h
+++ b/av2/encoder/rdopt_utils.h
@@ -207,6 +207,9 @@ static INLINE int is_winner_mode_processing_enabled(
       cpi->optimize_seg_arr[mbmi->segment_id] != FINAL_PASS_TRELLIS_OPT)
     return 1;
   if (sf->winner_mode_sf.enable_winner_mode_for_tx_size_srch) return 1;
+  if (sf->winner_mode_sf.disable_multiway_tx_part_in_rough_mode &&
+      mbmi->region_type == MIXED_INTER_INTRA_REGION)
+    return 1;
 
   return 0;
 }
@@ -301,7 +304,7 @@ static INLINE void set_mode_eval_params(const struct AV2_COMP *cpi,
           winner_mode_params->coeff_opt_dist_threshold, 0, 0);
       txfm_params->coeff_opt_satd_threshold = get_rd_opt_coeff_thresh(
           winner_mode_params->coeff_opt_satd_threshold, 0, 0);
-
+      txfm_params->eval_mode_type = DEFAULT_EVAL;
       // Set default transform size search method
       set_tx_size_search_method(cm, winner_mode_params, txfm_params, 0, 0, x,
                                 sf->tx_sf.use_largest_tx_size_for_small_bsize);
@@ -330,7 +333,7 @@ static INLINE void set_mode_eval_params(const struct AV2_COMP *cpi,
       txfm_params->coeff_opt_satd_threshold = get_rd_opt_coeff_thresh(
           winner_mode_params->coeff_opt_satd_threshold,
           sf->winner_mode_sf.enable_winner_mode_for_coeff_opt, 0);
-
+      txfm_params->eval_mode_type = MODE_EVAL;
       // Set the transform size search method for mode evaluation
       set_tx_size_search_method(
           cm, winner_mode_params, txfm_params,
@@ -348,7 +351,7 @@ static INLINE void set_mode_eval_params(const struct AV2_COMP *cpi,
           winner_mode_params->skip_txfm_level[WINNER_MODE_EVAL];
       txfm_params->predict_dc_level =
           winner_mode_params->predict_dc_level[WINNER_MODE_EVAL];
-
+      txfm_params->eval_mode_type = WINNER_MODE_EVAL;
       // Set transform domain distortion type for winner mode evaluation
       set_tx_domain_dist_params(
           winner_mode_params, txfm_params,

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -349,6 +349,20 @@ static void set_good_speed_features_framesize_independent(
 
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 2 : 1;
 
+    sf->winner_mode_sf.disable_multiway_tx_part_in_rough_mode = 1;
+    if (!frame_is_intra_only(cm) &&
+        sf->winner_mode_sf.disable_multiway_tx_part_in_rough_mode) {
+      sf->winner_mode_sf.multi_winner_mode_type = MULTI_WINNER_MODE_DEFAULT;
+
+      sf->tx_sf.tx_type_search.winner_mode_tx_type_pruning = 0;
+      sf->winner_mode_sf.tx_size_search_level = 0;
+      sf->winner_mode_sf.enable_winner_mode_for_tx_size_srch = 0;
+
+      sf->tx_sf.tx_type_search.fast_inter_tx_type_search = 0;
+      sf->inter_sf.prune_warpmv_prob_thresh = 0;
+      sf->rd_sf.perform_coeff_opt = 0;
+    }
+
     // Skip the second-best full-pel candidate's subpel refinement in the
     // single-ref NEWMV search.
     sf->mv_sf.skip_second_best_subpel = 1;
@@ -829,6 +843,7 @@ static AVM_INLINE void init_winner_mode_sf(
   // Set this at the appropriate speed levels
   winner_mode_sf->tx_size_search_level = USE_FULL_RD;
   winner_mode_sf->enable_winner_mode_for_coeff_opt = 0;
+  winner_mode_sf->disable_multiway_tx_part_in_rough_mode = 0;
   winner_mode_sf->enable_winner_mode_for_tx_size_srch = 0;
   winner_mode_sf->enable_winner_mode_for_use_tx_domain_dist = 0;
   winner_mode_sf->multi_winner_mode_type = 0;
@@ -1224,8 +1239,10 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
   const int boosted = frame_is_boosted(cpi);
   const int is_720p_or_larger = AVMMIN(cm->width, cm->height) >= 720;
   const int is_1080p_or_larger = AVMMIN(cm->width, cm->height) >= 1080;
+  const int is_2160p_or_larger = AVMMIN(cm->width, cm->height) >= 2160;
 
   const int qindex_offset = MAXQ_OFFSET * (cm->seq_params.bit_depth - 8);
+  const int qindex_thresh3 = 195 + qindex_offset;
 
   if (cpi->oxcf.mode == GOOD && speed == 0) {
     const int qindex_thresh = 124 + qindex_offset;
@@ -1286,6 +1303,13 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
       sf->flexmv_sf.prune_mv_prec_using_best_mv_prec_so_far = boosted ? 0 : 1;
       sf->tx_sf.prune_inter_tx_part_rd_eval = true;
     }
+  }
+
+  if (is_2160p_or_larger && cm->quant_params.base_qindex >= qindex_thresh3 &&
+      speed >= 1) {
+    sf->winner_mode_sf.disable_multiway_tx_part_in_rough_mode = 0;
+    if (!frame_is_intra_only(cm))
+      sf->winner_mode_sf.multi_winner_mode_type = MULTI_WINNER_MODE_OFF;
   }
 
   set_erp_speed_features(cpi);

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -865,6 +865,9 @@ typedef struct WINNER_MODE_SPEED_FEATURES {
   // Flag used to control the winner mode processing for better R-D optimization
   // of quantized coeffs
   int enable_winner_mode_for_coeff_opt;
+  // Disable multiway 4, 5 way transform partition in rough mode
+  // and enable them in winner mode
+  int disable_multiway_tx_part_in_rough_mode;
 
   // Flag used to control the winner mode processing for transform size
   // search method

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -3074,6 +3074,22 @@ static INLINE bool prune_tx_part_eval_using_none_rd(
   return false;
 }
 
+static AVM_INLINE int skip_tx_partition_by_eval_type(
+    TX_PARTITION_TYPE type, int eval_mode_type, REGION_TYPE region_type,
+    int disable_multiway_tx_part_in_rough_mode) {
+  if (!disable_multiway_tx_part_in_rough_mode) return 0;
+
+  if (eval_mode_type == MODE_EVAL && region_type == MIXED_INTER_INTRA_REGION &&
+      type > TX_PARTITION_VERT)
+    return 1;
+
+  if (eval_mode_type == WINNER_MODE_EVAL &&
+      region_type == MIXED_INTER_INTRA_REGION && type <= TX_PARTITION_VERT)
+    return 1;
+
+  return 0;
+}
+
 // Search for the best tx partition type for a given luma block.
 static void select_tx_partition_type(
     const AV2_COMP *cpi, MACROBLOCK *x, int blk_row, int blk_col, int block,
@@ -3105,7 +3121,18 @@ static void select_tx_partition_type(
   TX_SIZE sub_txs[MAX_TX_PARTITIONS] = { 0 };
 
   int64_t best_rd = INT64_MAX;
-  TX_PARTITION_TYPE best_tx_partition = TX_PARTITION_INVALID;
+
+  const TxfmSearchParams *txfm_params = &x->txfm_search_params;
+  const int txb_size_index =
+      is_inter_block(mbmi, xd->tree_type)
+          ? av2_get_txb_size_index(plane_bsize, blk_row, blk_col)
+          : 0;
+  TX_PARTITION_TYPE best_tx_partition =
+      txfm_params->eval_mode_type == WINNER_MODE_EVAL &&
+              mbmi->region_type == MIXED_INTER_INTRA_REGION &&
+              cpi->sf.winner_mode_sf.disable_multiway_tx_part_in_rough_mode
+          ? mbmi->tx_partition_type[txb_size_index]
+          : TX_PARTITION_INVALID;
   uint8_t best_partition_entropy_ctxs[MAX_TX_PARTITIONS] = { 0 };
   TX_TYPE best_partition_tx_types[MAX_TX_PARTITIONS] = { 0 };
   uint8_t full_blk_skip[MAX_TX_PARTITIONS] = { 0 };
@@ -3115,6 +3142,12 @@ static void select_tx_partition_type(
         type > TX_PARTITION_VERT) {
       break;
     }
+
+    if (skip_tx_partition_by_eval_type(
+            type, txfm_params->eval_mode_type, mbmi->region_type,
+            cpi->sf.winner_mode_sf.disable_multiway_tx_part_in_rough_mode))
+      continue;
+
     // Skip any illegal partitions for this block size
     if (!use_tx_partition(type, plane_bsize, max_tx_size)) continue;
     if (cpi->sf.tx_sf.enable_tx_partition == false && type) continue;
@@ -3419,7 +3452,13 @@ static void choose_tx_size_type_from_rd(const AV2_COMP *const cpi,
   TX_SIZE best_tx_size = max_tx_size;
   int is_wide_angle_mapped[MAX_TX_PARTITIONS] = { 0 };
   int mapped_wide_angle[MAX_TX_PARTITIONS] = { 0 };
-  TX_PARTITION_TYPE best_tx_partition_type = TX_PARTITION_NONE;
+  assert(!is_inter_block(mbmi, xd->tree_type));
+  TX_PARTITION_TYPE best_tx_partition_type =
+      txfm_params->eval_mode_type == WINNER_MODE_EVAL &&
+              mbmi->region_type == MIXED_INTER_INTRA_REGION &&
+              cpi->sf.winner_mode_sf.disable_multiway_tx_part_in_rough_mode
+          ? mbmi->tx_partition_type[0]
+          : TX_PARTITION_NONE;
   int64_t best_rd = INT64_MAX;
   x->rd_model = FULL_TXFM_RD;
   int64_t cur_rd = INT64_MAX;
@@ -3429,6 +3468,12 @@ static void choose_tx_size_type_from_rd(const AV2_COMP *const cpi,
         type > TX_PARTITION_VERT) {
       break;
     }
+
+    if (skip_tx_partition_by_eval_type(
+            type, txfm_params->eval_mode_type, mbmi->region_type,
+            cpi->sf.winner_mode_sf.disable_multiway_tx_part_in_rough_mode))
+      continue;
+
     // Skip any illegal partitions for this block size
     if (!use_tx_partition(type, bs, max_tx_size)) continue;
     if (cpi->sf.tx_sf.enable_tx_partition == false && type) continue;
@@ -3992,7 +4037,10 @@ void av2_pick_recursive_tx_size_type_yrd(const AV2_COMP *cpi, MACROBLOCK *x,
     // We should always find at least one candidate unless ref_best_rd is less
     // than INT64_MAX (in which case, all the calls to select_tx_size_fix_type
     // might have failed to find something better)
-    assert(ref_best_rd != INT64_MAX);
+    assert(IMPLIES(txfm_params->eval_mode_type != WINNER_MODE_EVAL,
+                   ref_best_rd != INT64_MAX));
+
+    // In winner ref_best_rd is INT64_MAX to avoid any early termination by cost
     av2_invalid_rd_stats(rd_stats);
     return;
   }


### PR DESCRIPTION
Enable winner transform search

Add small fix for winner transform

Disable 4 way and 5 way transform in rough search and enable in winner

Set winner transform candidates to three

Disable existing winner transform speed features.

Tests - cpu-used =1
Anchor: 6e71b0c85924e61d9403b6222921cd4bb8cf870e
Results (RA): 

A1 - 17 frames
A2 - 33 frames

<pre>
+---------+-------+--------+-------+-------+----------+----------+
| Summary |   Y   |   U    |   V   |  YUV  | Enc-time | Dec-time |
+---------+-------+--------+-------+-------+----------+----------+
| A1      | 0.13% | 0.01%  | 0.20% | 0.13% | 93.6%    | 100%   |
| A2      | 0.17% | -0.15% | 0.06% | 0.15% | 92.3%    | 100%   |
+---------+-------+--------+-------+-------+----------+----------+
</pre>



