### PR TITLE
Skip temporary prediction for opfl modes.

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -4887,10 +4887,15 @@ static void evaluate_inter_predictor(AV2_COMP *const cpi,
   }
 
   int compmode_interinter_cost = 0;
-
+  int is_opfl_mode =
+      (cpi->sf.inter_sf.skip_temporary_pred_for_opfl &&
+       mbmi->mode >= NEAR_NEARMV_OPTFLOW && mbmi->mode < COMP_INTER_MODE_END)
+          ? 1
+          : 0;
   // Handle a compound predictor, continue if it is determined
   // this cannot be the best compound mode
-  if (is_comp_pred && !is_joint_amvd_coding_mode(mbmi->mode, mbmi->use_amvd) &&
+  if (!is_opfl_mode && is_comp_pred &&
+      !is_joint_amvd_coding_mode(mbmi->mode, mbmi->use_amvd) &&
       (!mbmi->refinemv_flag || !switchable_refinemv_flag(cm, mbmi))) {
     const int not_best_mode = process_compound_inter_mode(
         cpi, x, env->args, *search_state->ref_best_rd, tmp_cur_mv, bsize,
@@ -4912,9 +4917,10 @@ static void evaluate_inter_predictor(AV2_COMP *const cpi,
   int64_t ret_val;
 
   // Determine the interpolation filter for this mode
-  ret_val = av2_interpolation_filter_search(
-      x, cpi, tile_data, bsize, env->tmp_dst, env->orig_dst, &rd, &rs,
-      &skip_build_pred, env->args, *search_state->ref_best_rd);
+  if (!is_opfl_mode)
+    ret_val = av2_interpolation_filter_search(
+        x, cpi, tile_data, bsize, env->tmp_dst, env->orig_dst, &rd, &rs,
+        &skip_build_pred, env->args, *search_state->ref_best_rd);
 
   assert(check_mv_precision(cm, mbmi, x));
 
@@ -4922,7 +4928,7 @@ static void evaluate_inter_predictor(AV2_COMP *const cpi,
     env->args->modelled_rd[eval_mode][ref_mv_idx_type][refs[0]] = rd;
   }
 
-  if (mbmi->mode != WARPMV) {
+  if (mbmi->mode != WARPMV && !is_opfl_mode) {
     if (ret_val != 0) {
       restore_dst_buf(xd, *env->orig_dst, num_planes);
       return;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -359,6 +359,7 @@ static void set_good_speed_features_framesize_independent(
     // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
     // nearest searched result beyond the cap.
     sf->mv_sf.newmv_drl_search_limit = 2;
+    sf->inter_sf.skip_temporary_pred_for_opfl = 1;
   }
 
   if (speed >= 2) {
@@ -703,6 +704,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->comp_inter_joint_search_thresh = BLOCK_4X4;
   inter_sf->adaptive_rd_thresh = 0;
   inter_sf->model_based_post_interp_filter_breakout = 0;
+  inter_sf->skip_temporary_pred_for_opfl = 0;
   inter_sf->reduce_inter_modes = 0;
   inter_sf->alt_ref_search_fp = 0;
   inter_sf->selective_ref_frame = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -708,6 +708,9 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // 1: use model based rd breakout
   int model_based_post_interp_filter_breakout;
 
+  // skip temporary predictions for opfl modes
+  int skip_temporary_pred_for_opfl;
+
   // Reuse compound type rd decision when exact match is found
   // 0: No reuse
   // 1: Reuse the compound type rd data


### PR DESCRIPTION
Skip process_compound_inter() function for opfl modes.

Tests - cpu-used =1
Anchor: https://github.com/AOMediaCodec/avm/commit/6e71b0c85924e61d9403b6222921cd4bb8cf870e
Results (RA):

A1 - 17 frames
A2 - 33 frames

<img width="1066" height="101" alt="MR7" src="https://github.com/user-attachments/assets/7e9e4bce-1065-4d28-84bc-a8df8f3479a7" />
