### PR TITLE
Add 6 param warp search in winner mode by tid

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -336,6 +336,12 @@ jobs:
       "
 
     steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 50
+
+      - uses: ./.github/actions/common-setup
+
       - name: Configure AVM encoder
         run: |
           if [ -z "${AVMENC_OUTPUT}" ]; then
@@ -484,7 +490,7 @@ jobs:
           ALLOW_FAIL=0
           FAILED=0
 
-          if [ -n "$(git --no-pager log --grep STATS_CHANGED --format=format:"%H" "${{ github.event.pull_request.base.sha }}..${{ github.sha }}")" ]; then
+          if [ -n "$(git --no-pager log --grep STATS_CHANGED --format=format:"%H" "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}")" ]; then
             ALLOW_FAIL=1
           fi
 
@@ -507,7 +513,7 @@ jobs:
               echo "         commits contain the STATS_CHANGED keyword, so mismatch"
               echo "         of encode outputs is allowed."
               echo "Commits containing STATS_CHANGED added in this MR:"
-              git --no-pager log --grep STATS_CHANGED --format=format:"%h: %s; \"%aN\" <%aE>" "${{ github.event.pull_request.base.sha }}..${{ github.sha }}"
+              git --no-pager log --grep STATS_CHANGED --format=format:"%h: %s; \"%aN\" <%aE>" "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
               echo ""
               exit 0
             fi

--- a/av2/av2_dx_iface.c
+++ b/av2/av2_dx_iface.c
@@ -1107,7 +1107,11 @@ static avm_codec_err_t decoder_decode(avm_codec_alg_priv_t *ctx,
 
     res = decode_one(ctx, &data_start, frame_unit_size, user_priv);
 
-    if (res != AVM_CODEC_OK) return res;
+    if (res != AVM_CODEC_OK) {
+      free(frame_worker_data->pbi->obu_list);
+      frame_worker_data->pbi->num_obus_with_frame_unit = 0;
+      return res;
+    }
 
     set_last_frame_unit(frame_worker_data->pbi);
     free(frame_worker_data->pbi->obu_list);

--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -5396,15 +5396,6 @@ static AVM_INLINE void av2_set_frame_sb_size(AV2_COMMON *cm,
   cm->mib_size_log2 = mi_size_wide_log2[sb_size];
 }
 
-static INLINE void set_sb_size(AV2_COMMON *cm, BLOCK_SIZE sb_size) {
-  SequenceHeader *const seq_params = &cm->seq_params;
-  seq_params->sb_size = sb_size;
-  seq_params->mib_size = mi_size_wide[sb_size];
-  seq_params->mib_size_log2 = mi_size_wide_log2[sb_size];
-
-  av2_set_frame_sb_size(cm, sb_size);
-}
-
 // Sets the frame's lr specific fields in feature params depending on
 // which tools are enabled for the frame for the given plane.
 static INLINE void av2_set_lr_tools(uint8_t lr_tools_disable_mask, int plane,

--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -3209,14 +3209,6 @@ static INLINE int frame_is_intra_only(const AV2_COMMON *const cm) {
          cm->current_frame.frame_type == INTRA_ONLY_FRAME;
 }
 
-// Check whether this is chroma component of an intra region in inter frame
-static INLINE int is_inter_sdp_chroma(const AV2_COMMON *const cm,
-                                      REGION_TYPE cur_region_type,
-                                      TREE_TYPE cur_tree_type) {
-  return !frame_is_intra_only(cm) && cur_region_type == INTRA_REGION &&
-         cur_tree_type == CHROMA_PART;
-}
-
 static INLINE int frame_is_sframe(const AV2_COMMON *cm) {
   return cm->current_frame.frame_type == S_FRAME;
 }
@@ -5181,26 +5173,6 @@ static INLINE TX_SIZE get_tx_partition_one_size(TX_PARTITION_TYPE partition,
 }
 
 /*
-Gets the type to signal for the 4 way split tree in the tx partition
-type signaling.
-*/
-static INLINE int get_split4_partition(TX_PARTITION_TYPE partition) {
-  switch (partition) {
-    case TX_PARTITION_NONE:
-    case TX_PARTITION_SPLIT:
-    case TX_PARTITION_VERT:
-    case TX_PARTITION_HORZ:
-    case TX_PARTITION_VERT4:
-    case TX_PARTITION_HORZ4:
-    case TX_PARTITION_HORZ5:
-    case TX_PARTITION_VERT5: return partition;
-    default: assert(0);
-  }
-  assert(0);
-  return 0;
-}
-
-/*
 Gets tx type group table if TX partition supports both vertical and horizontal
 partitions.
 */
@@ -5308,80 +5280,6 @@ static INLINE int use_tx_partition(TX_PARTITION_TYPE partition,
   }
   assert(0);
   return 0;
-}
-
-// Compute the next partition in the direction of the sb_type stored in the mi
-// array, starting with bsize.
-static INLINE PARTITION_TYPE get_partition(const AV2_COMMON *const cm,
-                                           const int plane_type, int mi_row,
-                                           int mi_col, BLOCK_SIZE bsize) {
-  const CommonModeInfoParams *const mi_params = &cm->mi_params;
-  if (mi_row >= mi_params->mi_rows || mi_col >= mi_params->mi_cols)
-    return PARTITION_INVALID;
-
-  const int offset = mi_row * mi_params->mi_stride + mi_col;
-  MB_MODE_INFO **mi = mi_params->mi_grid_base + offset;
-  const BLOCK_SIZE subsize = mi[0]->sb_type[plane_type];
-
-  assert(bsize < BLOCK_SIZES_ALL);
-
-  if (subsize == bsize) return PARTITION_NONE;
-
-  const int bhigh = mi_size_high[bsize];
-  const int bwide = mi_size_wide[bsize];
-  const int sshigh = mi_size_high[subsize];
-  const int sswide = mi_size_wide[subsize];
-
-  if (bsize > BLOCK_8X8 && mi_row + bwide / 2 < mi_params->mi_rows &&
-      mi_col + bhigh / 2 < mi_params->mi_cols) {
-    // In this case, the block might be using an extended partition
-    // type.
-    const MB_MODE_INFO *const mbmi_right = mi[bwide / 2];
-    const MB_MODE_INFO *const mbmi_below = mi[bhigh / 2 * mi_params->mi_stride];
-
-    if (sswide == bwide) {
-      // Smaller height but same width. Is PARTITION_HORZ_4, PARTITION_HORZ or
-      // PARTITION_HORZ_B. To distinguish the latter two, check if the lower
-      // half was split.
-      if (sshigh * 4 == bhigh) {
-        return PARTITION_HORZ_4A;
-      }
-      if (mbmi_below->sb_type[plane_type] == subsize) return PARTITION_HORZ;
-    } else if (sshigh == bhigh) {
-      // Smaller width but same height. Is PARTITION_VERT_4, PARTITION_VERT or
-      // PARTITION_VERT_B. To distinguish the latter two, check if the right
-      // half was split.
-      if (sswide * 4 == bwide) {
-        return PARTITION_VERT_4A;
-      }
-      if (mbmi_right->sb_type[plane_type] == subsize) return PARTITION_VERT;
-
-    } else {
-      // Smaller width and smaller height. Might be PARTITION_SPLIT or could be
-      // PARTITION_HORZ_A or PARTITION_VERT_A. If subsize isn't halved in both
-      // dimensions, we immediately know this is a split (which will recurse to
-      // get to subsize). Otherwise look down and to the right. With
-      // PARTITION_VERT_A, the right block will have height bhigh; with
-      // PARTITION_HORZ_A, the lower block with have width bwide. Otherwise
-      // it's PARTITION_SPLIT.
-      if (sswide * 2 != bwide || sshigh * 2 != bhigh) {
-        if (mi_size_wide[mbmi_below->sb_type[plane_type]] < bwide &&
-            mi_size_high[mbmi_right->sb_type[plane_type]] < bhigh)
-          return PARTITION_SPLIT;
-      }
-      return PARTITION_SPLIT;
-    }
-  }
-  const int vert_split = sswide < bwide;
-  const int horz_split = sshigh < bhigh;
-  const int split_idx = (vert_split << 1) | horz_split;
-  assert(split_idx != 0);
-
-  static const PARTITION_TYPE base_partitions[4] = {
-    PARTITION_INVALID, PARTITION_HORZ, PARTITION_VERT, PARTITION_SPLIT
-  };
-
-  return base_partitions[split_idx];
 }
 
 static AVM_INLINE void av2_set_frame_sb_size(AV2_COMMON *cm,

--- a/av2/common/common_data.h
+++ b/av2/common/common_data.h
@@ -802,22 +802,6 @@ static const int av2_size_class[TX_SIZES_ALL] = { 0, 1, 2, 3, 3, 0, 0, 1, 1,
                                                   3, 3, 3, 3, 1, 1, 3, 3, 3,
                                                   3, 3, 3, 3, 3, 3, 3 };
 
-static AVM_INLINE bool is_bsize_geq(BLOCK_SIZE bsize1, BLOCK_SIZE bsize2) {
-  if (bsize1 == BLOCK_INVALID || bsize2 == BLOCK_INVALID) {
-    return false;
-  }
-  return block_size_wide[bsize1] >= block_size_wide[bsize2] &&
-         block_size_high[bsize1] >= block_size_high[bsize2];
-}
-
-static AVM_INLINE bool is_bsize_gt(BLOCK_SIZE bsize1, BLOCK_SIZE bsize2) {
-  if (bsize1 == BLOCK_INVALID || bsize2 == BLOCK_INVALID) {
-    return false;
-  }
-  return block_size_wide[bsize1] > block_size_wide[bsize2] &&
-         block_size_high[bsize1] > block_size_high[bsize2];
-}
-
 static const int fwd_tx_shift[TX_SIZES_ALL][2] = {
   { 1, 10 },  // TX_4X4,    // 4x4 transform
   { 2, 10 },  // TX_8X8,    // 8x8 transform

--- a/av2/encoder/block.h
+++ b/av2/encoder/block.h
@@ -1709,6 +1709,22 @@ static INLINE int is_rect_tx_allowed(const MACROBLOCKD *xd,
          !xd->lossless[mbmi->segment_id];
 }
 
+static AVM_INLINE bool is_bsize_geq(BLOCK_SIZE bsize1, BLOCK_SIZE bsize2) {
+  if (bsize1 == BLOCK_INVALID || bsize2 == BLOCK_INVALID) {
+    return false;
+  }
+  return block_size_wide[bsize1] >= block_size_wide[bsize2] &&
+         block_size_high[bsize1] >= block_size_high[bsize2];
+}
+
+static AVM_INLINE bool is_bsize_gt(BLOCK_SIZE bsize1, BLOCK_SIZE bsize2) {
+  if (bsize1 == BLOCK_INVALID || bsize2 == BLOCK_INVALID) {
+    return false;
+  }
+  return block_size_wide[bsize1] > block_size_wide[bsize2] &&
+         block_size_high[bsize1] > block_size_high[bsize2];
+}
+
 static INLINE void set_blk_skip(uint8_t txb_skip[], int blk_idx, int skip) {
   if (skip)
     txb_skip[blk_idx] |= 1UL;

--- a/av2/encoder/compound_type.c
+++ b/av2/encoder/compound_type.c
@@ -121,8 +121,7 @@ static INLINE bool enable_wedge_interinter_search(MACROBLOCK *const x,
 static INLINE bool enable_wedge_interintra_search(MACROBLOCK *const x,
                                                   const AV2_COMP *const cpi) {
   return enable_wedge_search(x, cpi) &&
-         cpi->oxcf.comp_type_cfg.enable_interintra_wedge &&
-         !cpi->sf.inter_sf.disable_wedge_interintra_search;
+         cpi->oxcf.comp_type_cfg.enable_interintra_wedge;
 }
 
 static int8_t estimate_wedge_sign(const AV2_COMP *cpi, const MACROBLOCK *x,
@@ -582,8 +581,7 @@ static int handle_smooth_inter_intra_mode(
     }
     args->inter_intra_mode[mbmi->ref_frame[0]] = *best_interintra_mode;
   }
-  assert(IMPLIES(!cpi->oxcf.comp_type_cfg.enable_smooth_interintra ||
-                     cpi->sf.inter_sf.disable_smooth_interintra,
+  assert(IMPLIES(!cpi->oxcf.comp_type_cfg.enable_smooth_interintra,
                  *best_interintra_mode != II_SMOOTH_PRED));
   // Recompute prediction if required
   bool interintra_mode_reuse = cpi->sf.inter_sf.reuse_inter_intra_mode ||
@@ -634,8 +632,7 @@ static int handle_wedge_inter_intra_mode(
   const AV2_COMMON *const cm = &cpi->common;
   const int bw = block_size_wide[bsize];
   const int try_smooth_interintra =
-      cpi->oxcf.comp_type_cfg.enable_smooth_interintra &&
-      !cpi->sf.inter_sf.disable_smooth_interintra;
+      cpi->oxcf.comp_type_cfg.enable_smooth_interintra;
 
   mbmi->use_wedge_interintra = 1;
   assert(IMPLIES(!mbmi->warp_inter_intra, mbmi->motion_mode == INTERINTRA));
@@ -757,8 +754,7 @@ int av2_handle_inter_intra_mode(const AV2_COMP *const cpi, MACROBLOCK *const x,
   const MOTION_MODE org_motion_mode = mbmi->motion_mode;
   const MOTION_MODE org_warp_inter_intra = mbmi->warp_inter_intra;
   const int try_smooth_interintra =
-      cpi->oxcf.comp_type_cfg.enable_smooth_interintra &&
-      !cpi->sf.inter_sf.disable_smooth_interintra;
+      cpi->oxcf.comp_type_cfg.enable_smooth_interintra;
 
   const int is_wedge_used = av2_is_wedge_used(bsize);
   const int try_wedge_interintra =

--- a/av2/encoder/encodemb.c
+++ b/av2/encoder/encodemb.c
@@ -1767,11 +1767,7 @@ void av2_encode_block_intra_joint_uv(int block, int blk_row, int blk_col,
                       &quant_param);
     av2_xform_quant(cm, x, plane, block, blk_row, blk_col, plane_bsize,
                     &txfm_param, &quant_param);
-    const uint8_t fsc_mode =
-        ((cm->seq_params.enable_fsc &&
-          xd->mi[0]->fsc_mode[xd->tree_type == CHROMA_PART] &&
-          plane == PLANE_TYPE_Y) ||
-         use_inter_fsc(cm, plane, tx_type, 0 /*is_inter*/));
+
     if (quant_param.use_optimize_b && do_trellis) {
       const ENTROPY_CONTEXT *a =
           &args->ta[blk_col + (plane - AVM_PLANE_U) * MAX_MIB_SIZE];
@@ -1781,12 +1777,8 @@ void av2_encode_block_intra_joint_uv(int block, int blk_row, int blk_col,
       get_txb_ctx(plane_bsize, tx_size, plane, a, l, &txb_ctx,
                   xd->mi[0]->fsc_mode[xd->tree_type == CHROMA_PART] &&
                       cm->seq_params.enable_fsc);
-      if (fsc_mode)
-        av2_optimize_fsc(args->cpi, x, plane, block, tx_size, tx_type, &txb_ctx,
-                         &dummy_rate_cost);
-      else
-        av2_optimize_b(args->cpi, x, plane, block, tx_size, tx_type, cctx_type,
-                       &txb_ctx, &dummy_rate_cost);
+      av2_optimize_b(args->cpi, x, plane, block, tx_size, tx_type, cctx_type,
+                     &txb_ctx, &dummy_rate_cost);
     }
     if (do_dropout) {
       av2_dropout_qcoeff(x, plane, block, tx_size, tx_type,
@@ -1810,12 +1802,8 @@ void av2_encode_block_intra_joint_uv(int block, int blk_row, int blk_col,
         get_txb_ctx(plane_bsize, tx_size, plane, a, l, &txb_ctx,
                     xd->mi[0]->fsc_mode[xd->tree_type == CHROMA_PART] &&
                         cm->seq_params.enable_fsc);
-        if (fsc_mode)
-          av2_optimize_fsc(args->cpi, x, plane, block, tx_size, tx_type,
-                           &txb_ctx, &dummy_rate_cost);
-        else
-          av2_optimize_b(args->cpi, x, plane, block, tx_size, tx_type,
-                         cctx_type, &txb_ctx, &dummy_rate_cost);
+        av2_optimize_b(args->cpi, x, plane, block, tx_size, tx_type, cctx_type,
+                       &txb_ctx, &dummy_rate_cost);
       }
       if (do_dropout) {
         av2_dropout_qcoeff(x, plane, block, tx_size, tx_type,

--- a/av2/encoder/encodemb.c
+++ b/av2/encoder/encodemb.c
@@ -1712,6 +1712,8 @@ void av2_encode_block_intra_joint_uv(int block, int blk_row, int blk_col,
     if (plane == AVM_PLANE_V && (*eob_c1 == 0 || *eob_c1 == 1) &&
         cctx_type != CCTX_NONE) {
       cctx_type = CCTX_NONE;
+      update_cctx_array(xd, blk_row, blk_col, 0, 0,
+                        args->dry_run ? TX_4X4 : tx_size, CCTX_NONE);
       // If the encoding stage uses a different cctx_type from the one
       // used in the rd stage, re-do the u plane with the updated cctx_type.
       av2_setup_xform(cm, x, AVM_PLANE_U, tx_size, tx_type, cctx_type,

--- a/av2/encoder/encodemb.c
+++ b/av2/encoder/encodemb.c
@@ -1708,67 +1708,36 @@ void av2_encode_block_intra_joint_uv(int block, int blk_row, int blk_col,
   av2_setup_quant(tx_size, use_trellis, quant_idx,
                   cpi->oxcf.q_cfg.quant_b_adapt, &quant_param);
 
-  // Settings for optimization type. NOTE: To set optimization type for all
-  // intra frames, both `KEY_BLOCK_OPT_TYPE` and `INTRA_BLOCK_OPT_TYPE` should
-  // be set.
-  // TODO(yjshen): These settings are hard-coded and look okay for now. They
-  // should be made configurable later.
-  // Blocks of key frames ONLY.
-  OPT_TYPE KEY_BLOCK_OPT_TYPE = TRELLIS_DROPOUT_OPT;
-  // Blocks of intra frames (key frames EXCLUSIVE).
-  OPT_TYPE INTRA_BLOCK_OPT_TYPE = TRELLIS_DROPOUT_OPT;
-
-  int use_tcq = cm->features.tcq_mode != 0;
-  if (use_tcq) {
-    // Dropout setting should be disabled when Trellis Coded Quant is
-    // enabled.
-    KEY_BLOCK_OPT_TYPE = TRELLIS_OPT;
-    // Blocks of intra frames (key frames EXCLUSIVE).
-    INTRA_BLOCK_OPT_TYPE = TRELLIS_OPT;
-  }
-
-  // Whether trellis or dropout optimization is required for key frames and
-  // intra frames.
-  const bool do_trellis = (frame_is_intra_only(cm) &&
-                           (KEY_BLOCK_OPT_TYPE == TRELLIS_OPT ||
-                            KEY_BLOCK_OPT_TYPE == TRELLIS_DROPOUT_OPT)) ||
-                          (!frame_is_intra_only(cm) &&
-                           (INTRA_BLOCK_OPT_TYPE == TRELLIS_OPT ||
-                            INTRA_BLOCK_OPT_TYPE == TRELLIS_DROPOUT_OPT));
-  const bool do_dropout = (frame_is_intra_only(cm) &&
-                           (KEY_BLOCK_OPT_TYPE == DROPOUT_OPT ||
-                            KEY_BLOCK_OPT_TYPE == TRELLIS_DROPOUT_OPT)) ||
-                          (!frame_is_intra_only(cm) &&
-                           (INTRA_BLOCK_OPT_TYPE == DROPOUT_OPT ||
-                            INTRA_BLOCK_OPT_TYPE == TRELLIS_DROPOUT_OPT));
   for (int plane = AVM_PLANE_U; plane <= AVM_PLANE_V; plane++) {
-    if (plane == AVM_PLANE_V && !is_inter_block(xd->mi[0], xd->tree_type) &&
-        *eob_c1 == 1) {
-      update_cctx_array(xd, blk_row, blk_col, 0, 0,
-                        args->dry_run ? TX_4X4 : tx_size, CCTX_NONE);
-      cctx_type = av2_get_cctx_type(xd, blk_row, blk_col);
+    if (plane == AVM_PLANE_V && (*eob_c1 == 0 || *eob_c1 == 1) &&
+        cctx_type != CCTX_NONE) {
+      cctx_type = CCTX_NONE;
+      // If the encoding stage uses a different cctx_type from the one
+      // used in the rd stage, re-do the u plane with the updated cctx_type.
+      av2_setup_xform(cm, x, AVM_PLANE_U, tx_size, tx_type, cctx_type,
+                      &txfm_param);
+      av2_setup_qmatrix(&cm->quant_params, xd, AVM_PLANE_U, tx_size, tx_type,
+                        &quant_param);
+      av2_xform_quant(cm, x, AVM_PLANE_U, block, blk_row, blk_col, plane_bsize,
+                      &txfm_param, &quant_param);
+      if (quant_param.use_optimize_b) {
+        const ENTROPY_CONTEXT *a = &args->ta[blk_col];
+        const ENTROPY_CONTEXT *l = &args->tl[blk_row];
+        TXB_CTX txb_ctx;
+        get_txb_ctx(plane_bsize, tx_size, AVM_PLANE_U, a, l, &txb_ctx,
+                    xd->mi[0]->fsc_mode[xd->tree_type == CHROMA_PART] &&
+                        cm->seq_params.enable_fsc);
+        av2_optimize_b(args->cpi, x, AVM_PLANE_U, block, tx_size, tx_type,
+                       cctx_type, &txb_ctx, &dummy_rate_cost);
+      }
     }
-    // Since eob can be updated here, make sure cctx_type is always CCTX_NONE
-    // when eob of U is 0.
-    if (plane == AVM_PLANE_V && *eob_c1 == 0) {
-      // In dry run, cctx type will not be referenced by neighboring blocks,
-      // so there is no need to fill in the whole chroma region. In addition,
-      // ctx->cctx_type_map size in dry run may not be aligned with actual
-      // chroma coding region for some partition types.
-      update_cctx_array(xd, blk_row, blk_col, 0, 0,
-                        args->dry_run ? TX_4X4 : tx_size, CCTX_NONE);
-    }
-    if (plane == AVM_PLANE_V && *eob_c1 == 0 && cctx_type > CCTX_NONE) {
-      av2_quantize_skip(av2_get_max_eob(tx_size),
-                        p_c2->qcoeff + BLOCK_OFFSET(block), dqcoeff_c2, eob_c2);
-      break;
-    }
+
     av2_setup_qmatrix(&cm->quant_params, xd, plane, tx_size, tx_type,
                       &quant_param);
     av2_xform_quant(cm, x, plane, block, blk_row, blk_col, plane_bsize,
                     &txfm_param, &quant_param);
 
-    if (quant_param.use_optimize_b && do_trellis) {
+    if (quant_param.use_optimize_b) {
       const ENTROPY_CONTEXT *a =
           &args->ta[blk_col + (plane - AVM_PLANE_U) * MAX_MIB_SIZE];
       const ENTROPY_CONTEXT *l =
@@ -1779,36 +1748,6 @@ void av2_encode_block_intra_joint_uv(int block, int blk_row, int blk_col,
                       cm->seq_params.enable_fsc);
       av2_optimize_b(args->cpi, x, plane, block, tx_size, tx_type, cctx_type,
                      &txb_ctx, &dummy_rate_cost);
-    }
-    if (do_dropout) {
-      av2_dropout_qcoeff(x, plane, block, tx_size, tx_type,
-                         cm->quant_params.base_qindex);
-    }
-    if (plane == AVM_PLANE_V && !is_inter_block(xd->mi[0], xd->tree_type) &&
-        *eob_c1 == 1) {
-      update_cctx_array(xd, blk_row, blk_col, 0, 0,
-                        args->dry_run ? TX_4X4 : tx_size, CCTX_NONE);
-      cctx_type = av2_get_cctx_type(xd, blk_row, blk_col);
-      av2_setup_qmatrix(&cm->quant_params, xd, plane, tx_size, tx_type,
-                        &quant_param);
-      av2_xform_quant(cm, x, plane, block, blk_row, blk_col, plane_bsize,
-                      &txfm_param, &quant_param);
-      if (quant_param.use_optimize_b && do_trellis) {
-        const ENTROPY_CONTEXT *a =
-            &args->ta[blk_col + (plane - AVM_PLANE_U) * MAX_MIB_SIZE];
-        const ENTROPY_CONTEXT *l =
-            &args->tl[blk_row + (plane - AVM_PLANE_U) * MAX_MIB_SIZE];
-        TXB_CTX txb_ctx;
-        get_txb_ctx(plane_bsize, tx_size, plane, a, l, &txb_ctx,
-                    xd->mi[0]->fsc_mode[xd->tree_type == CHROMA_PART] &&
-                        cm->seq_params.enable_fsc);
-        av2_optimize_b(args->cpi, x, plane, block, tx_size, tx_type, cctx_type,
-                       &txb_ctx, &dummy_rate_cost);
-      }
-      if (do_dropout) {
-        av2_dropout_qcoeff(x, plane, block, tx_size, tx_type,
-                           cm->quant_params.base_qindex);
-      }
     }
   }
 

--- a/av2/encoder/encoder_utils.h
+++ b/av2/encoder/encoder_utils.h
@@ -69,6 +69,15 @@ static AVM_INLINE void set_mb_mi(CommonModeInfoParams *mi_params, int width,
          mi_size_high[mi_params->mi_alloc_bsize]);
 }
 
+static INLINE void set_sb_size(AV2_COMMON *cm, BLOCK_SIZE sb_size) {
+  SequenceHeader *const seq_params = &cm->seq_params;
+  seq_params->sb_size = sb_size;
+  seq_params->mib_size = mi_size_wide[sb_size];
+  seq_params->mib_size_log2 = mi_size_wide_log2[sb_size];
+
+  av2_set_frame_sb_size(cm, sb_size);
+}
+
 static AVM_INLINE void enc_free_mi(CommonModeInfoParams *mi_params) {
   avm_free(mi_params->mi_alloc);
   mi_params->mi_alloc = NULL;

--- a/av2/encoder/interp_search.h
+++ b/av2/encoder/interp_search.h
@@ -32,6 +32,18 @@ typedef struct {
   int64_t rd;
   unsigned int pred_sse;
 } INTERPOLATION_FILTER_STATS;
+
+// Holds the best fast (model-based, pre-tx) and full (post-tx) RD seen for a
+// given (mode, refs) tuple across all motion modes, ref_mv_idx, MV precisions,
+// jmvd, bawp and refinemv variants. Used as input to mode-pruning heuristics.
+typedef struct InterModeRdPair {
+  int64_t fast_rd;
+  int64_t full_rd;
+} InterModeRdPair;
+
+// Number of slots in the use_amvd dimension of the inter-mode RD tables.
+// mbmi->use_amvd is 0 or 1, so this dimension has size 2.
+#define NUM_USE_AMVD_OPTIONS 2
 /*!\endcond */
 
 /*!\brief Miscellaneous arguments for inter mode search.
@@ -88,6 +100,16 @@ typedef struct {
    * (number of inter modes) X (length of refmv list) X (number of ref frames)
    */
   int64_t (*simple_rd)[MAX_REF_MV_SEARCH][SINGLE_REF_FRAMES];
+
+  /*!
+   * Pointer to a 3D array storing the best fast/full RD per single-ref inter
+   * mode, use_amvd option, and reference frame. The aggregation is the
+   * minimum across all motion modes, ref_mv_idx, MV precisions, bawp,
+   * refinemv and jmvd tuples for a given (mode, use_amvd, ref). Indexed by
+   * [mode_idx][use_amvd][ref_frame_idx] where
+   * mode_idx = mode - SINGLE_INTER_MODE_START.
+   */
+  InterModeRdPair (*single_inter_rd)[NUM_USE_AMVD_OPTIONS][SINGLE_REF_FRAMES];
 
   /*!
    * An integer value 0 or 1 which indicates whether or not to skip the motion

--- a/av2/encoder/motion_search_facade.c
+++ b/av2/encoder/motion_search_facade.c
@@ -382,7 +382,8 @@ void av2_single_motion_search(const AV2_COMP *const cpi, MACROBLOCK *x,
     switch (mbmi->motion_mode) {
       case SIMPLE_TRANSLATION:
         if (cpi->sf.mv_sf.subpel_search_type) {
-          const int try_second = second_best_mv.as_int != INVALID_MV &&
+          const int try_second = !cpi->sf.mv_sf.skip_second_best_subpel &&
+                                 second_best_mv.as_int != INVALID_MV &&
                                  second_best_mv.as_int != best_mv->as_int;
           const int best_mv_var = mv_search_params->find_fractional_mv_step(
               xd, cm, &ms_params, subpel_start_mv, &best_mv->as_mv, &dis,

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2873,7 +2873,8 @@ static AVM_INLINE PARTITION_TYPE get_forced_partition_type(
 
 static AVM_INLINE void init_allowed_partitions(
     PartitionSearchState *part_search_state, const PartitionCfg *part_cfg,
-    const int bru_skip, const bool *partition_allowed) {
+    const SPEED_FEATURES *const sf, const int bru_skip,
+    const bool *partition_allowed) {
   const PartitionBlkParams *blk_params = &part_search_state->part_blk_params;
   const BLOCK_SIZE bsize = blk_params->bsize;
   if (bru_skip) {
@@ -2910,6 +2911,7 @@ static AVM_INLINE void init_allowed_partitions(
       is_bsize_geq(vert_subsize, min_partition_size);
 
   part_search_state->partition_3_allowed[HORZ] =
+      !sf->part_sf.disable_ext_partitions &&
       partition_allowed[PARTITION_HORZ_3] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_3),
                    blk_params->min_partition_size) &&
@@ -2917,6 +2919,7 @@ static AVM_INLINE void init_allowed_partitions(
                    blk_params->min_partition_size);
 
   part_search_state->partition_3_allowed[VERT] =
+      !sf->part_sf.disable_ext_partitions &&
       partition_allowed[PARTITION_VERT_3] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_3),
                    blk_params->min_partition_size) &&
@@ -2924,18 +2927,26 @@ static AVM_INLINE void init_allowed_partitions(
                    blk_params->min_partition_size);
 
   part_search_state->partition_4a_allowed[HORZ] =
+      !sf->part_sf.disable_ext_partitions &&
+      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_HORZ_4A] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_4A),
                    blk_params->min_partition_size);
   part_search_state->partition_4b_allowed[HORZ] =
+      !sf->part_sf.disable_ext_partitions &&
+      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_HORZ_4B] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_4B),
                    blk_params->min_partition_size);
   part_search_state->partition_4a_allowed[VERT] =
+      !sf->part_sf.disable_ext_partitions &&
+      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_VERT_4A] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_4A),
                    blk_params->min_partition_size);
   part_search_state->partition_4b_allowed[VERT] =
+      !sf->part_sf.disable_ext_partitions &&
+      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_VERT_4B] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_4B),
                    blk_params->min_partition_size);
@@ -3056,7 +3067,7 @@ static void init_partition_search_state_params(
       pc_tree->region_type, partition_allowed);
 
   init_allowed_partitions(
-      part_search_state, &cpi->oxcf.part_cfg,
+      part_search_state, &cpi->oxcf.part_cfg, &cpi->sf,
       is_bru_not_active_and_not_on_partial_border(cm, mi_col, mi_row, bsize),
       partition_allowed);
 
@@ -6058,7 +6069,7 @@ BEGIN_PARTITION_SEARCH:
         (pc_tree->parent ? pc_tree->parent->region_type : INTRA_REGION), mi_row,
         mi_col, ss_x, ss_y, bsize, &pc_tree->chroma_ref_info);
     init_allowed_partitions(
-        &part_search_state, &cpi->oxcf.part_cfg,
+        &part_search_state, &cpi->oxcf.part_cfg, &cpi->sf,
         is_bru_not_active_and_not_on_partial_border(cm, mi_col, mi_row, bsize),
         partition_allowed);
 #if CONFIG_ML_PART_SPLIT

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -34,6 +34,7 @@
 #include "av2/encoder/partition_strategy.h"
 #include "av2/encoder/reconinter_enc.h"
 #include "av2/encoder/tokenize.h"
+#include "av2/encoder/tx_search.h"
 #include "av2/common/reconinter.h"
 #include "av2/encoder/erp_ml.h"
 

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2781,7 +2781,13 @@ void av2_rd_use_partition(AV2_COMP *cpi, ThreadData *td, TileDataEnc *tile_data,
   // If last_part is better set the partitioning to that.
   const int plane_type = (xd->tree_type == CHROMA_PART);
   mib[0]->sb_type[plane_type] = bsize;
-  if (bsize >= BLOCK_8X8) pc_tree->partitioning = partition;
+  if (bsize >= BLOCK_8X8) {
+    if (last_part_rdc.rate < INT_MAX && last_part_rdc.dist < INT64_MAX) {
+      pc_tree->partitioning = partition;
+    } else {
+      pc_tree->partitioning = PARTITION_NONE;
+    }
+  }
 
   av2_restore_context(cm, x, &x_ctx, mi_row, mi_col, bsize, num_planes);
 
@@ -2790,7 +2796,8 @@ void av2_rd_use_partition(AV2_COMP *cpi, ThreadData *td, TileDataEnc *tile_data,
   if (bsize == cm->sb_size)
     assert(last_part_rdc.rate < INT_MAX && last_part_rdc.dist < INT64_MAX);
 
-  if (do_recon) {
+  if (do_recon && last_part_rdc.rate < INT_MAX &&
+      last_part_rdc.dist < INT64_MAX) {
     if (bsize == cm->sb_size) {
       // NOTE: To get estimate for rate due to the tokens, use:
       // int rate_coeffs = 0;

--- a/av2/encoder/partition_search.h
+++ b/av2/encoder/partition_search.h
@@ -55,4 +55,86 @@ void setup_block_rdmult(const AV2_COMP *const cpi, MACROBLOCK *const x,
                         int mi_row, int mi_col, BLOCK_SIZE bsize,
                         AQ_MODE aq_mode, MB_MODE_INFO *mbmi);
 
+// Check whether this is chroma component of an intra region in inter frame
+static INLINE int is_inter_sdp_chroma(const AV2_COMMON *const cm,
+                                      REGION_TYPE cur_region_type,
+                                      TREE_TYPE cur_tree_type) {
+  return !frame_is_intra_only(cm) && cur_region_type == INTRA_REGION &&
+         cur_tree_type == CHROMA_PART;
+}
+
+// Compute the next partition in the direction of the sb_type stored in the mi
+// array, starting with bsize.
+static INLINE PARTITION_TYPE get_partition(const AV2_COMMON *const cm,
+                                           const int plane_type, int mi_row,
+                                           int mi_col, BLOCK_SIZE bsize) {
+  const CommonModeInfoParams *const mi_params = &cm->mi_params;
+  if (mi_row >= mi_params->mi_rows || mi_col >= mi_params->mi_cols)
+    return PARTITION_INVALID;
+
+  const int offset = mi_row * mi_params->mi_stride + mi_col;
+  MB_MODE_INFO **mi = mi_params->mi_grid_base + offset;
+  const BLOCK_SIZE subsize = mi[0]->sb_type[plane_type];
+
+  assert(bsize < BLOCK_SIZES_ALL);
+
+  if (subsize == bsize) return PARTITION_NONE;
+
+  const int bhigh = mi_size_high[bsize];
+  const int bwide = mi_size_wide[bsize];
+  const int sshigh = mi_size_high[subsize];
+  const int sswide = mi_size_wide[subsize];
+
+  if (bsize > BLOCK_8X8 && mi_row + bwide / 2 < mi_params->mi_rows &&
+      mi_col + bhigh / 2 < mi_params->mi_cols) {
+    // In this case, the block might be using an extended partition
+    // type.
+    const MB_MODE_INFO *const mbmi_right = mi[bwide / 2];
+    const MB_MODE_INFO *const mbmi_below = mi[bhigh / 2 * mi_params->mi_stride];
+
+    if (sswide == bwide) {
+      // Smaller height but same width. Is PARTITION_HORZ_4, PARTITION_HORZ or
+      // PARTITION_HORZ_B. To distinguish the latter two, check if the lower
+      // half was split.
+      if (sshigh * 4 == bhigh) {
+        return PARTITION_HORZ_4A;
+      }
+      if (mbmi_below->sb_type[plane_type] == subsize) return PARTITION_HORZ;
+    } else if (sshigh == bhigh) {
+      // Smaller width but same height. Is PARTITION_VERT_4, PARTITION_VERT or
+      // PARTITION_VERT_B. To distinguish the latter two, check if the right
+      // half was split.
+      if (sswide * 4 == bwide) {
+        return PARTITION_VERT_4A;
+      }
+      if (mbmi_right->sb_type[plane_type] == subsize) return PARTITION_VERT;
+
+    } else {
+      // Smaller width and smaller height. Might be PARTITION_SPLIT or could be
+      // PARTITION_HORZ_A or PARTITION_VERT_A. If subsize isn't halved in both
+      // dimensions, we immediately know this is a split (which will recurse to
+      // get to subsize). Otherwise look down and to the right. With
+      // PARTITION_VERT_A, the right block will have height bhigh; with
+      // PARTITION_HORZ_A, the lower block with have width bwide. Otherwise
+      // it's PARTITION_SPLIT.
+      if (sswide * 2 != bwide || sshigh * 2 != bhigh) {
+        if (mi_size_wide[mbmi_below->sb_type[plane_type]] < bwide &&
+            mi_size_high[mbmi_right->sb_type[plane_type]] < bhigh)
+          return PARTITION_SPLIT;
+      }
+      return PARTITION_SPLIT;
+    }
+  }
+  const int vert_split = sswide < bwide;
+  const int horz_split = sshigh < bhigh;
+  const int split_idx = (vert_split << 1) | horz_split;
+  assert(split_idx != 0);
+
+  static const PARTITION_TYPE base_partitions[4] = {
+    PARTITION_INVALID, PARTITION_HORZ, PARTITION_VERT, PARTITION_SPLIT
+  };
+
+  return base_partitions[split_idx];
+}
+
 #endif  // AVM_AV2_ENCODER_PARTITION_SEARCH_H_

--- a/av2/encoder/rd.h
+++ b/av2/encoder/rd.h
@@ -92,9 +92,6 @@ typedef struct RD_OPT {
 } RD_OPT;
 
 static INLINE void av2_init_rd_stats(RD_STATS *rd_stats) {
-#if CONFIG_RD_DEBUG
-  int plane;
-#endif
   rd_stats->rate = 0;
   rd_stats->dist = 0;
   rd_stats->rdcost = 0;
@@ -104,13 +101,12 @@ static INLINE void av2_init_rd_stats(RD_STATS *rd_stats) {
 #if CONFIG_RD_DEBUG
   // This may run into problems when monochrome video is
   // encoded, as there will only be 1 plane
-  for (plane = 0; plane < MAX_MB_PLANE; ++plane) {
+  for (int plane = 0; plane < MAX_MB_PLANE; ++plane) {
     rd_stats->txb_coeff_cost[plane] = 0;
-    {
-      int r, c;
-      for (r = 0; r < TXB_COEFF_COST_MAP_SIZE; ++r)
-        for (c = 0; c < TXB_COEFF_COST_MAP_SIZE; ++c)
-          rd_stats->txb_coeff_cost_map[plane][r][c] = 0;
+    for (int r = 0; r < TXB_COEFF_COST_MAP_SIZE; ++r) {
+      for (int c = 0; c < TXB_COEFF_COST_MAP_SIZE; ++c) {
+        rd_stats->txb_coeff_cost_map[plane][r][c] = 0;
+      }
     }
   }
 #endif

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -1428,6 +1428,72 @@ static int64_t handle_newmv(const AV2_COMP *const cpi, MACROBLOCK *const x,
                                               mode_info, &start_mv, &best_mv);
 
     } else {
+      // Predictive NEWMV reuse across the DRL. Two triggers select a match:
+      //   Tier 1 (predict_repeated_newmv): match when reference MVs are
+      //     within one full pel.
+      //   Tier 2 (newmv_drl_search_limit): once ref_mv_idx reaches the limit,
+      //     reuse the nearest searched result regardless of distance.
+      const int t1_active = cpi->sf.mv_sf.predict_repeated_newmv != 0;
+      const int drl_limit = cpi->sf.mv_sf.newmv_drl_search_limit;
+      const int t2_active =
+          drl_limit > 0 && mbmi->ref_mv_idx[ref_idx] >= drl_limit;
+      if ((t1_active || t2_active) && !mbmi->use_amvd &&
+          mbmi->ref_mv_idx[ref_idx] > 0) {
+        const MV ref_mv = av2_get_ref_mv(x, ref_idx).as_mv;
+        int near_diff = INT_MAX;
+        int near_idx = -1;
+        for (int idx = 0; idx < mbmi->ref_mv_idx[ref_idx]; ++idx) {
+          if (!args->single_newmv_valid[pb_mv_precision][idx][refs[0]])
+            continue;
+          const MV prev_ref_mv =
+              av2_get_ref_mv_from_stack(ref_idx, mbmi->ref_frame, idx,
+                                        x->mbmi_ext, mbmi)
+                  .as_mv;
+          const int ref_mv_diff = AVMMAX(abs(ref_mv.row - prev_ref_mv.row),
+                                         abs(ref_mv.col - prev_ref_mv.col));
+          if (ref_mv_diff < near_diff) {
+            near_diff = ref_mv_diff;
+            near_idx = idx;
+          }
+        }
+        int best_match = -1;
+        // Reuse the nearest previously-searched ref-mv when Tier 1 (within
+        // one full pel -- (1 << 3) in 1/8-pel units) or Tier 2 (no distance
+        // cap) fires.
+        if (near_idx >= 0 &&
+            ((t1_active && near_diff <= (1 << 3)) || t2_active)) {
+          best_match = near_idx;
+        }
+        if (best_match >= 0) {
+          const int_mv reuse_mv =
+              args->single_newmv[pb_mv_precision][best_match][refs[0]];
+          SubpelMvLimits mv_limits;
+          av2_set_subpel_mv_search_range(&mv_limits, &x->mv_limits, &ref_mv,
+                                         pb_mv_precision);
+          const int is_adaptive_mvd = enable_adaptive_mvd_resolution(cm, mbmi);
+          // The reused MV was searched against a different reference MV, so
+          // check that its MVD relative to the *current* reference MV is
+          // representable at pb_mv_precision (otherwise the decoder would
+          // reconstruct a different MV -- bitstream mismatch).
+          MV reuse_mvd;
+          get_mvd_from_ref_mv(reuse_mv.as_mv, ref_mv, is_adaptive_mvd,
+                              pb_mv_precision, &reuse_mvd);
+          if (av2_is_subpelmv_in_range(&mv_limits, reuse_mv.as_mv) &&
+              is_this_mv_precision_compliant(reuse_mvd, pb_mv_precision)) {
+            *rate_mv =
+                av2_mv_bit_cost(&reuse_mv.as_mv, &ref_mv, pb_mv_precision,
+                                &x->mv_costs, MV_COST_WEIGHT, is_adaptive_mvd);
+            const int cur_idx = get_ref_mv_idx(mbmi, 0);
+            args->single_newmv[pb_mv_precision][cur_idx][refs[0]] = reuse_mv;
+            args->single_newmv_rate[pb_mv_precision][cur_idx][refs[0]] =
+                *rate_mv;
+            args->single_newmv_valid[pb_mv_precision][cur_idx][refs[0]] = 1;
+            cur_mv[0].as_int = reuse_mv.as_int;
+            return 0;
+          }
+        }
+      }
+
       int search_range = INT_MAX;
       if (cpi->sf.mv_sf.reduce_search_range && mbmi->ref_mv_idx[0] > 0) {
         const MV ref_mv = av2_get_ref_mv(x, ref_idx).as_mv;

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -9008,17 +9008,7 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
       cm->current_frame.reference_mode == REFERENCE_MODE_SELECT;
 
   const int num_total_refs = cm->ref_frames_info.num_total_refs;
-  // Suppress TIP on frames that must decode correctly under base-only
-  // implicit-ref-map decode: base-layer frames (mlayer_id == 0) of a
-  // multi-layer sequence (number_mlayers > 1) using implicit ref-map
-  // signalling. TIP's virtual reference is derived from frames that may
-  // be absent under such decode, so a TIP-winning block on these frames
-  // would not be correctly decodable.
-  const int must_avoid_tip_for_base_only_decode =
-      cm->number_mlayers > 1 && cm->mlayer_id == 0 &&
-      !cm->seq_params.enable_explicit_ref_frame_map;
-  const int tip_allowed =
-      is_tip_allowed(cm, xd) && !must_avoid_tip_for_base_only_decode;
+  const int tip_allowed = is_tip_allowed(cm, xd);
   const int comp_ref_allowed =
       cm->current_frame.reference_mode != SINGLE_REFERENCE &&
       is_comp_ref_allowed(bsize);

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -6319,9 +6319,7 @@ static AVM_INLINE void rd_pick_skip_mode(
   assert(second_ref_frame != NONE_FRAME);
   const PREDICTION_MODE this_mode = NEAR_NEARMV;
 
-  if ((!cpi->oxcf.ref_frm_cfg.enable_onesided_comp ||
-       cpi->sf.inter_sf.disable_onesided_comp) &&
-      cpi->all_one_sided_refs) {
+  if (!cpi->oxcf.ref_frm_cfg.enable_onesided_comp && cpi->all_one_sided_refs) {
     return;
   }
 
@@ -6877,8 +6875,7 @@ static AVM_INLINE int prune_ref_frame(const AV2_COMP *cpi, const MACROBLOCK *x,
   av2_set_ref_frame(rf, ref_frame);
   const int comp_pred = is_inter_ref_frame(rf[1]);
   if (comp_pred) {
-    if (!cpi->oxcf.ref_frm_cfg.enable_onesided_comp ||
-        cpi->sf.inter_sf.disable_onesided_comp) {
+    if (!cpi->oxcf.ref_frm_cfg.enable_onesided_comp) {
       // Disable all compound references
       if (cpi->all_one_sided_refs) return 1;
       // If both references are on the same side prune
@@ -7647,47 +7644,6 @@ static int compound_skip_by_single_states(
   return 0;
 }
 
-// Check if ref frames of current block matches with given block.
-static INLINE void match_ref_frame(const MB_MODE_INFO *const mbmi,
-                                   const MV_REFERENCE_FRAME *ref_frames,
-                                   int *const is_ref_match) {
-  if (is_inter_block(mbmi, SHARED_PART)) {
-    is_ref_match[0] |= ref_frames[0] == mbmi->ref_frame[0];
-    is_ref_match[1] |= ref_frames[1] == mbmi->ref_frame[0];
-    if (has_second_ref(mbmi)) {
-      is_ref_match[0] |= ref_frames[0] == mbmi->ref_frame[1];
-      is_ref_match[1] |= ref_frames[1] == mbmi->ref_frame[1];
-    }
-  }
-}
-
-// Prune compound mode using ref frames of neighbor blocks.
-static INLINE int compound_skip_using_neighbor_refs(
-    MACROBLOCKD *const xd, const PREDICTION_MODE this_mode,
-    const MV_REFERENCE_FRAME *ref_frames, int prune_compound_using_neighbors) {
-  // Exclude non-extended compound modes from pruning
-  if (this_mode == NEAR_NEARMV || this_mode == NEW_NEWMV ||
-      this_mode == GLOBAL_GLOBALMV)
-    return 0;
-
-  int is_ref_match[2] = { 0 };  // 0 - match for forward refs
-                                // 1 - match for backward refs
-  // Check if ref frames of this block matches with left neighbor.
-  if (xd->left_available)
-    match_ref_frame(xd->left_mbmi, ref_frames, is_ref_match);
-
-  // Check if ref frames of this block matches with above neighbor.
-  if (xd->up_available)
-    match_ref_frame(xd->above_mbmi, ref_frames, is_ref_match);
-
-  // Combine ref frame match with neighbors in forward and backward refs.
-  const int track_ref_match = is_ref_match[0] + is_ref_match[1];
-
-  // Pruning based on ref frame match with neighbors.
-  if (track_ref_match >= prune_compound_using_neighbors) return 0;
-  return 1;
-}
-
 // Update best single mode for the given reference frame based on simple rd.
 static INLINE void update_best_single_mode(InterModeSearchState *search_state,
                                            const PREDICTION_MODE this_mode,
@@ -7982,13 +7938,6 @@ static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, const BLOCK_SIZE bsize,
     }
     if (args->prune_cpd_using_sr_stats_ready &&
         !in_single_ref_cutoff(ref_frame_rd, ref_frame, second_ref_frame))
-      return 1;
-  }
-
-  if (sf->inter_sf.prune_compound_using_neighbors && comp_pred) {
-    if (compound_skip_using_neighbor_refs(
-            xd, this_mode, ref_frames,
-            sf->inter_sf.prune_compound_using_neighbors))
       return 1;
   }
 

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -2076,28 +2076,84 @@ static int av2_adjust_mvs_for_derive_sign(const AV2_COMP *const cpi,
   return (best_model_rd != INT64_MAX);
 }
 
-// Reject this motion mode if modelrd is larder that the stored model rd values
+// Returns 1 for the simplest inter-mode setting: SIMPLE_TRANSLATION
+// (or a warp mode with no side-info tweaks), top-ranked ref frame,
+// first DRL index, and no CWP/BAWP/JMVD/RefineMV modifiers. This
+// setting is always fully evaluated (never pruned by the model-RD
+// heuristic) so the search keeps a stable point to compare against.
+static int motion_mode_is_prune_exempt(const AV2_COMMON *const cm,
+                                       const MACROBLOCKD *const xd,
+                                       BLOCK_SIZE bsize) {
+  const MB_MODE_INFO *const mbmi = xd->mi[0];
+
+  // Motion mode: only SIMPLE_TRANSLATION, or a warp mode (WARP_CAUSAL /
+  // WARP_DELTA / WARP_EXTEND) with all warp side-info knobs at their
+  // default (no warp+inter-intra combo, first warp ref candidate, no
+  // warp MVD, first warp precision).
+  if (mbmi->motion_mode != SIMPLE_TRANSLATION) {
+    if (!is_warp_mode(mbmi->motion_mode)) return 0;
+    if (mbmi->warp_inter_intra != 0 || mbmi->warp_ref_idx != 0 ||
+        mbmi->warpmv_with_mvd_flag != 0 || mbmi->warp_precision_idx != 0)
+      return 0;
+  }
+
+  // Reference frames: top ranked ref for single, (0, 1) pair for compound.
+  if (has_second_ref(mbmi)) {
+    if (mbmi->ref_frame[0] != 0 || mbmi->ref_frame[1] != 1) return 0;
+  } else if (mbmi->ref_frame[0] != 0) {
+    return 0;
+  }
+
+  // DRL index: first candidate, for both lists when a separate DRL is used.
+  if (mbmi->ref_mv_idx[0] != 0) return 0;
+  if (has_second_drl(mbmi) && mbmi->ref_mv_idx[1] != 0) return 0;
+
+  // CWP: equal weighting, when CWP is allowed for this mode.
+  if (is_cwp_allowed(mbmi) && mbmi->cwp_idx != CWP_EQUAL) return 0;
+
+  // BAWP: off or basic on (exclude explicit-scale variants), when allowed.
+  if (av2_allow_bawp(cm, mbmi, xd->mi_row, xd->mi_col) &&
+      mbmi->bawp_flag[0] > 1)
+    return 0;
+
+  // JMVD scale index: no scaling, when joint-MVD coding is used.
+  if (is_joint_mvd_coding_mode(mbmi->mode) && mbmi->jmvd_scale_mode != 0)
+    return 0;
+
+  // RefineMV: disabled, when refinemv is allowed.
+  if (is_refinemv_allowed(cm, mbmi, bsize) && mbmi->refinemv_flag != 0)
+    return 0;
+
+  return 1;
+}
+
+// Reject this motion mode if modelrd is larger than the stored model rd values.
+// Maintains a sorted list of the best model rd values seen so far.
 //  Return 1 means reject this mode
 //  Return 0 means compute full RD
 static int prune_motion_mode(int64_t this_model_rd,
-                             int64_t top_motion_mode_model_rd[]) {
-  const double thresh_top = 1.00;
+                             int64_t top_motion_mode_model_rd[],
+                             const AV2_COMMON *const cm,
+                             const MACROBLOCKD *const xd, BLOCK_SIZE bsize) {
+  // top_motion_mode_model_rd[] holds the smallest model RDs seen so far in
+  // ascending order, padded with the INT64_MAX sentinel. Insert this_model_rd
+  // if it ranks among them.
   for (int i = 0; i < TOP_MOTION_MODE_MODEL_COUNT; i++) {
     if (this_model_rd < top_motion_mode_model_rd[i]) {
       for (int j = TOP_MOTION_MODE_MODEL_COUNT - 1; j > i; j--) {
         top_motion_mode_model_rd[j] = top_motion_mode_model_rd[j - 1];
       }
       top_motion_mode_model_rd[i] = this_model_rd;
-      break;
+      return 0;  // Ranked among the best -> compute full RD.
     }
   }
-  if (top_motion_mode_model_rd[TOP_MOTION_MODE_MODEL_COUNT - 1] != INT64_MAX &&
-      this_model_rd >
-          thresh_top *
-              top_motion_mode_model_rd[TOP_MOTION_MODE_MODEL_COUNT - 1])
-    return 1;
-
-  return 0;
+  // Never prune the prune-exempt setting, even when its model RD does not rank.
+  if (motion_mode_is_prune_exempt(cm, xd, bsize)) return 0;
+  // Did not rank: this_model_rd is >= every kept value. Prune only when it
+  // strictly exceeds the largest kept RD. An unfilled pool keeps the INT64_MAX
+  // sentinel in the last slot, which can never be exceeded, so it returns 0.
+  return this_model_rd >
+         top_motion_mode_model_rd[TOP_MOTION_MODE_MODEL_COUNT - 1];
 }
 
 // Handle SIMPLE_TRANSLATION motion mode: adjust MVD sign if needed.
@@ -2798,7 +2854,8 @@ static AVM_INLINE int evaluate_motion_mode_trial(
           NULL, &curr_sse, NULL, NULL, NULL);
       int64_t est_rd =
           RDCOST(x->rdmult, rd_stats->rate + est_residue_cost, est_dist);
-      if (prune_motion_mode(est_rd, top_motion_mode_model_rd)) return -1;
+      if (prune_motion_mode(est_rd, top_motion_mode_model_rd, cm, xd, bsize))
+        return -1;
     }
 
     // Do transform search
@@ -7119,8 +7176,6 @@ static AVM_INLINE void init_inter_mode_search_state(
 static bool mask_says_skip(const mode_skip_mask_t *mode_skip_mask,
                            const MV_REFERENCE_FRAME *ref_frame,
                            const PREDICTION_MODE this_mode) {
-  if (is_tip_ref_frame(ref_frame[0])) return false;
-
   if (mode_skip_mask->pred_modes[COMPACT_INDEX0_NRS(ref_frame[0])] &
       ((int64_t)1 << this_mode)) {
     return true;
@@ -7128,33 +7183,6 @@ static bool mask_says_skip(const mode_skip_mask_t *mode_skip_mask,
 
   return mode_skip_mask->ref_combo[COMPACT_INDEX0_NRS(ref_frame[0])]
                                   [COMPACT_INDEX0_NRS(ref_frame[1]) + 1];
-}
-
-static int inter_mode_compatible_skip(const AV2_COMP *cpi, const MACROBLOCK *x,
-                                      BLOCK_SIZE bsize,
-                                      PREDICTION_MODE curr_mode,
-                                      const MV_REFERENCE_FRAME *ref_frames) {
-  const int comp_pred = is_inter_ref_frame(ref_frames[1]);
-  if (comp_pred) {
-    if (!is_comp_ref_allowed(bsize)) return 1;
-    if (!(cpi->common.ref_frame_flags & (1 << ref_frames[1]))) return 1;
-
-    const AV2_COMMON *const cm = &cpi->common;
-    if (frame_is_intra_only(cm)) return 1;
-
-    const CurrentFrame *const current_frame = &cm->current_frame;
-    if (current_frame->reference_mode == SINGLE_REFERENCE) return 1;
-
-    (void)x;
-  }
-
-  if (is_inter_ref_frame(ref_frames[0]) && ref_frames[1] == INTRA_FRAME) {
-    // Mode must be compatible
-    if (!is_interintra_allowed_bsize(bsize)) return 1;
-    if (!is_interintra_allowed_mode(curr_mode)) return 1;
-  }
-
-  return 0;
 }
 
 static uint64_t fetch_picked_ref_frames_mask(const MACROBLOCK *const x,
@@ -7375,6 +7403,7 @@ static INLINE void init_mbmi(MB_MODE_INFO *mbmi, PREDICTION_MODE curr_mode,
   }
   set_default_interp_filters(mbmi, cm, xd, cm->features.interp_filter);
   mbmi->use_intrabc[xd->tree_type == CHROMA_PART] = 0;
+  mbmi->use_intrabc[xd->tree_type != CHROMA_PART] = 0;
   mbmi->morph_pred = 0;
   mbmi->local_rest_type = 1;
   mbmi->local_ccso_blk_flag = 1;
@@ -7394,6 +7423,7 @@ static INLINE void init_mbmi(MB_MODE_INFO *mbmi, PREDICTION_MODE curr_mode,
   mbmi->bawp_flag[0] = 0;
   mbmi->bawp_flag[1] = 0;
   mbmi->jmvd_scale_mode = 0;
+  mbmi->interinter_comp.type = COMPOUND_AVERAGE;
 }
 
 static AVM_INLINE void collect_single_states(const AV2_COMMON *const cm,
@@ -7861,8 +7891,8 @@ typedef struct {
 } InterModeSFArgs;
 /*!\endcond */
 
-static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, const BLOCK_SIZE bsize,
-                           int64_t *ref_frame_rd, PREDICTION_MODE this_mode,
+static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, int64_t *ref_frame_rd,
+                           PREDICTION_MODE this_mode,
                            const MV_REFERENCE_FRAME *ref_frames,
                            InterModeSFArgs *args) {
   const SPEED_FEATURES *const sf = &cpi->sf;
@@ -7871,18 +7901,7 @@ static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, const BLOCK_SIZE bsize,
   const MV_REFERENCE_FRAME second_ref_frame = ref_frames[1];
   const int comp_pred = is_inter_ref_frame(second_ref_frame);
 
-  if (is_tip_ref_frame(ref_frame) &&
-      cpi->common.features.tip_frame_mode == TIP_FRAME_DISABLED) {
-    return 1;
-  } else if (is_tip_ref_frame(ref_frame)) {
-    return 0;
-  }
-
-  // Check if this mode should be skipped because it is incompatible with the
-  // current frame
-  if (inter_mode_compatible_skip(cpi, x, bsize, this_mode, ref_frames))
-    return 1;
-
+  if (is_tip_ref_frame(ref_frame)) return 0;
   if (this_mode == WARPMV) return 0;
 
   const int ret = inter_mode_search_order_independent_skip(
@@ -7909,23 +7928,18 @@ static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, const BLOCK_SIZE bsize,
 
   if (args->search_state->best_rd < mode_threshold) return 1;
 
+  if (!comp_pred) return 0;
+
   // Skip this compound mode based on the RD results from the single
   // prediction modes
   if (sf->inter_sf.prune_comp_search_by_single_result > 0 &&
-      this_mode < NEAR_NEARMV_OPTFLOW && comp_pred &&
-      !has_second_drl(xd->mi[0])) {
+      this_mode < NEAR_NEARMV_OPTFLOW && !has_second_drl(xd->mi[0])) {
     if (compound_skip_by_single_states(cpi, args->search_state, this_mode,
                                        ref_frame, second_ref_frame, x))
       return 1;
   }
 
-  // Speed features to prune out INTRA frames
-  if (ref_frame == INTRA_FRAME) {
-    // Intra modes will be handled in another loop later
-    return 1;
-  }
-
-  if (sf->inter_sf.prune_compound_using_single_ref && comp_pred) {
+  if (sf->inter_sf.prune_compound_using_single_ref) {
     // After we done with single reference modes, find the 2nd best RD
     // for a reference frame. Only search compound modes that have a reference
     // frame at least as good as 110% the best one.
@@ -7941,7 +7955,7 @@ static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, const BLOCK_SIZE bsize,
       return 1;
   }
 
-  if (sf->inter_sf.prune_comp_using_best_single_mode_ref && comp_pred) {
+  if (sf->inter_sf.prune_comp_using_best_single_mode_ref) {
     if (skip_compound_using_best_single_mode_ref(
             this_mode, ref_frames, args->search_state->best_single_mode,
             sf->inter_sf.prune_comp_using_best_single_mode_ref))
@@ -8148,20 +8162,6 @@ static void handle_winner_cand(
   }
 }
 
-static INLINE int is_tip_mode(PREDICTION_MODE mode) {
-  return (mode == NEARMV || mode == NEWMV);
-}
-
-static INLINE int is_compound_mode_disallowed(PREDICTION_MODE mode,
-                                              int ref_frame0, int ref_frame1) {
-  if (ref_frame0 == ref_frame1 &&
-      (mode == NEW_NEARMV || mode == NEW_NEARMV_OPTFLOW)) {
-    return 1;
-  }
-
-  return 0;
-}
-
 // Initialize the table that stores best RD Costs of NONE transform partition
 static INLINE void init_top_tx_part_rd_for_inter_modes(
     MACROBLOCK *const x, bool prune_inter_tx_part_rd_eval) {
@@ -8356,6 +8356,127 @@ static void av2_evaluate_intra_modes_in_inter_frame(
   }
 }
 
+/*!\cond */
+// (mode, rf0, rf1) tuple describing one entry of the ref-frame-centric
+// evaluation order. rf1 == NONE_FRAME marks a single-reference entry;
+// rf0 == TIP_FRAME marks a TIP entry; rf0 == rf1 marks a same-ref compound
+// entry.
+typedef struct {
+  PREDICTION_MODE mode;
+  MV_REFERENCE_FRAME rf0;
+  MV_REFERENCE_FRAME rf1;
+} MODE_REF_TUPLE;
+/*!\endcond */
+
+// Pre-computed (mode, rf0, rf1) evaluation order used by
+// av2_rd_pick_inter_mode_sb.
+//
+// Traversal:
+//   1. TIP entries: TIP/NEARMV, TIP/NEWMV.
+//   2. For max_ref = 0..INTER_REFS_PER_FRAME-1 (= 0..6):
+//      a. All single inter modes with (rf0=max_ref, rf1=NONE_FRAME).
+//      b. All compound inter modes with (rf0, rf1=max_ref) for
+//         rf0 in [0, min(max_ref, RANKED_REF0_TO_PRUNE)).
+//         RANKED_REF0_TO_PRUNE = 3, so rf0 ∈ {0, 1, 2} for max_ref >= 3.
+//      c. Same-ref compound modes (rf0=max_ref, rf1=max_ref) only when
+//         max_ref < num_same_ref_compound (= 2, so max_ref ∈ {0, 1}).
+//         Restricted to modes that permit same-ref compound:
+//         NEAR_NEARMV, NEAR_NEWMV, GLOBAL_GLOBALMV, NEW_NEWMV.
+//
+// Frame-level feasibility checks (tip_allowed, comp_ref_allowed, opfl,
+// joint MVD, BRU, ref_frame_flags, warpmv, global_motion, etc.) still
+// apply at the use site via existing skip/continue logic.
+// clang-format off
+#define MODE_REF_SINGLE_GROUP(rf)               \
+  { NEARMV,     (rf), NONE_FRAME },             \
+  { GLOBALMV,   (rf), NONE_FRAME },             \
+  { NEWMV,      (rf), NONE_FRAME },             \
+  { WARPMV,     (rf), NONE_FRAME },             \
+  { WARP_NEWMV, (rf), NONE_FRAME }
+
+#define MODE_REF_COMPOUND_GROUP(rf0, rf1)       \
+  { NEAR_NEARMV,         (rf0), (rf1) },        \
+  { NEAR_NEWMV,          (rf0), (rf1) },        \
+  { NEW_NEARMV,          (rf0), (rf1) },        \
+  { GLOBAL_GLOBALMV,     (rf0), (rf1) },        \
+  { NEW_NEWMV,           (rf0), (rf1) },        \
+  { JOINT_NEWMV,         (rf0), (rf1) },        \
+  { NEAR_NEARMV_OPTFLOW, (rf0), (rf1) },        \
+  { NEAR_NEWMV_OPTFLOW,  (rf0), (rf1) },        \
+  { NEW_NEARMV_OPTFLOW,  (rf0), (rf1) },        \
+  { NEW_NEWMV_OPTFLOW,   (rf0), (rf1) },        \
+  { JOINT_NEWMV_OPTFLOW, (rf0), (rf1) }
+
+#define MODE_REF_SAME_REF_GROUP(rf)             \
+  { NEAR_NEARMV,     (rf), (rf) },              \
+  { NEAR_NEWMV,      (rf), (rf) },              \
+  { GLOBAL_GLOBALMV, (rf), (rf) },              \
+  { NEW_NEWMV,       (rf), (rf) }
+
+#define MODE_REF_TIP_GROUP                      \
+  { NEARMV, TIP_FRAME, NONE_FRAME },            \
+  { NEWMV,  TIP_FRAME, NONE_FRAME }
+
+static const MODE_REF_TUPLE ref_frame_centric_eval_order[] = {
+  // TIP entries : TIP/NEARMV, TIP/NEWMV
+  MODE_REF_TIP_GROUP,
+
+  // max_ref = 0 : single, same-ref(0,0)
+  MODE_REF_SINGLE_GROUP(0),
+  MODE_REF_SAME_REF_GROUP(0),
+
+  // max_ref = 1 : single, cross(0,1), same-ref(1,1)
+  MODE_REF_SINGLE_GROUP(1),
+  MODE_REF_COMPOUND_GROUP(0, 1),
+  MODE_REF_SAME_REF_GROUP(1),
+
+  // max_ref = 2 : single, cross(0,2), cross(1,2)
+  MODE_REF_SINGLE_GROUP(2),
+  MODE_REF_COMPOUND_GROUP(0, 2),
+  MODE_REF_COMPOUND_GROUP(1, 2),
+
+  // max_ref = 3 : single, cross(0,3), cross(1,3), cross(2,3)
+  MODE_REF_SINGLE_GROUP(3),
+  MODE_REF_COMPOUND_GROUP(0, 3),
+  MODE_REF_COMPOUND_GROUP(1, 3),
+  MODE_REF_COMPOUND_GROUP(2, 3),
+
+  // max_ref = 4 : single, cross(0..2, 4)  (rf0 clamped by RANKED_REF0_TO_PRUNE)
+  MODE_REF_SINGLE_GROUP(4),
+  MODE_REF_COMPOUND_GROUP(0, 4),
+  MODE_REF_COMPOUND_GROUP(1, 4),
+  MODE_REF_COMPOUND_GROUP(2, 4),
+
+  // max_ref = 5 : single, cross(0..2, 5)
+  MODE_REF_SINGLE_GROUP(5),
+  MODE_REF_COMPOUND_GROUP(0, 5),
+  MODE_REF_COMPOUND_GROUP(1, 5),
+  MODE_REF_COMPOUND_GROUP(2, 5),
+
+  // max_ref = 6 : single, cross(0..2, 6)
+  MODE_REF_SINGLE_GROUP(6),
+  MODE_REF_COMPOUND_GROUP(0, 6),
+  MODE_REF_COMPOUND_GROUP(1, 6),
+  MODE_REF_COMPOUND_GROUP(2, 6),
+};
+#undef MODE_REF_SINGLE_GROUP
+#undef MODE_REF_COMPOUND_GROUP
+#undef MODE_REF_SAME_REF_GROUP
+#undef MODE_REF_TIP_GROUP
+// clang-format on
+
+static const int ref_frame_centric_eval_order_num =
+    (int)(sizeof(ref_frame_centric_eval_order) /
+          sizeof(ref_frame_centric_eval_order[0]));
+// Tripwire: if the LUT above grows or shrinks, this assert fires so any
+// caller-side dependencies on the count are re-audited before shipping.
+// Update the literal deliberately.
+static_assert(sizeof(ref_frame_centric_eval_order) /
+                      sizeof(ref_frame_centric_eval_order[0]) ==
+                  210,
+              "ref_frame_centric_eval_order size changed; audit callers.");
+
+// TODO(chiyotsai@google.com): See the todo for av2_rd_pick_intra_mode_sb.
 void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
                                struct TileDataEnc *tile_data,
                                struct macroblock *x, struct RD_STATS *rd_cost,
@@ -8383,9 +8504,9 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
     INTERINTRA_MODES, INTERINTRA_MODES, INTERINTRA_MODES, INTERINTRA_MODES
   };
   HandleInterModeArgs args = {
-    NULL,
-    NULL,
-    NULL,
+    search_state.single_newmv,
+    search_state.single_newmv_rate,
+    search_state.single_newmv_valid,
     search_state.modelled_rd,
     INT_MAX,
     INT_MAX,
@@ -8637,254 +8758,248 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
                               mode_thresh_mul_fact,
                               &num_single_modes_processed,
                               0 };
-  // This is the main loop of this function. It loops over all possible modes
-  // and calls handle_inter_mode() to compute the RD for each.
-  // Here midx is just an iterator index that should not be used by itself
-  // except to keep track of the number of modes searched. It should be used
-  // with av2_default_mode_order to get the enum that defines the mode, which
-  // can be used with av2_mode_defs to get the prediction mode and the ref
-  // frames.
-  for (PREDICTION_MODE this_mode = 0; this_mode < MB_MODE_COUNT; ++this_mode) {
-    int64_t top_motion_mode_model_rd[TOP_MOTION_MODE_MODEL_COUNT];
-    uint8_t enable_tx_prune = do_tx_search;
-    if (enable_tx_prune) {
+
+  const uint8_t enable_tx_prune = do_tx_search;
+  // Pool of top model RDs used by prune_motion_mode(). When
+  // share_across_modes is 1, every prediction mode shares pool_shared
+  // (smaller working set, more pruning). When 0, each prediction mode
+  // keeps its own row in pool_per_mode.
+  const int share_across_modes = cpi->sf.inter_sf.share_motion_mode_prune_pool;
+  int64_t pool_shared[TOP_MOTION_MODE_MODEL_COUNT];
+  int64_t pool_per_mode[MB_MODE_COUNT][TOP_MOTION_MODE_MODEL_COUNT];
+  if (enable_tx_prune) {
+    if (share_across_modes) {
       for (int k = 0; k < TOP_MOTION_MODE_MODEL_COUNT; k++) {
-        top_motion_mode_model_rd[k] = INT64_MAX;
+        pool_shared[k] = INT64_MAX;
+      }
+    } else {
+      for (int m = 0; m < MB_MODE_COUNT; m++) {
+        for (int k = 0; k < TOP_MOTION_MODE_MODEL_COUNT; k++) {
+          pool_per_mode[m][k] = INT64_MAX;
+        }
+      }
+    }
+  }
+  // This is the main loop of this function. It loops over all inter modes
+  // and calls handle_inter_mode() to compute the RD for each.
+
+  // Intra modes are evaluated separately after this loop.
+  const int prune_comp_by_single =
+      sf->inter_sf.prune_comp_search_by_single_result > 0;
+  const int prune_comp_best_single =
+      sf->inter_sf.prune_comp_using_best_single_mode_ref > 0;
+  const int prune_comp_using_single_ref =
+      sf->inter_sf.prune_compound_using_single_ref;
+  const int motion_mode_winner =
+      cpi->sf.winner_mode_sf.motion_mode_for_winner_cand;
+  const int reference_mode_select =
+      cm->current_frame.reference_mode == REFERENCE_MODE_SELECT;
+
+  const int num_total_refs = cm->ref_frames_info.num_total_refs;
+  // Suppress TIP on frames that must decode correctly under base-only
+  // implicit-ref-map decode: base-layer frames (mlayer_id == 0) of a
+  // multi-layer sequence (number_mlayers > 1) using implicit ref-map
+  // signalling. TIP's virtual reference is derived from frames that may
+  // be absent under such decode, so a TIP-winning block on these frames
+  // would not be correctly decodable.
+  const int must_avoid_tip_for_base_only_decode =
+      cm->number_mlayers > 1 && cm->mlayer_id == 0 &&
+      !cm->seq_params.enable_explicit_ref_frame_map;
+  const int tip_allowed =
+      is_tip_allowed(cm, xd) && !must_avoid_tip_for_base_only_decode;
+  const int comp_ref_allowed =
+      cm->current_frame.reference_mode != SINGLE_REFERENCE &&
+      is_comp_ref_allowed(bsize);
+  const int warpmv_allowed =
+      (cm->features.enabled_motion_modes & (1 << WARP_DELTA)) != 0 &&
+      cm->features.allow_warpmv_mode && is_warpmv_allowed_bsize(bsize);
+  const int warp_newmv_allowed =
+      is_motion_variation_allowed_bsize(bsize, mi_row, mi_col) &&
+      !xd->cur_frame_force_integer_mv;
+  const int thin_4xn_nx4 = is_thin_4xn_nx4_block(bsize);
+  // OPTFLOW modes are only useful with REFINE_SWITCHABLE; REFINE_NONE disables
+  // opfl entirely, REFINE_ALL applies opfl to all compound (explicit modes
+  // redundant), and sframes/seq-level disable also kill it.
+  const int opfl_modes_allowed =
+      cm->seq_params.enable_opfl_refine != AVM_OPFL_REFINE_NONE &&
+      cm->features.opfl_refine_type == REFINE_SWITCHABLE &&
+      !frame_is_sframe(cm) && !thin_4xn_nx4;
+
+  for (int mode_refs_pair_idx = 0;
+       mode_refs_pair_idx < ref_frame_centric_eval_order_num;
+       ++mode_refs_pair_idx) {
+    if (bsize == BLOCK_4X4) break;
+    const PREDICTION_MODE this_mode =
+        ref_frame_centric_eval_order[mode_refs_pair_idx].mode;
+    const MV_REFERENCE_FRAME ref_frame =
+        ref_frame_centric_eval_order[mode_refs_pair_idx].rf0;
+    const MV_REFERENCE_FRAME second_ref_frame =
+        ref_frame_centric_eval_order[mode_refs_pair_idx].rf1;
+    const int is_comp_mode = (second_ref_frame != NONE_FRAME);
+    const int is_single_pred = !is_comp_mode;
+    const int comp_pred = is_comp_mode;
+
+    // Gate LUT entries by runtime ref-frame availability.
+    if (is_tip_ref_frame(ref_frame)) {
+      if (!tip_allowed) continue;
+    } else if ((int)ref_frame >= num_total_refs) {
+      continue;
+    }
+    if (is_comp_mode) {
+      if (!comp_ref_allowed) continue;
+      if ((int)second_ref_frame >= num_total_refs) continue;
+      // Same-ref compound only when permitted at runtime.
+      if (ref_frame == second_ref_frame &&
+          (int)ref_frame >= cm->ref_frames_info.num_same_ref_compound)
+        continue;
+    }
+
+    if (this_mode == WARPMV && !warpmv_allowed) continue;
+    if (this_mode == WARP_NEWMV && (!warpmv_allowed || !warp_newmv_allowed))
+      continue;
+    if (this_mode >= NEAR_NEARMV_OPTFLOW && !opfl_modes_allowed) continue;
+    if (is_joint_mvd_coding_mode(this_mode) &&
+        cm->seq_params.enable_joint_mvd == 0)
+      continue;
+
+    const int num_amvd_modes =
+        1 + (cm->seq_params.enable_adaptive_mvd && allow_amvd_mode(this_mode));
+    // Asymmetric NEAR/NEW compound modes default to AMVD on, invert the flag
+    const int amvd_inverted =
+        (this_mode == NEW_NEARMV || this_mode == NEAR_NEWMV ||
+         this_mode == NEAR_NEWMV_OPTFLOW || this_mode == NEW_NEARMV_OPTFLOW);
+
+    if (cm->bru.enabled) {
+      assert(xd->sbi->sb_active_mode == BRU_ACTIVE_SB);
+      if (xd->sbi->sb_active_mode == BRU_ACTIVE_SB) {
+        if (cm->bru.update_ref_idx == ref_frame) continue;
+        if (second_ref_frame != NONE_FRAME &&
+            cm->bru.update_ref_idx == second_ref_frame)
+          continue;
       }
     }
 
-    for (MV_REFERENCE_FRAME rf = NONE_FRAME;
-         rf < cm->ref_frames_info.num_total_refs + 1; ++rf) {
-      const MV_REFERENCE_FRAME ref_frame =
-          (rf == NONE_FRAME)
-              ? INTRA_FRAME
-              : ((rf == cm->ref_frames_info.num_total_refs) ? TIP_FRAME : rf);
-      if (is_tip_ref_frame(ref_frame) &&
-          (!is_tip_allowed(cm, xd) || !is_tip_mode(this_mode)))
+    if (comp_pred && !(cm->ref_frame_flags & (1 << second_ref_frame))) continue;
+
+    const MV_REFERENCE_FRAME ref_frames[2] = { ref_frame, second_ref_frame };
+    init_mbmi(mbmi, this_mode, ref_frames, cm, xd, xd->sbi);
+    mbmi->fsc_mode[PLANE_TYPE_Y] = 0;
+    mbmi->fsc_mode[PLANE_TYPE_UV] = 0;
+    mbmi->angle_delta[PLANE_TYPE_Y] = 0;
+    mbmi->angle_delta[PLANE_TYPE_UV] = 0;
+    mbmi->use_dpcm_y = 0;
+    mbmi->dpcm_mode_y = 0;
+    mbmi->use_dpcm_uv = 0;
+    mbmi->dpcm_mode_uv = 0;
+
+    // Bi-directional ref check for OPTFLOW (frame-level checks already
+    // passed via opfl_modes_allowed)
+    if (this_mode >= NEAR_NEARMV_OPTFLOW &&
+        !opfl_allowed_cur_refs_bsize(cm, xd, mbmi))
+      continue;
+
+    set_ref_ptrs(cm, xd, ref_frame, second_ref_frame);
+
+    if (skip_inter_mode(cpi, x, ref_frame_rd, this_mode, ref_frames, &sf_args))
+      continue;
+
+    // Select prediction reference frames.
+    for (i = 0; i < num_planes; i++) {
+      xd->plane[i].pre[0] = yv12_mb[COMPACT_INDEX0_NRS(ref_frame)][i];
+      if (comp_pred)
+        xd->plane[i].pre[1] = yv12_mb[COMPACT_INDEX0_NRS(second_ref_frame)][i];
+    }
+
+    const int ref_frame_index = COMPACT_INDEX0_NRS(ref_frame);
+    const int ref_frame_cost = comp_pred
+                                   ? ref_costs_comp[ref_frame][second_ref_frame]
+                                   : ref_costs_single[ref_frame_index];
+    const int compmode_cost = (comp_ref_allowed && !is_tip_ref_frame(ref_frame))
+                                  ? comp_inter_cost[comp_pred]
+                                  : 0;
+    const int real_compmode_cost = reference_mode_select ? compmode_cost : 0;
+    // Point to variables that are maintained between loop iterations
+    args.single_comp_cost = real_compmode_cost;
+    args.ref_frame_cost = ref_frame_cost;
+
+    for (int use_amvd_mode = 0; use_amvd_mode < num_amvd_modes;
+         ++use_amvd_mode) {
+      mbmi->use_amvd = (num_amvd_modes > 1 && amvd_inverted) ? !use_amvd_mode
+                                                             : use_amvd_mode;
+
+      if (amvd_inverted && !mbmi->use_amvd &&
+          search_state.best_mbmode.mode != mbmi->mode) {
         continue;
-
-      if (this_mode < INTRA_MODE_END && ref_frame != INTRA_FRAME) continue;
-      if (this_mode >= INTRA_MODE_END && ref_frame == INTRA_FRAME) continue;
-      if (ref_frame != INTRA_FRAME && bsize == BLOCK_4X4) {
-        continue;  // disable 4x4 inter blocks
       }
-      for (MV_REFERENCE_FRAME second_rf = NONE_FRAME;
-           second_rf < cm->ref_frames_info.num_total_refs; ++second_rf) {
-        MV_REFERENCE_FRAME second_ref_frame = second_rf;
-        // write this to a function
-        if (cm->bru.enabled) {
-          assert(xd->sbi->sb_active_mode == BRU_ACTIVE_SB);
-          if (xd->sbi->sb_active_mode == BRU_ACTIVE_SB) {
-            if (ref_frame != INVALID_IDX &&
-                cm->bru.update_ref_idx == ref_frame) {
-              continue;
-            }
-            if (second_ref_frame != INVALID_IDX &&
-                cm->bru.update_ref_idx == second_ref_frame) {
-              continue;
-            }
-          }
+
+      num_single_modes_processed += is_single_pred;
+      txfm_info->skip_txfm = 0;
+
+      const int64_t ref_best_rd = search_state.best_rd;
+      int64_t skip_rd[2] = { search_state.best_skip_rd[0],
+                             search_state.best_skip_rd[1] };
+
+      RD_STATS rd_stats, rd_stats_y, rd_stats_uv;
+      av2_init_rd_stats(&rd_stats);
+
+      int64_t *const pool =
+          enable_tx_prune
+              ? (share_across_modes ? pool_shared : pool_per_mode[this_mode])
+              : NULL;
+      int64_t this_rd = handle_inter_mode(
+          cpi, tile_data, x, bsize, &rd_stats, &rd_stats_y, &rd_stats_uv, &args,
+          ref_best_rd, tmp_buf, &x->comp_rd_buffer, &best_est_rd, do_tx_search,
+          inter_modes_info, &motion_mode_cand, skip_rd,
+          search_state.best_mbmode.mode, pool, &inter_cost_info_from_tpl);
+
+      // collect_single_states uses simple_rd/modelled_rd populated by
+      // handle_inter_mode even when this_rd == INT64_MAX, so call before
+      // the early exit.
+      if (is_single_pred && prune_comp_by_single)
+        collect_single_states(cm, x, &search_state, mbmi);
+
+      if (this_rd == INT64_MAX) continue;
+
+      if (is_single_pred) {
+        if (prune_comp_best_single)
+          update_best_single_mode(&search_state, this_mode, ref_frame, this_rd);
+        if (prune_comp_using_single_ref &&
+            this_rd < ref_frame_rd[ref_frame_index])
+          ref_frame_rd[ref_frame_index] = this_rd;
+      }
+
+      if (mbmi->skip_txfm[xd->tree_type == CHROMA_PART]) {
+        rd_stats_y.rate = 0;
+        rd_stats_uv.rate = 0;
+      }
+
+      // Did this mode help, i.e., is it the new best mode
+      if (this_rd < search_state.best_rd) {
+        if (is_tip_ref_frame(ref_frame) &&
+            this_rd + TIP_RD_CORRECTION > search_state.best_rd) {
+          continue;
         }
-        if ((ref_frame == second_ref_frame) &&
-            (is_joint_mvd_coding_mode(this_mode)))
-          continue;
 
-        if (second_ref_frame != NONE_FRAME && this_mode < COMP_INTER_MODE_START)
-          continue;
-        if (this_mode >= COMP_INTER_MODE_START &&
-            this_mode < COMP_INTER_MODE_END && second_ref_frame == NONE_FRAME)
-          continue;
-        if (is_inter_ref_frame(second_ref_frame) &&
-            ((second_ref_frame < ref_frame) ||
-             is_compound_mode_disallowed(this_mode, ref_frame,
-                                         second_ref_frame) ||
-             ((second_ref_frame == ref_frame) &&
-              (ref_frame >= cm->ref_frames_info.num_same_ref_compound))))
-          continue;
+        assert(IMPLIES(comp_pred,
+                       cm->current_frame.reference_mode != SINGLE_REFERENCE));
+        update_search_state(&search_state, rd_cost, ctx, &rd_stats, &rd_stats_y,
+                            &rd_stats_uv, this_mode, x, do_tx_search, cm);
+        if (do_tx_search) search_state.best_skip_rd[0] = skip_rd[0];
+        search_state.best_skip_rd[1] = skip_rd[1];
+      }
+      if (motion_mode_winner) {
+        handle_winner_cand(mbmi, &best_motion_mode_cands,
+                           max_winner_motion_mode_cand, this_rd,
+                           &motion_mode_cand, args.skip_motion_mode);
+      }
 
-        if (is_tip_ref_frame(ref_frame) && second_ref_frame != NONE_FRAME)
-          continue;
+      /* keep record of best compound/single-only prediction */
+      record_best_compound(cm->current_frame.reference_mode, &rd_stats,
+                           comp_pred, x->rdmult, &search_state, compmode_cost);
+    }  // end of use_amvd mode loop
+  }  // end of LUT entry loop
 
-        const MV_REFERENCE_FRAME ref_frames[2] = { ref_frame,
-                                                   second_ref_frame };
-
-        const int is_single_pred =
-            ref_frame != INTRA_FRAME && second_ref_frame == NONE_FRAME;
-        const int comp_pred = is_inter_ref_frame(second_ref_frame);
-
-        init_mbmi(mbmi, this_mode, ref_frames, cm, xd, xd->sbi);
-
-        if ((this_mode == WARPMV || this_mode == WARP_NEWMV) &&
-            !is_warpmv_mode_allowed(cm, mbmi, bsize))
-          continue;
-
-        if (this_mode == WARP_NEWMV &&
-            !is_warp_newmv_allowed(cm, xd, mbmi, bsize))
-          continue;
-
-        set_mv_precision(mbmi, mbmi->max_mv_precision);
-        if (is_pb_mv_precision_active(cm, mbmi, bsize))
-          set_most_probable_mv_precision(cm, mbmi, bsize);
-
-        // Initialize compound average type for optical flow refinement
-        mbmi->interinter_comp.type = COMPOUND_AVERAGE;
-
-        // Optical flow compound modes are only enabled
-        // when prediction is bi-directional
-        if (this_mode >= NEAR_NEARMV_OPTFLOW &&
-            (!opfl_allowed_cur_refs_bsize(cm, xd, mbmi) ||
-             cm->features.opfl_refine_type == REFINE_ALL))
-          continue;
-        // Optical flow is disabled for 4xn/nx4 blocks
-        if (is_thin_4xn_nx4_block(bsize) && (this_mode >= NEAR_NEARMV_OPTFLOW))
-          continue;
-
-        int num_amvd_modes = 1 + allow_amvd_mode(mbmi->mode);
-        for (int use_amvd_mode = 0; use_amvd_mode < num_amvd_modes;
-             ++use_amvd_mode) {
-          mbmi->use_amvd = use_amvd_mode;
-
-          if (mbmi->mode == NEW_NEARMV || mbmi->mode == NEAR_NEWMV ||
-              mbmi->mode == NEAR_NEWMV_OPTFLOW ||
-              mbmi->mode == NEW_NEARMV_OPTFLOW) {
-            mbmi->use_amvd = use_amvd_mode ? 0 : 1;
-
-            if (!mbmi->use_amvd &&
-                search_state.best_mbmode.mode != mbmi->mode) {
-              continue;
-            }
-          }
-
-          txfm_info->skip_txfm = 0;
-          num_single_modes_processed += is_single_pred;
-          set_ref_ptrs(cm, xd, ref_frame, second_ref_frame);
-
-          // Apply speed features to decide if this inter mode can be skipped
-          if (skip_inter_mode(cpi, x, bsize, ref_frame_rd, this_mode,
-                              ref_frames, &sf_args))
-            continue;
-
-          if (cm->seq_params.enable_adaptive_mvd == 0 && mbmi->use_amvd == 1)
-            continue;
-
-          if (is_joint_mvd_coding_mode(this_mode) &&
-              cm->seq_params.enable_joint_mvd == 0)
-            continue;
-
-          // Select prediction reference frames.
-          for (i = 0; i < num_planes; i++) {
-            xd->plane[i].pre[0] = yv12_mb[COMPACT_INDEX0_NRS(ref_frame)][i];
-            if (comp_pred)
-              xd->plane[i].pre[1] =
-                  yv12_mb[COMPACT_INDEX0_NRS(second_ref_frame)][i];
-          }
-
-          mbmi->fsc_mode[PLANE_TYPE_Y] = 0;
-          mbmi->fsc_mode[PLANE_TYPE_UV] = 0;
-          mbmi->use_intrabc[0] = 0;
-          mbmi->use_intrabc[1] = 0;
-          mbmi->angle_delta[PLANE_TYPE_Y] = 0;
-          mbmi->angle_delta[PLANE_TYPE_UV] = 0;
-          mbmi->use_intra_dip = 0;
-          mbmi->use_dpcm_y = 0;
-          mbmi->dpcm_mode_y = 0;
-          mbmi->use_dpcm_uv = 0;
-          mbmi->dpcm_mode_uv = 0;
-          mbmi->ref_mv_idx[0] = 0;
-          mbmi->ref_mv_idx[1] = 0;
-          mbmi->warp_ref_idx = 0;
-          mbmi->max_num_warp_candidates = 0;
-          mbmi->warpmv_with_mvd_flag = 0;
-          const int64_t ref_best_rd = search_state.best_rd;
-          RD_STATS rd_stats, rd_stats_y, rd_stats_uv;
-          av2_init_rd_stats(&rd_stats);
-
-          const int ref_frame_index = COMPACT_INDEX0_NRS(ref_frame);
-
-          const int ref_frame_cost =
-              comp_pred ? ref_costs_comp[ref_frame][second_ref_frame]
-                        : ref_costs_single[ref_frame_index];
-
-          const int compmode_cost =
-              (is_comp_ref_allowed(mbmi->sb_type[PLANE_TYPE_Y]) &&
-               !is_tip_ref_frame(ref_frame))
-                  ? comp_inter_cost[comp_pred]
-                  : 0;
-          const int real_compmode_cost =
-              cm->current_frame.reference_mode == REFERENCE_MODE_SELECT
-                  ? compmode_cost
-                  : 0;
-          // Point to variables that are maintained between loop iterations
-          args.single_newmv = search_state.single_newmv;
-          args.single_newmv_rate = search_state.single_newmv_rate;
-          args.single_newmv_valid = search_state.single_newmv_valid;
-          args.single_comp_cost = real_compmode_cost;
-          args.ref_frame_cost = ref_frame_cost;
-
-          int64_t skip_rd[2] = { search_state.best_skip_rd[0],
-                                 search_state.best_skip_rd[1] };
-
-          int64_t this_rd = handle_inter_mode(
-              cpi, tile_data, x, bsize, &rd_stats, &rd_stats_y, &rd_stats_uv,
-              &args, ref_best_rd, tmp_buf, &x->comp_rd_buffer, &best_est_rd,
-              do_tx_search, inter_modes_info, &motion_mode_cand, skip_rd,
-              search_state.best_mbmode.mode,
-              enable_tx_prune ? top_motion_mode_model_rd : NULL,
-              &inter_cost_info_from_tpl);
-
-          if (sf->inter_sf.prune_comp_search_by_single_result > 0 &&
-              is_inter_singleref_mode(this_mode)) {
-            collect_single_states(cm, x, &search_state, mbmi);
-          }
-
-          if (sf->inter_sf.prune_comp_using_best_single_mode_ref > 0 &&
-              is_inter_singleref_mode(this_mode))
-            update_best_single_mode(&search_state, this_mode, ref_frame,
-                                    this_rd);
-
-          if (this_rd == INT64_MAX) continue;
-          if (mbmi->skip_txfm[xd->tree_type == CHROMA_PART]) {
-            rd_stats_y.rate = 0;
-            rd_stats_uv.rate = 0;
-          }
-
-          if (sf->inter_sf.prune_compound_using_single_ref && is_single_pred &&
-              this_rd < ref_frame_rd[ref_frame_index]) {
-            ref_frame_rd[ref_frame_index] = this_rd;
-          }
-
-          // Did this mode help, i.e., is it the new best mode
-          if (this_rd < search_state.best_rd) {
-            if (is_tip_ref_frame(ref_frame) &&
-                this_rd + TIP_RD_CORRECTION > search_state.best_rd) {
-              continue;
-            }
-            assert(IMPLIES(comp_pred, cm->current_frame.reference_mode !=
-                                          SINGLE_REFERENCE));
-            update_search_state(&search_state, rd_cost, ctx, &rd_stats,
-                                &rd_stats_y, &rd_stats_uv, this_mode, x,
-                                do_tx_search, cm);
-            if (do_tx_search) search_state.best_skip_rd[0] = skip_rd[0];
-            search_state.best_skip_rd[1] = skip_rd[1];
-          }
-          if (cpi->sf.winner_mode_sf.motion_mode_for_winner_cand) {
-            // Add this mode to motion mode candidate list for motion mode
-            // search if using motion_mode_for_winner_cand speed feature
-            handle_winner_cand(mbmi, &best_motion_mode_cands,
-                               max_winner_motion_mode_cand, this_rd,
-                               &motion_mode_cand, args.skip_motion_mode);
-          }
-
-          /* keep record of best compound/single-only prediction */
-          record_best_compound(cm->current_frame.reference_mode, &rd_stats,
-                               comp_pred, x->rdmult, &search_state,
-                               compmode_cost);
-        }  // end of use_amvd mode loop
-      }  // end of ref1 loop
-    }  // end of ref0 loop
-  }  // end of mode loop
-
-  if (cpi->sf.winner_mode_sf.motion_mode_for_winner_cand) {
+  if (motion_mode_winner) {
     // For the single ref winner candidates, evaluate other motion modes (non
     // simple translation).
     evaluate_motion_mode_for_winner_candidates(

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -1388,7 +1388,7 @@ static int64_t handle_newmv(const AV2_COMP *const cpi, MACROBLOCK *const x,
                        is_pb_mv_precision_active(&cpi->common, mbmi, bsize);
     if (do_refine_ms) {
       int valid_mv0_found = 0;
-      for (int prev_mv_precision = pb_mv_precision;
+      for (int prev_mv_precision = pb_mv_precision + 1;
            prev_mv_precision <= mbmi->max_mv_precision; prev_mv_precision++) {
         assert(get_ref_mv_idx(mbmi, 1) == get_ref_mv_idx(mbmi, 0));
         if (args->single_newmv_valid[prev_mv_precision][get_ref_mv_idx(mbmi, 0)]

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -2960,11 +2960,15 @@ static AVM_INLINE int evaluate_motion_mode_trial(
                                 &tmp_rate2) < 0)
       return -1;
   } else if (mbmi->motion_mode == INTERINTRA) {
+    if (cpi->sf.inter_sf.prune_interintra_by_ref_idx && mbmi->ref_frame[0] > 1)
+      return -1;
     if (av2_handle_inter_intra_mode(cpi, x, bsize, mbmi, args, *ref_best_rd,
                                     &tmp_rate_mv, &tmp_rate2, orig_dst) < 0)
       return -1;
     assert(mbmi->motion_mode == INTERINTRA);
   } else if (mbmi->motion_mode == WARP_DELTA) {
+    if (cpi->sf.inter_sf.prune_warp_delta_by_ref_idx && mbmi->ref_frame[0] > 2)
+      return -1;
     if (handle_warp_delta_mode(
             cpi, x, bsize, mbmi, mbmi_ext, args, *ref_best_rd, orig_dst,
             ctx->previous_mvs, ctx->prev_best_models, org_warp_inter_intra,
@@ -5021,6 +5025,12 @@ static void evaluate_inter_predictor(AV2_COMP *const cpi,
     }
   }
   restore_dst_buf(xd, *env->orig_dst, num_planes);
+  // motion_mode_rd() may leave mbmi->motion_mode set to a non-SIMPLE
+  // winner. The winning value has already been captured into
+  // search_state->best_mbmi and winner_mode_stats above. Restore here so
+  // the outer caller (handle_inter_mode) sees SIMPLE_TRANSLATION at the
+  // top of its next per-precision iteration.
+  mbmi->motion_mode = SIMPLE_TRANSLATION;
 }
 
 /*!\brief AV2 inter mode RD computation
@@ -5630,6 +5640,11 @@ static int64_t handle_inter_mode(
                     &base_mbmi, 0, num_planes, args->skip_motion_mode);
                 for (int refinemv_loop = 0; refinemv_loop < REFINEMV_NUM_MODES;
                      refinemv_loop++) {
+                  if (refinemv_loop == 1 &&
+                      cpi->sf.inter_sf.prune_refinemv_by_ref_idx &&
+                      !(base_mbmi.ref_frame[0] == 0 &&
+                        base_mbmi.ref_frame[1] == 1))
+                    continue;
                   it_ctx.refinemv_loop = refinemv_loop;
                   evaluate_inter_predictor(
                       cpi, tile_data, x, &env, &it_ctx, &search_state,

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -110,6 +110,12 @@ typedef struct SingleInterModeState {
   int valid;
 } SingleInterModeState;
 
+// Returns the index into single_inter_rd[] for a single-ref inter mode.
+static INLINE int single_inter_mode_idx(PREDICTION_MODE mode) {
+  assert(mode >= SINGLE_INTER_MODE_START && mode < SINGLE_INTER_MODE_END);
+  return mode - SINGLE_INTER_MODE_START;
+}
+
 typedef struct InterModeSearchState {
   int64_t best_rd;
   int64_t best_skip_rd[2];
@@ -134,6 +140,12 @@ typedef struct InterModeSearchState {
   int64_t modelled_rd[MB_MODE_COUNT][MAX_REF_MV_SEARCH][SINGLE_REF_FRAMES];
   // The rd of simple translation in single inter modes
   int64_t simple_rd[MB_MODE_COUNT][MAX_REF_MV_SEARCH][SINGLE_REF_FRAMES];
+  // Best fast/full RD per single-ref inter mode, use_amvd option, and
+  // reference frame. Aggregated as the minimum across all motion modes,
+  // ref_mv_idx, MV precisions, bawp, refinemv and jmvd tuples for a given
+  // (mode, use_amvd, ref).
+  InterModeRdPair single_inter_rd[SINGLE_INTER_MODE_NUM][NUM_USE_AMVD_OPTIONS]
+                                 [SINGLE_REF_FRAMES];
   int64_t best_single_rd[SINGLE_REF_FRAMES];
   PREDICTION_MODE best_single_mode[SINGLE_REF_FRAMES];
 
@@ -2156,6 +2168,135 @@ static int prune_motion_mode(int64_t this_model_rd,
          top_motion_mode_model_rd[TOP_MOTION_MODE_MODEL_COUNT - 1];
 }
 
+// Records the best fast/full RD for a given (mode, refs) into the
+// single_inter_rd table in args. is_fast == 1 selects the fast (model-based,
+// pre-transform) slot; is_fast == 0 selects the full (post av2_txfm_search)
+// slot. True compound modes (refs[1] is an inter ref) are not tracked.
+// Interintra (refs[1] == INTRA_FRAME) is folded into the single-ref table
+// via refs[0].
+static AVM_INLINE void update_inter_mode_rd(HandleInterModeArgs *args,
+                                            const MB_MODE_INFO *mbmi,
+                                            int64_t rd, int is_fast) {
+  // Fast path when the consuming speed feature
+  // (prune_newmv_modes_using_prior_rd) is off: caller wires this pointer to
+  // NULL, so the whole tracker collapses to one pointer load + branch.
+  if (args->single_inter_rd == NULL) return;
+  const PREDICTION_MODE this_mode = mbmi->mode;
+  if (has_second_ref(mbmi) && mbmi->ref_frame[1] != INTRA_FRAME) return;
+  if (!is_inter_singleref_mode(this_mode)) return;
+  const int use_amvd = mbmi->use_amvd;
+  assert(use_amvd == 0 || use_amvd == 1);
+  const int rf0 = COMPACT_INDEX0_NRS(mbmi->ref_frame[0]);
+  assert(rf0 >= 0 && rf0 < SINGLE_REF_FRAMES);
+  InterModeRdPair *slot =
+      &args->single_inter_rd[single_inter_mode_idx(this_mode)][use_amvd][rf0];
+  int64_t *p = is_fast ? &slot->fast_rd : &slot->full_rd;
+  if (rd < *p) *p = rd;
+}
+
+// Returns 1 if a single-ref mode (e.g. NEWMV or GLOBALMV) for this ref frame
+// should be skipped because the matching reference RD is not within
+// (1 / slack_denom) of the best reference RD across all ref frames. Decision
+// rule: keep when EITHER full_rd OR fast_rd is within slack of its respective
+// best; prune when neither is (this includes the no-reference-data case).
+// slack_denom = 10 means 10% slack; slack_denom = 4 means 25% slack; lower
+// values are looser.
+static AVM_INLINE int prune_single_by_reference_rd(
+    const InterModeRdPair reference_rd[SINGLE_REF_FRAMES], int this_ref_idx,
+    int slack_denom) {
+  if (this_ref_idx < 0 || this_ref_idx >= SINGLE_REF_FRAMES) return 0;
+  if (slack_denom <= 0) return 0;
+  if (reference_rd[this_ref_idx].full_rd != INT64_MAX) {
+    int64_t best_full = INT64_MAX;
+    for (int r = 0; r < SINGLE_REF_FRAMES; ++r) {
+      if (reference_rd[r].full_rd < best_full)
+        best_full = reference_rd[r].full_rd;
+    }
+    if (reference_rd[this_ref_idx].full_rd <=
+        best_full + best_full / slack_denom) {
+      return 0;
+    }
+  }
+  if (reference_rd[this_ref_idx].fast_rd != INT64_MAX) {
+    int64_t best_fast = INT64_MAX;
+    for (int r = 0; r < SINGLE_REF_FRAMES; ++r) {
+      if (reference_rd[r].fast_rd < best_fast)
+        best_fast = reference_rd[r].fast_rd;
+    }
+    if (reference_rd[this_ref_idx].fast_rd <=
+        best_fast + best_fast / slack_denom) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+// Returns 1 if a single-ref NEWMV / WARP_NEWMV trial for this
+// (this_mode, ref_frame, use_amvd) should be skipped because the best RD
+// seen so far for this ref in a prior mode is far from the best
+// prior-mode RD across all refs. Returns 0 to keep evaluating, including
+// for any mode other than NEWMV / WARP_NEWMV and when the speed feature
+// is off.
+//
+// Exemptions:
+//   - speed feature prune_newmv_modes_using_prior_rd is off.
+//   - NEWMV with ref_frame <= 2 (top refs) or TIP.
+//   - WARP_NEWMV when lag_in_frames == 0.
+//
+// Prior-mode source selection (single_inter_rd is populated by earlier
+// outer-mode-loop iterations of NEARMV / NEWMV / WARPMV):
+//   - NEWMV with use_amvd == 1: prefer NEWMV[*][use_amvd=0] when
+//     populated (use_amvd=0 is searched first in the outer use_amvd
+//     loop), else fall back to NEARMV[*][0].
+//   - NEWMV with use_amvd == 0: NEARMV[*][0].
+//   - WARP_NEWMV: first populated of {NEWMV[*][0], WARPMV[*][0],
+//     NEWMV[*][1], NEARMV[*][0]}. WARP_NEWMV does not support AMVD,
+//     so use_amvd is always 0 here.
+//
+// NEARMV / WARPMV / WARP_NEWMV do not support AMVD, so they are
+// always written to the use_amvd=0 slot.
+static AVM_INLINE int prune_newmv_modes_by_prior_rd(
+    const AV2_COMP *cpi, const InterModeSearchState *search_state,
+    PREDICTION_MODE this_mode, int ref_frame, int use_amvd) {
+  if (!cpi->sf.inter_sf.prune_newmv_modes_using_prior_rd) return 0;
+  if (this_mode != NEWMV && this_mode != WARP_NEWMV) return 0;
+  if (this_mode == NEWMV && (ref_frame <= 2 || is_tip_ref_frame(ref_frame))) {
+    return 0;
+  }
+  if (this_mode == WARP_NEWMV && cpi->oxcf.gf_cfg.lag_in_frames == 0) return 0;
+
+  const int slack_denom = 10;
+  const int rf_idx = COMPACT_INDEX0_NRS(ref_frame);
+  const InterModeRdPair *prior =
+      search_state->single_inter_rd[single_inter_mode_idx(NEARMV)][0];
+  if (this_mode == NEWMV) {
+    if (use_amvd == 1) {
+      const InterModeRdPair *newmv_amvd0 =
+          search_state->single_inter_rd[single_inter_mode_idx(NEWMV)][0];
+      if (newmv_amvd0[rf_idx].full_rd != INT64_MAX ||
+          newmv_amvd0[rf_idx].fast_rd != INT64_MAX) {
+        prior = newmv_amvd0;
+      }
+    }
+    return prune_single_by_reference_rd(prior, rf_idx, slack_denom);
+  }
+
+  // WARP_NEWMV
+  const InterModeRdPair *const candidates[3] = {
+    search_state->single_inter_rd[single_inter_mode_idx(NEWMV)][0],
+    search_state->single_inter_rd[single_inter_mode_idx(WARPMV)][0],
+    search_state->single_inter_rd[single_inter_mode_idx(NEWMV)][1],
+  };
+  for (int cand = 0; cand < 3; ++cand) {
+    if (candidates[cand][rf_idx].full_rd != INT64_MAX ||
+        candidates[cand][rf_idx].fast_rd != INT64_MAX) {
+      prior = candidates[cand];
+      break;
+    }
+  }
+  return prune_single_by_reference_rd(prior, rf_idx, slack_denom);
+}
+
 // Handle SIMPLE_TRANSLATION motion mode: adjust MVD sign if needed.
 // Returns -1 to skip this motion mode iteration, 0 on success.
 static AVM_INLINE int handle_simple_translation_mode(
@@ -2812,6 +2953,7 @@ static AVM_INLINE int evaluate_motion_mode_trial(
     rd_stats->rate += est_residue_cost;
     rd_stats->dist = est_dist;
     rd_stats->rdcost = est_rd;
+    update_inter_mode_rd(args, mbmi, est_rd, 1);
     if (rd_stats->rdcost < *best_est_rd) {
       *best_est_rd = rd_stats->rdcost;
       assert(sse_y >= 0);
@@ -2854,6 +2996,7 @@ static AVM_INLINE int evaluate_motion_mode_trial(
           NULL, &curr_sse, NULL, NULL, NULL);
       int64_t est_rd =
           RDCOST(x->rdmult, rd_stats->rate + est_residue_cost, est_dist);
+      update_inter_mode_rd(args, mbmi, est_rd, 1);
       if (prune_motion_mode(est_rd, top_motion_mode_model_rd, cm, xd, bsize))
         return -1;
     }
@@ -2868,6 +3011,7 @@ static AVM_INLINE int evaluate_motion_mode_trial(
       return -1;
     }
     const int64_t curr_rd = RDCOST(x->rdmult, rd_stats->rate, rd_stats->dist);
+    update_inter_mode_rd(args, mbmi, curr_rd, 0);
     if (curr_rd < *ref_best_rd) {
       *ref_best_rd = curr_rd;
       ref_skip_rd[0] = skip_rd;
@@ -7142,6 +7286,17 @@ static AVM_INLINE void init_inter_mode_search_state(
     }
   }
 
+  if (cpi->sf.inter_sf.prune_newmv_modes_using_prior_rd) {
+    for (int m = 0; m < SINGLE_INTER_MODE_NUM; ++m) {
+      for (int u = 0; u < NUM_USE_AMVD_OPTIONS; ++u) {
+        for (int r = 0; r < SINGLE_REF_FRAMES; ++r) {
+          search_state->single_inter_rd[m][u][r].fast_rd = INT64_MAX;
+          search_state->single_inter_rd[m][u][r].full_rd = INT64_MAX;
+        }
+      }
+    }
+  }
+
   for (int dir = 0; dir < 2; ++dir) {
     for (int mode = 0; mode < SINGLE_INTER_MODE_NUM; ++mode) {
       for (int ref_frame = 0; ref_frame < SINGLE_REF_FRAMES; ++ref_frame) {
@@ -7980,7 +8135,7 @@ static void tx_search_best_inter_candidates(
     int64_t best_rd_so_far, BLOCK_SIZE bsize,
     struct buf_2d yv12_mb[SINGLE_REF_FRAMES][MAX_MB_PLANE], int mi_row,
     int mi_col, InterModeSearchState *search_state, RD_STATS *rd_cost,
-    PICK_MODE_CONTEXT *ctx) {
+    PICK_MODE_CONTEXT *ctx, HandleInterModeArgs *args) {
   AV2_COMMON *const cm = &cpi->common;
   MACROBLOCKD *const xd = &x->e_mbd;
   TxfmSearchInfo *txfm_info = &x->txfm_search_info;
@@ -8070,6 +8225,7 @@ static void tx_search_best_inter_candidates(
                   [skip_ctx][mbmi->skip_txfm[xd->tree_type == CHROMA_PART]]);
     }
     rd_stats.rdcost = RDCOST(x->rdmult, rd_stats.rate, rd_stats.dist);
+    update_inter_mode_rd(args, mbmi, rd_stats.rdcost, 0);
 
     const MV_REFERENCE_FRAME refs[2] = { mbmi->ref_frame[0],
                                          mbmi->ref_frame[1] };
@@ -8484,6 +8640,9 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
     INT_MAX,
     INT_MAX,
     search_state.simple_rd,
+    cpi->sf.inter_sf.prune_newmv_modes_using_prior_rd
+        ? search_state.single_inter_rd
+        : NULL,
     0,
     interintra_modes,
     { { 0, { { 0 } }, { 0 }, 0, 0, 0 } },
@@ -8905,6 +9064,15 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
         continue;
       }
 
+      // Skip single-ref NEWMV / WARP_NEWMV when prior-mode RD for this
+      // ref frame is far from the best across all refs. See
+      // prune_newmv_modes_by_prior_rd() for source selection and
+      // exemptions.
+      if (prune_newmv_modes_by_prior_rd(cpi, &search_state, this_mode,
+                                        ref_frame, mbmi->use_amvd)) {
+        continue;
+      }
+
       txfm_info->skip_txfm = 0;
 
       const int64_t ref_best_rd = search_state.best_rd;
@@ -8990,7 +9158,7 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
     // top mode candidates
     tx_search_best_inter_candidates(cpi, tile_data, x, best_rd_so_far, bsize,
                                     yv12_mb, mi_row, mi_col, &search_state,
-                                    rd_cost, ctx);
+                                    rd_cost, ctx, &args);
   }
 #if CONFIG_COLLECT_COMPONENT_TIMING
   end_timing(cpi, do_tx_search_time);

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -7717,18 +7717,6 @@ static INLINE int skip_compound_using_best_single_mode_ref(
   return 1;
 }
 
-static int compare_int64(const void *a, const void *b) {
-  int64_t a64 = *((int64_t *)a);
-  int64_t b64 = *((int64_t *)b);
-  if (a64 < b64) {
-    return -1;
-  } else if (a64 == b64) {
-    return 0;
-  } else {
-    return 1;
-  }
-}
-
 static INLINE void update_search_state(
     InterModeSearchState *search_state, RD_STATS *best_rd_stats_dst,
     PICK_MODE_CONTEXT *ctx, const RD_STATS *new_best_rd_stats,
@@ -7773,31 +7761,21 @@ static INLINE void update_search_state(
                  ctx->num_4x4_blk_chroma);
 }
 
-// Find the best RD for a reference frame (among single reference modes)
-// and store +10% of it in the 0-th (or last for NRS) element in ref_frame_rd.
-static AVM_INLINE void find_top_ref(int64_t *ref_frame_rd) {
-  int64_t ref_copy[MAX_COMPOUND_REF_INDEX - 1];
-  assert(ref_frame_rd[INTRA_FRAME_INDEX] == INT64_MAX);
-  memcpy(ref_copy, ref_frame_rd,
-         sizeof(ref_frame_rd[0]) * (MAX_COMPOUND_REF_INDEX - 1));
-  qsort(ref_copy, MAX_COMPOUND_REF_INDEX - 1, sizeof(int64_t), compare_int64);
-
-  int64_t cutoff = AVMMIN(ref_copy[0], ref_frame_rd[TIP_FRAME_INDEX]);
-  // The cut-off is within 10% of the best.
+// Check if either ref frame is within a ~10% cutoff of the best single-ref-mode
+// RD seen so far. best_single_mode_rd is INT64_MAX until any single-ref mode
+// has completed, in which case both refs pass.
+static INLINE bool in_single_ref_cutoff(const int64_t *ref_frame_rd,
+                                        int64_t best_single_mode_rd,
+                                        MV_REFERENCE_FRAME frame1,
+                                        MV_REFERENCE_FRAME frame2) {
+  assert(is_inter_ref_frame(frame2));
+  int64_t cutoff = best_single_mode_rd;
+  // Keep the cut-off within 10% of the best.
   if (cutoff != INT64_MAX) {
     assert(cutoff < INT64_MAX / 200);
     cutoff = (110 * cutoff) / 100;
   }
-  ref_frame_rd[INTRA_FRAME_INDEX] = cutoff;
-}
-
-// Check if either frame is within the cutoff.
-static INLINE bool in_single_ref_cutoff(int64_t *ref_frame_rd,
-                                        MV_REFERENCE_FRAME frame1,
-                                        MV_REFERENCE_FRAME frame2) {
-  assert(is_inter_ref_frame(frame2));
-  return ref_frame_rd[frame1] <= ref_frame_rd[INTRA_FRAME_INDEX] ||
-         ref_frame_rd[frame2] <= ref_frame_rd[INTRA_FRAME_INDEX];
+  return ref_frame_rd[frame1] <= cutoff || ref_frame_rd[frame2] <= cutoff;
 }
 
 static AVM_INLINE void evaluate_motion_mode_for_winner_candidates(
@@ -7886,12 +7864,12 @@ typedef struct {
   uint64_t skip_ref_frame_mask;
   int reach_first_comp_mode;
   int mode_thresh_mul_fact;
-  int *num_single_modes_processed;
-  int prune_cpd_using_sr_stats_ready;
 } InterModeSFArgs;
 /*!\endcond */
 
-static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, int64_t *ref_frame_rd,
+static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x,
+                           const int64_t *ref_frame_rd,
+                           int64_t best_single_mode_rd,
                            PREDICTION_MODE this_mode,
                            const MV_REFERENCE_FRAME *ref_frames,
                            InterModeSFArgs *args) {
@@ -7940,18 +7918,13 @@ static int skip_inter_mode(AV2_COMP *cpi, MACROBLOCK *x, int64_t *ref_frame_rd,
   }
 
   if (sf->inter_sf.prune_compound_using_single_ref) {
-    // After we done with single reference modes, find the 2nd best RD
-    // for a reference frame. Only search compound modes that have a reference
-    // frame at least as good as 110% the best one.
-    if (!args->prune_cpd_using_sr_stats_ready &&
-        *args->num_single_modes_processed ==
-            cpi->common.ref_frames_info.num_total_refs *
-                SINGLE_INTER_MODE_NUM) {
-      find_top_ref(ref_frame_rd);
-      args->prune_cpd_using_sr_stats_ready = 1;
-    }
-    if (args->prune_cpd_using_sr_stats_ready &&
-        !in_single_ref_cutoff(ref_frame_rd, ref_frame, second_ref_frame))
+    // Prune compound modes whose refs are not within the ~10% cutoff of the
+    // best single-ref-mode RD seen so far.
+    if (!(ref_frame < sf->inter_sf.skip_compound_prune_top_refs_num_ref0 &&
+          second_ref_frame <
+              sf->inter_sf.skip_compound_prune_top_refs_num_ref1) &&
+        !in_single_ref_cutoff(ref_frame_rd, best_single_mode_rd, ref_frame,
+                              second_ref_frame))
       return 1;
   }
 
@@ -8659,18 +8632,19 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
   InterModesInfo *inter_modes_info = x->inter_modes_info;
   inter_modes_info->num = 0;
 
-  int num_single_modes_processed = 0;
-
   // Temporary buffers used by handle_inter_mode().
   uint16_t *const tmp_buf = x->tmp_pred_bufs[0];
 
   // The best RD found for the reference frame, among single reference modes.
-  // Note that the 0-th element will contain a cut-off that is later used
-  // to determine if we should skip a compound mode.
+  // Read by in_single_ref_cutoff() to check whether either ref of a compound
+  // trial is within ~10% of the best single-ref-mode RD.
 
   int64_t ref_frame_rd[SINGLE_REF_FRAMES] = { INT64_MAX, INT64_MAX, INT64_MAX,
                                               INT64_MAX, INT64_MAX, INT64_MAX,
                                               INT64_MAX, INT64_MAX, INT64_MAX };
+  // Running minimum RD across all single-ref inter modes evaluated so far.
+  // Used as the anchor for the single-ref cutoff in in_single_ref_cutoff().
+  int64_t best_single_mode_rd = INT64_MAX;
 
   // Prepared stats used later to check if we could skip intra mode eval.
   int64_t inter_cost = -1;
@@ -8755,9 +8729,7 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
                               &search_state,
                               skip_ref_frame_mask,
                               0,
-                              mode_thresh_mul_fact,
-                              &num_single_modes_processed,
-                              0 };
+                              mode_thresh_mul_fact };
 
   const uint8_t enable_tx_prune = do_tx_search;
   // Pool of top model RDs used by prune_motion_mode(). When
@@ -8900,7 +8872,8 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
 
     set_ref_ptrs(cm, xd, ref_frame, second_ref_frame);
 
-    if (skip_inter_mode(cpi, x, ref_frame_rd, this_mode, ref_frames, &sf_args))
+    if (skip_inter_mode(cpi, x, ref_frame_rd, best_single_mode_rd, this_mode,
+                        ref_frames, &sf_args))
       continue;
 
     // Select prediction reference frames.
@@ -8932,7 +8905,6 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
         continue;
       }
 
-      num_single_modes_processed += is_single_pred;
       txfm_info->skip_txfm = 0;
 
       const int64_t ref_best_rd = search_state.best_rd;
@@ -8963,9 +8935,11 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
       if (is_single_pred) {
         if (prune_comp_best_single)
           update_best_single_mode(&search_state, this_mode, ref_frame, this_rd);
-        if (prune_comp_using_single_ref &&
-            this_rd < ref_frame_rd[ref_frame_index])
-          ref_frame_rd[ref_frame_index] = this_rd;
+        if (prune_comp_using_single_ref) {
+          if (this_rd < ref_frame_rd[ref_frame_index])
+            ref_frame_rd[ref_frame_index] = this_rd;
+          if (this_rd < best_single_mode_rd) best_single_mode_rd = this_rd;
+        }
       }
 
       if (mbmi->skip_txfm[xd->tree_type == CHROMA_PART]) {

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -1651,7 +1651,7 @@ static INLINE int select_modes_to_search(const AV2_COMP *const cpi,
   // the motion_mode_for_winner_cand speed feature, avoid searching it again.
   if (cpi->sf.winner_mode_sf.motion_mode_for_winner_cand) {
     if (!eval_motion_mode) {
-      modes_to_search = (1 << SIMPLE_TRANSLATION);
+      modes_to_search |= (1 << SIMPLE_TRANSLATION);
     } else {
       // Skip translation, as will have already been evaluated
       modes_to_search &= ~(1 << SIMPLE_TRANSLATION);
@@ -2533,7 +2533,8 @@ static AVM_INLINE int handle_warp_delta_mode(
     MB_MODE_INFO_EXT *mbmi_ext, HandleInterModeArgs *args, int64_t ref_best_rd,
     const BUFFER_SET *orig_dst, int_mv *previous_mvs,
     warp_mode_info_array *prev_best_models, int org_warp_inter_intra,
-    int rate2_nocoeff, int rate_mv0, int *tmp_rate_mv, int *tmp_rate2) {
+    int rate2_nocoeff, int rate_mv0, int *tmp_rate_mv, int *tmp_rate2,
+    int eval_motion_mode) {
   const AV2_COMMON *cm = &cpi->common;
   MACROBLOCKD *xd = &x->e_mbd;
   const int mi_row = xd->mi_row;
@@ -2579,6 +2580,8 @@ static AVM_INLINE int handle_warp_delta_mode(
   if (!allow_warp_parameter_signaling(cm, mbmi)) {
     if (mbmi->warp_precision_idx) return -1;
 
+    // Default parameters are not searched if the delta is not
+    // signalled
     if (mbmi_ext
             ->warp_param_stack[av2_ref_frame_type(mbmi->ref_frame)]
                               [mbmi->warp_ref_idx]
@@ -2595,14 +2598,23 @@ static AVM_INLINE int handle_warp_delta_mode(
         mbmi->mv[0].as_int = previous_mvs[mbmi->warp_ref_idx].as_int;
       }
     }
-    valid = av2_refine_mv_for_base_param_warp_model(
-        cm, xd, mbmi, mbmi_ext, &ms_params, cpi->sf.mv_sf.warp_search_method,
-        cpi->sf.mv_sf.warp_search_iters);
+    if (!cpi->sf.part_sf.enable_six_param_warp_in_winner_mode ||
+        !eval_motion_mode)
+      valid = av2_refine_mv_for_base_param_warp_model(
+          cm, xd, mbmi, mbmi_ext, &ms_params, cpi->sf.mv_sf.warp_search_method,
+          cpi->sf.mv_sf.warp_search_iters);
   } else {
     mbmi->six_param_warp_model_flag = get_default_six_param_flag(cm, mbmi);
-    valid = av2_pick_warp_delta(
-        cm, xd, mbmi, &ms_params, &x->mode_costs, prev_best_models,
-        mbmi_ext->warp_param_stack[av2_ref_frame_type(mbmi->ref_frame)]);
+    const int six_param_enabled_by_tid =
+        mbmi->six_param_warp_model_flag &&
+        cpi->sf.part_sf.enable_six_param_warp_in_winner_mode_by_tid;
+    const bool use_six_param_in_winner =
+        (eval_motion_mode == six_param_enabled_by_tid);
+    if (use_six_param_in_winner ||
+        !cpi->sf.part_sf.enable_six_param_warp_in_winner_mode)
+      valid = av2_pick_warp_delta(
+          cm, xd, mbmi, &ms_params, &x->mode_costs, prev_best_models,
+          mbmi_ext->warp_param_stack[av2_ref_frame_type(mbmi->ref_frame)]);
   }
 
   if (!valid) return -1;
@@ -2913,7 +2925,7 @@ static AVM_INLINE int evaluate_motion_mode_trial(
     int do_tx_search, InterModesInfo *inter_modes_info,
     int64_t top_motion_mode_model_rd[], const MB_MODE_INFO *base_mbmi,
     const MotionModeTrialParams *trial, const MotionModeTrialCtx *ctx,
-    MotionModeBestState *best) {
+    MotionModeBestState *best, int eval_motion_mode) {
   const AV2_COMMON *const cm = &cpi->common;
   TxfmSearchInfo *txfm_info = &x->txfm_search_info;
   const int num_planes = av2_num_planes(cm);
@@ -2969,10 +2981,11 @@ static AVM_INLINE int evaluate_motion_mode_trial(
   } else if (mbmi->motion_mode == WARP_DELTA) {
     if (cpi->sf.inter_sf.prune_warp_delta_by_ref_idx && mbmi->ref_frame[0] > 2)
       return -1;
-    if (handle_warp_delta_mode(
-            cpi, x, bsize, mbmi, mbmi_ext, args, *ref_best_rd, orig_dst,
-            ctx->previous_mvs, ctx->prev_best_models, org_warp_inter_intra,
-            ctx->rate2_nocoeff, ctx->rate_mv0, &tmp_rate_mv, &tmp_rate2) < 0)
+    if (handle_warp_delta_mode(cpi, x, bsize, mbmi, mbmi_ext, args,
+                               *ref_best_rd, orig_dst, ctx->previous_mvs,
+                               ctx->prev_best_models, org_warp_inter_intra,
+                               ctx->rate2_nocoeff, ctx->rate_mv0, &tmp_rate_mv,
+                               &tmp_rate2, eval_motion_mode) < 0)
       return -1;
   } else if (mbmi->motion_mode == WARP_EXTEND) {
     if (handle_warp_extend_mode(cpi, x, bsize, mbmi, mbmi_ext,
@@ -3265,7 +3278,10 @@ static int64_t motion_mode_rd(
   for (int mode_index = SIMPLE_TRANSLATION; mode_index < mode_index_end;
        mode_index++) {
     if ((modes_to_search & (1 << mode_index)) == 0) continue;
-
+    if (cpi->sf.part_sf.enable_six_param_warp_in_winner_mode &&
+        eval_motion_mode &&
+        (mode_index == WARP_CAUSAL || mode_index == WARP_EXTEND))
+      continue;
     const int warp_ref_idx_limit =
         get_warp_ref_idx_limit(xd, &base_mbmi, mbmi_ext, mode_index);
 
@@ -3278,7 +3294,7 @@ static int64_t motion_mode_rd(
           cpi, tile_data, x, bsize, rd_stats, rd_stats_y, rd_stats_uv, args,
           &ref_best_rd, ref_skip_rd, orig_dst, best_est_rd, do_tx_search,
           inter_modes_info, top_motion_mode_model_rd, &base_mbmi, &trial, &ctx,
-          &best);
+          &best, eval_motion_mode);
       if (ret > 0) return INT64_MAX;
     } else if (base_mbmi.mode == WARPMV) {
       // WARP_DELTA + WARPMV: iterate warp_inter_intra × ref_idx × mvd_flag
@@ -3304,7 +3320,7 @@ static int64_t motion_mode_rd(
                 cpi, tile_data, x, bsize, rd_stats, rd_stats_y, rd_stats_uv,
                 args, &ref_best_rd, ref_skip_rd, orig_dst, best_est_rd,
                 do_tx_search, inter_modes_info, top_motion_mode_model_rd,
-                &base_mbmi, &trial, &ctx, &best);
+                &base_mbmi, &trial, &ctx, &best, eval_motion_mode);
             if (ret > 0) return INT64_MAX;
           }
         }
@@ -3329,7 +3345,7 @@ static int64_t motion_mode_rd(
               cpi, tile_data, x, bsize, rd_stats, rd_stats_y, rd_stats_uv, args,
               &ref_best_rd, ref_skip_rd, orig_dst, best_est_rd, do_tx_search,
               inter_modes_info, top_motion_mode_model_rd, &base_mbmi, &trial,
-              &ctx, &best);
+              &ctx, &best, eval_motion_mode);
           if (ret > 0) return INT64_MAX;
         }
       }
@@ -8327,8 +8343,16 @@ static void tx_search_best_inter_candidates(
 }
 
 // Indicates number of winner simple translation modes to be used
-static const unsigned int num_winner_motion_modes[3] = { 0, 10, 3 };
+static const unsigned int num_winner_motion_modes[3] = { 0, 10, 6 };
 
+// Returns true if a mode is added to the winner mode check.
+static AVM_INLINE int is_check_in_winner(AV2_COMP *cpi,
+                                         MB_MODE_INFO *const mbmi) {
+  if (!cpi->sf.part_sf.enable_six_param_warp_in_winner_mode) return 0;
+  PREDICTION_MODE this_mode = mbmi->mode;
+  if (this_mode == WARP_NEWMV) return 1;
+  return 0;
+}
 // Adds a motion mode to the candidate list for motion_mode_for_winner_cand
 // speed feature. This list consists of modes that have only searched
 // SIMPLE_TRANSLATION. The final list will be used to search other motion
@@ -9200,7 +9224,7 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
         if (do_tx_search) search_state.best_skip_rd[0] = skip_rd[0];
         search_state.best_skip_rd[1] = skip_rd[1];
       }
-      if (motion_mode_winner) {
+      if (motion_mode_winner && is_check_in_winner(cpi, mbmi)) {
         handle_winner_cand(mbmi, &best_motion_mode_cands,
                            max_winner_motion_mode_cand, this_rd,
                            &motion_mode_cand, args.skip_motion_mode);

--- a/av2/encoder/rdopt.h
+++ b/av2/encoder/rdopt.h
@@ -31,7 +31,7 @@ extern "C" {
 #define COMP_TYPE_RD_THRESH_SCALE 11
 #define COMP_TYPE_RD_THRESH_SHIFT 4
 #define MAX_WINNER_MOTION_MODES 10
-#define TOP_MOTION_MODE_MODEL_COUNT 10
+#define TOP_MOTION_MODE_MODEL_COUNT 11
 
 struct TileInfo;
 struct macroblock;

--- a/av2/encoder/rdopt_utils.h
+++ b/av2/encoder/rdopt_utils.h
@@ -199,11 +199,6 @@ static INLINE int is_winner_mode_processing_enabled(
         sf->tx_sf.tx_type_search.fast_inter_tx_type_search &&
         !cpi->oxcf.txfm_cfg.use_inter_dct_only)
       return 1;
-  } else {
-    if (sf->tx_sf.tx_type_search.fast_intra_tx_type_search &&
-        !cpi->oxcf.txfm_cfg.use_intra_default_tx_only &&
-        !cpi->oxcf.txfm_cfg.use_intra_dct_only)
-      return 1;
   }
 
   // Check speed feature related to winner mode processing
@@ -315,8 +310,7 @@ static INLINE void set_mode_eval_params(const struct AV2_COMP *cpi,
       break;
     case MODE_EVAL:
       txfm_params->use_default_intra_tx_type =
-          (cpi->sf.tx_sf.tx_type_search.fast_intra_tx_type_search ||
-           cpi->oxcf.txfm_cfg.use_intra_default_tx_only);
+          cpi->oxcf.txfm_cfg.use_intra_default_tx_only;
       txfm_params->use_default_inter_tx_type =
           cpi->sf.tx_sf.tx_type_search.fast_inter_tx_type_search;
       txfm_params->skip_txfm_level =

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -344,6 +344,17 @@ static void set_good_speed_features_framesize_independent(
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
 
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 2 : 1;
+
+    // Skip the second-best full-pel candidate's subpel refinement in the
+    // single-ref NEWMV search.
+    sf->mv_sf.skip_second_best_subpel = 1;
+
+    // Predictive single-ref NEWMV reuse across the DRL.
+    sf->mv_sf.predict_repeated_newmv = 1;
+
+    // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
+    // nearest searched result beyond the cap.
+    sf->mv_sf.newmv_drl_search_limit = 2;
   }
 
   if (speed >= 2) {
@@ -655,6 +666,9 @@ static AVM_INLINE void init_mv_sf(MV_SPEED_FEATURES *mv_sf) {
   mv_sf->exhaustive_searches_thresh = 0;
   mv_sf->prune_mesh_search = 0;
   mv_sf->reduce_search_range = 0;
+  mv_sf->skip_second_best_subpel = 0;
+  mv_sf->predict_repeated_newmv = 0;
+  mv_sf->newmv_drl_search_limit = 0;
   mv_sf->search_method = NSTEP;
   mv_sf->simple_motion_subpel_force_stop = EIGHTH_PEL;
   mv_sf->subpel_force_stop = EIGHTH_PEL;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -199,10 +199,6 @@ static void set_good_speed_feature_framesize_dependent(
   if (speed >= 3) {
     sf->part_sf.use_square_partition_only_threshold = BLOCK_128X128;
 
-    if (is_480p_or_larger) {
-      sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 1;
-    }
-
     sf->part_sf.ml_early_term_after_part_split_level = 0;
 
     if (is_720p_or_larger) {
@@ -223,7 +219,7 @@ static void set_good_speed_feature_framesize_dependent(
     }
 
     if (is_480p_or_larger) {
-      sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 2;
+      sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 1;
     }
   }
 
@@ -326,8 +322,6 @@ static void set_good_speed_features_framesize_independent(
   sf->tx_sf.model_based_prune_tx_search_level = 1;
   sf->tx_sf.prune_tx_rd_eval_sec_tx_sse = true;
   sf->tx_sf.tx_type_search.use_reduced_intra_txset = 1;
-  sf->tx_sf.tx_type_search.skip_stx_search = 0;
-  sf->tx_sf.tx_type_search.skip_cctx_search = 0;
 
   if (cpi->twopass.fr_content_type == FC_HIGHMOTION ||
       cpi->is_screen_content_type) {
@@ -355,6 +349,9 @@ static void set_good_speed_features_framesize_independent(
     // speed feature accordingly
     sf->part_sf.simple_motion_search_split = allow_screen_content_tools ? 1 : 2;
 
+    sf->part_sf.disable_uneven_4way_partitions = true;
+    sf->part_sf.disable_ext_partitions = true;
+
     if (cpi->twopass.fr_content_type == FC_HIGHMOTION ||
         cpi->is_screen_content_type) {
       sf->mv_sf.exhaustive_searches_thresh = (1 << 21);
@@ -376,17 +373,13 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.selective_ref_frame = 2;
     sf->inter_sf.skip_repeated_newmv = 1;
 
-    sf->interp_sf.use_interp_filter = 1;
     sf->intra_sf.prune_palette_search_level = 1;
-    sf->intra_sf.skip_intra_dip_search = true;
 
     sf->tx_sf.adaptive_tx_type_search_idx = 4;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
     sf->tx_sf.model_based_prune_tx_search_level = 0;
     sf->tx_sf.tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_2;
-    sf->tx_sf.tx_type_search.skip_tx_search = 1;
 
-    sf->rd_sf.disable_tcq = 1;
     sf->rd_sf.perform_coeff_opt = boosted ? 2 : 3;
     sf->rd_sf.tx_domain_dist_level = boosted ? 1 : 2;
     sf->rd_sf.tx_domain_dist_thres_level = 1;
@@ -399,6 +392,14 @@ static void set_good_speed_features_framesize_independent(
   }
 
   if (speed >= 3) {
+    // These features are moved down from speed 2
+    // --- Start ---
+    sf->interp_sf.use_interp_filter = 1;
+    sf->tx_sf.tx_type_search.skip_tx_search = 1;
+    sf->intra_sf.skip_intra_dip_search = true;
+    sf->rd_sf.disable_tcq = 1;
+    // --- End ---
+
     sf->hl_sf.high_precision_mv_usage = CURRENT_Q;
     sf->hl_sf.recode_loop = ALLOW_RECODE_KFARFGF;
 
@@ -417,7 +418,6 @@ static void set_good_speed_features_framesize_independent(
     sf->mv_sf.full_pixel_search_level = 1;
     sf->mv_sf.simple_motion_subpel_force_stop = QUARTER_PEL;
     sf->mv_sf.subpel_search_method = SUBPEL_TREE_PRUNED;
-    sf->mv_sf.search_method = DIAMOND;
 
     sf->gm_sf.num_refinement_steps = 0;
 
@@ -429,19 +429,13 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.comp_inter_joint_search_thresh = BLOCK_SIZES_ALL;
     sf->inter_sf.disable_wedge_search_var_thresh = 100;
     sf->inter_sf.fast_interintra_wedge_search = 1;
-    sf->inter_sf.prune_compound_using_neighbors = 1;
     sf->inter_sf.prune_comp_type_by_comp_avg = 2;
     sf->inter_sf.disable_sb_level_mv_cost_upd = 1;
-    // TODO(yunqing): evaluate this speed feature for speed 1 & 2, and combine
-    // it with cpi->sf.disable_wedge_search_var_thresh.
-    sf->inter_sf.disable_wedge_interintra_search = 1;
-    sf->inter_sf.disable_smooth_interintra = boosted ? 0 : 1;
     // TODO(any): Experiment with the early exit mechanism for speeds 0, 1 and 2
     // and clean-up the speed feature
     sf->inter_sf.perform_best_rd_based_gating_for_chroma = 1;
     sf->inter_sf.prune_inter_modes_based_on_tpl = boosted ? 0 : 1;
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 4 : 2;
-    sf->inter_sf.selective_ref_frame = 4;
     sf->inter_sf.skip_repeated_ref_mv = 1;
     sf->inter_sf.skip_repeated_full_newmv = 1;
     // TODO(any): Set this speed feature to 2 after correcting the match
@@ -462,8 +456,6 @@ static void set_good_speed_features_framesize_independent(
     sf->tpl_sf.subpel_force_stop = QUARTER_PEL;
     sf->tpl_sf.search_method = DIAMOND;
 
-    sf->tx_sf.tx_type_search.skip_stx_search = 1;
-    sf->tx_sf.tx_type_search.skip_cctx_search = 1;
     sf->tx_sf.adaptive_tx_type_search_idx = boosted ? 4 : 5;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = boosted ? 4 : 5;
     sf->tx_sf.tx_type_search.use_skip_flag_prediction = 2;
@@ -497,12 +489,7 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.txfm_rd_gate_level = boosted ? 0 : 4;
 
     sf->inter_sf.prune_inter_modes_based_on_tpl = boosted ? 0 : 3;
-    sf->inter_sf.prune_compound_using_neighbors = 2;
     sf->inter_sf.prune_comp_using_best_single_mode_ref = 2;
-    sf->inter_sf.disable_smooth_interintra = 1;
-    sf->inter_sf.disable_onesided_comp = 1;
-
-    sf->interp_sf.use_interp_filter = 2;
 
     sf->intra_sf.intra_uv_mode_mask[TX_16X16] = UV_INTRA_DC_H_V_CFL;
     sf->intra_sf.intra_uv_mode_mask[TX_32X32] = UV_INTRA_DC_H_V_CFL;
@@ -514,21 +501,18 @@ static void set_good_speed_features_framesize_independent(
     // presets as well
     sf->intra_sf.skip_intra_in_interframe = 2;
 
-    sf->mv_sf.simple_motion_subpel_force_stop = HALF_PEL;
-
     sf->tpl_sf.prune_starting_mv = 2;
     sf->tpl_sf.subpel_force_stop = HALF_PEL;
     sf->tpl_sf.search_method = FAST_BIGDIA;
 
     sf->tx_sf.tx_type_search.winner_mode_tx_type_pruning = 1;
-    sf->tx_sf.tx_type_search.fast_intra_tx_type_search = 1;
-    sf->tx_sf.tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_3;
+    sf->tx_sf.tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_2;
     sf->tx_sf.tx_type_search.prune_tx_type_est_rd = 1;
 
     sf->rd_sf.perform_coeff_opt = is_boosted_arf2_bwd_type ? 3 : 5;
     sf->rd_sf.perform_coeff_opt_based_on_satd =
         is_boosted_arf2_bwd_type ? 1 : 2;
-    sf->rd_sf.tx_domain_dist_thres_level = 2;
+    sf->rd_sf.tx_domain_dist_thres_level = 1;
 
     // TODO(any): Extend multi-winner mode processing support for inter frames
     sf->winner_mode_sf.multi_winner_mode_type =
@@ -553,15 +537,10 @@ static void set_good_speed_features_framesize_independent(
         frame_is_intra_only(&cpi->common) ? MULTI_WINNER_MODE_FAST
                                           : MULTI_WINNER_MODE_OFF;
 
-    sf->lpf_sf.disable_lr_filter = 1;
-
     sf->mv_sf.prune_mesh_search = 1;
     sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
 
     sf->tpl_sf.prune_starting_mv = 3;
-
-    sf->winner_mode_sf.dc_blk_pred_level = 1;
-    sf->winner_mode_sf.tx_size_search_level = USE_LARGESTALL;
   }
 
   if (speed >= 6) {
@@ -661,6 +640,8 @@ static AVM_INLINE void init_part_sf(PARTITION_SPEED_FEATURES *part_sf) {
   part_sf->prune_split_ml_level = -2;  // default pruning
   part_sf->prune_split_ml_level_inter = -1;
 #endif  // CONFIG_ML_PART_SPLIT
+  part_sf->disable_ext_partitions = false;
+  part_sf->disable_uneven_4way_partitions = false;
 }
 
 static AVM_INLINE void init_mv_sf(MV_SPEED_FEATURES *mv_sf) {
@@ -717,16 +698,12 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->skip_repeated_full_newmv = 0;
   inter_sf->inter_mode_rd_model_estimation = 0;
   inter_sf->prune_compound_using_single_ref = 0;
-  inter_sf->prune_compound_using_neighbors = 0;
   inter_sf->prune_comp_using_best_single_mode_ref = 0;
-  inter_sf->disable_onesided_comp = 0;
   inter_sf->prune_mode_search_simple_translation = 0;
   inter_sf->prune_comp_type_by_comp_avg = 0;
   inter_sf->disable_interinter_wedge_newmv_search = 0;
   inter_sf->enable_interinter_diffwtd_newmv_search = 0;
-  inter_sf->disable_smooth_interintra = 0;
   inter_sf->prune_motion_mode_level = 0;
-  inter_sf->disable_wedge_interintra_search = 0;
   inter_sf->fast_interintra_wedge_search = 0;
   inter_sf->prune_comp_type_by_model_rd = 0;
   inter_sf->perform_best_rd_based_gating_for_chroma = 0;
@@ -766,7 +743,6 @@ static AVM_INLINE void init_tx_sf(TX_SPEED_FEATURES *tx_sf) {
   tx_sf->tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_1;
   tx_sf->tx_type_search.use_skip_flag_prediction = 1;
   tx_sf->tx_type_search.use_reduced_intra_txset = 0;
-  tx_sf->tx_type_search.fast_intra_tx_type_search = 0;
   tx_sf->tx_type_search.fast_inter_tx_type_search = 0;
   tx_sf->tx_type_search.skip_tx_search = 0;
   tx_sf->tx_type_search.prune_tx_type_using_stats = 0;
@@ -1047,9 +1023,6 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
     cpi->common.seq_params.enable_masked_compound &=
         !sf->inter_sf.disable_masked_comp;
 
-    if (sf->inter_sf.disable_wedge_interintra_search) {
-      cpi->common.seq_params.seq_enabled_motion_modes &= ~(1 << INTERINTRA);
-    }
     if (sf->intra_sf.skip_intra_dip_search) {
       cpi->common.seq_params.enable_intra_dip = 0;
     }

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -339,6 +339,9 @@ static void set_good_speed_features_framesize_independent(
     // TODO (Yeqing Wu): need to be tuned for speed > 1.
     sf->inter_sf.skip_compound_prune_top_refs_num_ref0 = 1;
     sf->inter_sf.skip_compound_prune_top_refs_num_ref1 = 2;
+    sf->inter_sf.prune_refinemv_by_ref_idx = 1;
+    sf->inter_sf.prune_interintra_by_ref_idx = 1;
+    sf->inter_sf.prune_warp_delta_by_ref_idx = 1;
 
     sf->tx_sf.adaptive_tx_type_search_idx = 4;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
@@ -721,6 +724,9 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->prune_compound_using_single_ref = 0;
   inter_sf->skip_compound_prune_top_refs_num_ref0 = 0;
   inter_sf->skip_compound_prune_top_refs_num_ref1 = 0;
+  inter_sf->prune_refinemv_by_ref_idx = 0;
+  inter_sf->prune_interintra_by_ref_idx = 0;
+  inter_sf->prune_warp_delta_by_ref_idx = 0;
   inter_sf->prune_comp_using_best_single_mode_ref = 0;
   inter_sf->prune_mode_search_simple_translation = 0;
   inter_sf->prune_comp_type_by_comp_avg = 0;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -333,6 +333,7 @@ static void set_good_speed_features_framesize_independent(
   sf->rd_sf.perform_coeff_opt = 1;
   if (speed >= 1) {
     sf->inter_sf.selective_ref_frame = 2;
+    sf->inter_sf.prune_newmv_modes_using_prior_rd = 1;
     sf->inter_sf.share_motion_mode_prune_pool = 1;
     sf->inter_sf.prune_compound_using_single_ref = 1;
     // TODO (Yeqing Wu): need to be tuned for speed > 1.
@@ -687,6 +688,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->reduce_inter_modes = 0;
   inter_sf->alt_ref_search_fp = 0;
   inter_sf->selective_ref_frame = 0;
+  inter_sf->prune_newmv_modes_using_prior_rd = 0;
   inter_sf->share_motion_mode_prune_pool = 0;
   inter_sf->prune_ref_frames = 0;
   inter_sf->disable_wedge_search_var_thresh = 0;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -345,6 +345,7 @@ static void set_good_speed_features_framesize_independent(
 
     sf->tx_sf.adaptive_tx_type_search_idx = 4;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
+    sf->tx_sf.prune_intra_ist_stx_by_zero_eob = true;
 
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 2 : 1;
 
@@ -786,6 +787,7 @@ static AVM_INLINE void init_tx_sf(TX_SPEED_FEATURES *tx_sf) {
   tx_sf->restrict_tx_partition_type_search = 0;
   tx_sf->prune_inter_tx_part_rd_eval = false;
   tx_sf->enable_tx_partition = true;
+  tx_sf->prune_intra_ist_stx_by_zero_eob = false;
 }
 
 static AVM_INLINE void init_rd_sf(RD_CALC_SPEED_FEATURES *rd_sf,

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -334,6 +334,10 @@ static void set_good_speed_features_framesize_independent(
   if (speed >= 1) {
     sf->inter_sf.selective_ref_frame = 2;
     sf->inter_sf.share_motion_mode_prune_pool = 1;
+    sf->inter_sf.prune_compound_using_single_ref = 1;
+    // TODO (Yeqing Wu): need to be tuned for speed > 1.
+    sf->inter_sf.skip_compound_prune_top_refs_num_ref0 = 1;
+    sf->inter_sf.skip_compound_prune_top_refs_num_ref1 = 2;
 
     sf->tx_sf.adaptive_tx_type_search_idx = 4;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
@@ -699,6 +703,8 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->skip_repeated_full_newmv = 0;
   inter_sf->inter_mode_rd_model_estimation = 0;
   inter_sf->prune_compound_using_single_ref = 0;
+  inter_sf->skip_compound_prune_top_refs_num_ref0 = 0;
+  inter_sf->skip_compound_prune_top_refs_num_ref1 = 0;
   inter_sf->prune_comp_using_best_single_mode_ref = 0;
   inter_sf->prune_mode_search_simple_translation = 0;
   inter_sf->prune_comp_type_by_comp_avg = 0;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -300,7 +300,6 @@ static void set_good_speed_features_framesize_independent(
   sf->inter_sf.inter_mode_rd_model_estimation = 0;
 
   sf->inter_sf.model_based_post_interp_filter_breakout = 1;
-  sf->inter_sf.prune_compound_using_single_ref = 1;
   sf->inter_sf.prune_mode_search_simple_translation = 1;
   sf->inter_sf.prune_motion_mode_level = 1;
   sf->inter_sf.prune_ref_frames = 0;
@@ -334,6 +333,7 @@ static void set_good_speed_features_framesize_independent(
   sf->rd_sf.perform_coeff_opt = 1;
   if (speed >= 1) {
     sf->inter_sf.selective_ref_frame = 2;
+    sf->inter_sf.share_motion_mode_prune_pool = 1;
 
     sf->tx_sf.adaptive_tx_type_search_idx = 4;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
@@ -683,6 +683,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->reduce_inter_modes = 0;
   inter_sf->alt_ref_search_fp = 0;
   inter_sf->selective_ref_frame = 0;
+  inter_sf->share_motion_mode_prune_pool = 0;
   inter_sf->prune_ref_frames = 0;
   inter_sf->disable_wedge_search_var_thresh = 0;
   inter_sf->fast_wedge_sign_estimate = 0;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -359,6 +359,12 @@ static void set_good_speed_features_framesize_independent(
     // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
     // nearest searched result beyond the cap.
     sf->mv_sf.newmv_drl_search_limit = 2;
+    sf->part_sf.enable_six_param_warp_in_winner_mode = 1;
+    if (sf->part_sf.enable_six_param_warp_in_winner_mode) {
+      sf->winner_mode_sf.motion_mode_for_winner_cand = 2;
+      sf->part_sf.enable_six_param_warp_in_winner_mode_by_tid =
+          cm->current_frame.pyramid_level >= 3 ? 1 : 0;
+    }
   }
 
   if (speed >= 2) {
@@ -654,6 +660,8 @@ static AVM_INLINE void init_part_sf(PARTITION_SPEED_FEATURES *part_sf) {
   part_sf->ext_recur_depth_level = 0;
   part_sf->prune_rect_with_split_depth = 0;
   part_sf->prune_part_h_with_partition_boundary = 0;
+  part_sf->enable_six_param_warp_in_winner_mode = 0;
+  part_sf->enable_six_param_warp_in_winner_mode_by_tid = 0;
 #if CONFIG_ML_PART_SPLIT
   part_sf->prune_split_with_ml = 0;
   part_sf->prune_none_with_ml = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -477,6 +477,21 @@ typedef struct MV_SPEED_FEATURES {
   // Reduce single motion search range based on MV result of prior ref_mv_idx.
   int reduce_search_range;
 
+  // When set, skip the second-best full-pel candidate's subpel refinement in
+  // the single-ref NEWMV search.
+  int skip_second_best_subpel;
+
+  // Predictively reuse single-ref NEWMV results across the DRL.
+  //   0: off
+  //   1: reuse when reference MVs are within one full pel.
+  int predict_repeated_newmv;
+
+  // Cap the DRL depth that runs a fresh single-ref NEWMV motion search;
+  // beyond the cap, reuse the nearest searched result.
+  //   0: off (no cap).
+  //   K: search ref_mv_idx 0..K-1, reuse for ref_mv_idx >= K.
+  int newmv_drl_search_limit;
+
   // Prune mesh search.
   int prune_mesh_search;
 

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -604,6 +604,15 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // the single reference modes, it is one of the two best performers.
   int prune_compound_using_single_ref;
 
+  // Top-ref0 / top-ref1 cutoffs used inside the prune_compound_using_single_ref
+  // pruning. Compound pairs with refs[0] <
+  // skip_compound_prune_top_refs_num_ref0 AND refs[1] <
+  // skip_compound_prune_top_refs_num_ref1 are exempt from the single-ref-cutoff
+  // pruning. Enabled at speed >= 1.
+  // TODO (Yeqing Wu): need to be tuned for speed > 1.
+  int skip_compound_prune_top_refs_num_ref0;
+  int skip_compound_prune_top_refs_num_ref1;
+
   // Skip extended compound mode when ref frame corresponding to NEWMV does not
   // have NEWMV as single mode winner.
   // 0 : no pruning

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -146,7 +146,6 @@ enum {
 
 typedef struct {
   TX_TYPE_PRUNE_MODE prune_2d_txfm_mode;
-  int fast_intra_tx_type_search;
   int fast_inter_tx_type_search;
 
   // prune two least frequently chosen transforms for each intra mode
@@ -170,10 +169,6 @@ typedef struct {
   // mode evaluation and disables tx type mode pruning for winner mode
   // processing.
   int winner_mode_tx_type_pruning;
-  // Speed feature to disable intra secondary transform
-  int skip_stx_search;
-  // Speed feature to disable cross chroma component transform
-  int skip_cctx_search;
 } TX_TYPE_SEARCH;
 
 enum {
@@ -433,6 +428,9 @@ typedef struct PARTITION_SPEED_FEATURES {
   int prune_split_ml_level_inter;
   int prune_none_with_ml;
 #endif  // CONFIG_ML_PART_SPLIT
+
+  bool disable_ext_partitions;
+  bool disable_uneven_4way_partitions;
 } PARTITION_SPEED_FEATURES;
 
 typedef struct MV_SPEED_FEATURES {
@@ -599,13 +597,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // the single reference modes, it is one of the two best performers.
   int prune_compound_using_single_ref;
 
-  // Skip extended compound mode using ref frames of above and left neighbor
-  // blocks.
-  // 0 : no pruning
-  // 1 : prune extended compound mode (less aggressiveness)
-  // 2 : prune extended compound mode (high aggressiveness)
-  int prune_compound_using_neighbors;
-
   // Skip extended compound mode when ref frame corresponding to NEWMV does not
   // have NEWMV as single mode winner.
   // 0 : no pruning
@@ -615,9 +606,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
 
   // Based on previous ref_mv_idx search result, prune the following search.
   int prune_ref_mv_idx_search;
-
-  // Disable one sided compound modes.
-  int disable_onesided_comp;
 
   // Prune/gate motion mode evaluation based on token based rd
   // during transform search for inter blocks
@@ -630,9 +618,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
 
   // Prune warpmv with mvd search using previous frame stats.
   int prune_warpmv_prob_thresh;
-
-  // Enable/disable interintra wedge search.
-  int disable_wedge_interintra_search;
 
   // De-couple wedge and mode search during interintra RDO.
   int fast_interintra_wedge_search;
@@ -652,9 +637,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // Enable/disable ME for interinter diffwtd search. PSNR BD-rate gain of
   // ~0.1 on the lowres test set, but ~15% slower computation.
   int enable_interinter_diffwtd_newmv_search;
-
-  // Enable/disable smooth inter-intra mode
-  int disable_smooth_interintra;
 
   // Disable interinter_wedge
   int disable_interinter_wedge;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -527,6 +527,13 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // aggressively than lower ones. (0 means no pruning).
   int selective_ref_frame;
 
+  // When 1, the top_motion_mode_model_rd[] pool used by
+  // prune_motion_mode() is shared across all prediction modes for the
+  // block (more aggressive pruning, faster, slight coding loss). When 0,
+  // each prediction mode keeps its own pool (slower, no coding loss).
+  // Enabled at speed >= 1.
+  int share_motion_mode_prune_pool;
+
   // Prune reference frames.
   // 0 implies no pruning
   // 1 implies prune for extended partition

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -814,6 +814,14 @@ typedef struct TX_SPEED_FEATURES {
 
   // Enable txfm partition search
   bool enable_tx_partition;
+
+  // Skip IST/STX cascade for intra-luma candidates whose primary transform
+  // quantizes to zero. Extends the intra-luma pre-skip / post-trellis gates
+  // from eob == 1 to also cover eob == 0 (stx > 0 only, so skip-coded
+  // non-DCT winners survive) and adds a pre-quant L-infinity gate that
+  // predicts eob == 0 from the post-primary coefficients to skip
+  // av2_quant + trellis + cost_coeffs.
+  bool prune_intra_ist_stx_by_zero_eob;
 } TX_SPEED_FEATURES;
 
 typedef struct RD_CALC_SPEED_FEATURES {

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -634,6 +634,18 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   int skip_compound_prune_top_refs_num_ref0;
   int skip_compound_prune_top_refs_num_ref1;
 
+  // Skip refinemv_loop == 1 for ref-pairs other than (0, 1). Enabled at
+  // speed >= 1.
+  int prune_refinemv_by_ref_idx;
+
+  // Skip INTERINTRA motion mode when ref_frame[0] > 1. Enabled at
+  // speed >= 1.
+  int prune_interintra_by_ref_idx;
+
+  // Skip WARP_DELTA motion mode when ref_frame[0] > 2. Enabled at
+  // speed >= 1.
+  int prune_warp_delta_by_ref_idx;
+
   // Skip extended compound mode when ref frame corresponding to NEWMV does not
   // have NEWMV as single mode winner.
   // 0 : no pruning

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -527,6 +527,12 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // aggressively than lower ones. (0 means no pruning).
   int selective_ref_frame;
 
+  // When 1, prune single-ref NEWMV / WARP_NEWMV for a given ref frame
+  // when the best RD seen so far for that ref (taken from a prior mode
+  // such as NEARMV, NEWMV[amvd=0], or WARPMV) is far from the best RD
+  // across all refs. 0 disables this pruning. Enabled at speed >= 1.
+  int prune_newmv_modes_using_prior_rd;
+
   // When 1, the top_motion_mode_model_rd[] pool used by
   // prune_motion_mode() is shared across all prediction modes for the
   // block (more aggressive pruning, faster, slight coding loss). When 0,

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -422,6 +422,10 @@ typedef struct PARTITION_SPEED_FEATURES {
   // the current best partition's boundary after searching NONE, HORZ, VERT, and
   // H-parts.
   int prune_part_4_with_partition_boundary;
+  // Enable six parameter warp in winner mode by tid. If set to 1, enable six
+  // parameter warp in winner mode by tid threshold.
+  int enable_six_param_warp_in_winner_mode;
+  int enable_six_param_warp_in_winner_mode_by_tid;
 #if CONFIG_ML_PART_SPLIT
   int prune_split_with_ml;
   int prune_split_ml_level;

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -2094,6 +2094,29 @@ static bool prune_sec_txfm_rd_eval(int64_t sec_tx_sse_to_be_coded,
 // Encoder-only variable to reudce the search complexity of IST
 #define IST_REDUCED_SEARCH_SET_SIZE 4
 
+// Return 1 if primary FP-quant is guaranteed to produce eob = 0 across the
+// IST window, 0 otherwise. Uses an L-infinity scan of the post-primary
+// coefficients against the FP quantizer's kill threshold
+//   abs(coeff) < min(dequant[0], dequant[1]) >> (4 + log_scale)
+// which upper-bounds the per-position quantizer kill rule
+// (av2_highbd_quantize_fp_facade in av2_quantize.c).
+static INLINE int check_primary_quant_all_zero(const tran_low_t *coeff,
+                                               const int32_t dequant_QTX[2],
+                                               int width, int height,
+                                               int log_scale) {
+  const int shift = 4 + log_scale;
+  const int32_t deq_min = AVMMIN(dequant_QTX[0], dequant_QTX[1]);
+  const int32_t thr = deq_min >> shift;
+  if (thr <= 0) return 0;
+  const uint32_t uthr = (uint32_t)thr;
+  const int n = width * height;
+  for (int i = 0; i < n; ++i) {
+    const int32_t a = (coeff[i] < 0) ? -coeff[i] : coeff[i];
+    if ((uint32_t)a >= uthr) return 0;
+  }
+  return 1;
+}
+
 // Search for the best transform type for a given transform block.
 // This function can be used for both inter and intra, both luma and chroma.
 static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
@@ -2399,6 +2422,30 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
         }
         *coeffs_available = 1;
 
+        // Pre-IST quant-zero gate. Predict primary FP-quant eob = 0 from the
+        // post-primary coefficients and, if so, skip av2_quant / trellis /
+        // cost_coeffs and propagate the same eob_found / DCT_DCT handling as
+        // the post-quant eob == 1 gate below. Scoped to intra Y, stx == 0,
+        // non-DC-only, IST-enabled, non-QM blocks.
+        if (cpi->sf.tx_sf.prune_intra_ist_stx_by_zero_eob &&
+            plane == PLANE_TYPE_Y && !is_inter && stx == 0 && !dc_only_blk &&
+            xd->enable_ist &&
+            !av2_use_qmatrix(&cm->quant_params, xd, mbmi->segment_id)) {
+          const int tr_w = AVMMIN(tx_size_wide[tx_size], 32);
+          const int tr_h = AVMMIN(tx_size_high[tx_size], 32);
+          const int log_scale = av2_get_tx_scale(tx_size);
+          if (check_primary_quant_all_zero(p->coeff + BLOCK_OFFSET(block),
+                                           x->plane[plane].dequant_QTX, tr_w,
+                                           tr_h, log_scale)) {
+            p->eobs[block] = 0;
+            if (tx_type1 == DCT_DCT) eob_found = 1;
+            if (tx_type1 != DCT_DCT || (stx && primary_tx_type)) {
+              update_txk_array(xd, blk_row, blk_col, tx_size, DCT_DCT);
+              continue;
+            }
+          }
+        }
+
         const TX_CLASS tx_class =
             tx_type_to_class[get_primary_tx_type(tx_type)];
         if (tcq_enable(cm->features.tcq_mode,
@@ -2424,11 +2471,22 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
           }
         }
 
-        // pre-skip DC only case to make things faster
+        // Pre-skip the all-zero (eob == 0) and DC-only (eob == 1) cases on
+        // intra luma. The eob == 1 branch kills the candidate when the
+        // primary is non-DCT or stx > 0. The eob == 0 branch is narrower:
+        // it only kills stx > 0 candidates, so a non-DCT primary with
+        // stx == 0 that quantized to all-zero can still win via skip
+        // coding (bitstream signals the tx_type and elides the
+        // coefficients).
         uint16_t *const eob = &p->eobs[block];
-        if (*eob == 1 && plane == PLANE_TYPE_Y && !is_inter) {
+        if (plane == PLANE_TYPE_Y && !is_inter &&
+            (*eob == 1 ||
+             (cpi->sf.tx_sf.prune_intra_ist_stx_by_zero_eob && *eob == 0))) {
           if (tx_type1 == DCT_DCT) eob_found = 1;
-          if (tx_type1 != DCT_DCT || (stx && primary_tx_type)) {
+          const int kill =
+              (*eob == 1) ? (tx_type1 != DCT_DCT || (stx && primary_tx_type))
+                          : (stx > 0);
+          if (kill) {
             update_txk_array(xd, blk_row, blk_col, tx_size, DCT_DCT);
             continue;
           }
@@ -2456,6 +2514,9 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
               cost_coeffs(cm, x, plane, block, tx_size, tx_type, CCTX_NONE,
                           txb_ctx, cm->features.reduced_tx_set_used);
         }
+        // Post-trellis safety net: re-apply the same eob == 0 / eob == 1
+        // pre-skip logic in case trellis (RDOQ) adjusted the eob across
+        // the threshold.
         if (*eob == 1 && plane == PLANE_TYPE_Y && !is_inter) {
           if (tx_type1 == DCT_DCT) eob_found = 1;
           if (tx_type1 != DCT_DCT || (stx && primary_tx_type)) {
@@ -2464,6 +2525,14 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
           }
           if (get_secondary_tx_type(tx_type) > 0) continue;
           if (txfm_param.sec_tx_type > 0) continue;
+        }
+        if (cpi->sf.tx_sf.prune_intra_ist_stx_by_zero_eob && *eob == 0 &&
+            plane == PLANE_TYPE_Y && !is_inter) {
+          if (tx_type1 == DCT_DCT) eob_found = 1;
+          if (stx > 0) {
+            update_txk_array(xd, blk_row, blk_col, tx_size, DCT_DCT);
+            continue;
+          }
         }
         if (*eob <= 3 && plane == PLANE_TYPE_Y && is_inter && stx) {
           update_txk_array(xd, blk_row, blk_col, tx_size, primary_tx_type);

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -1804,14 +1804,10 @@ get_tx_mask(const AV2_COMP *cpi, MACROBLOCK *x, int plane, int block,
 
     if (cpi->sf.tx_sf.tx_type_search.prune_tx_type_using_stats) {
       // TODO(yunqing): adjust the thresholds.
-      static const int thresh_arr[2][FRAME_UPDATE_TYPES] = {
-        { 10, 15, 15, 10, 15, 15, 15, 0, 0 },
-        { 10, 17, 17, 10, 17, 17, 17, 0, 0 }
-      };
+      static const int thresh_arr[FRAME_UPDATE_TYPES] = { 10, 17, 17, 10, 17,
+                                                          17, 17, 0,  0 };
 
-      const int thresh =
-          thresh_arr[cpi->sf.tx_sf.tx_type_search.prune_tx_type_using_stats - 1]
-                    [update_type];
+      const int thresh = thresh_arr[update_type];
       uint16_t prune = 0;
       int max_prob = -1;
       int max_idx = 0;
@@ -2315,7 +2311,6 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
     xd->enable_ist =
         (is_inter_block(mbmi, xd->tree_type) ? cm->seq_params.enable_inter_ist
                                              : cm->seq_params.enable_ist) &&
-        !cpi->sf.tx_sf.tx_type_search.skip_stx_search &&
         !mbmi->fsc_mode[xd->tree_type == CHROMA_PART] &&
         !xd->lossless[mbmi->segment_id];
 
@@ -2648,8 +2643,7 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
   // Intra mode needs decoded pixels such that the next transform block
   // can use them for prediction. If cctx is enabled, this reconstruction
   // should be done later in search_cctx_type, when cctx type is chosen.
-  if (plane == AVM_PLANE_Y || !is_cctx_allowed(cm, xd) ||
-      cpi->sf.tx_sf.tx_type_search.skip_cctx_search) {
+  if (plane == AVM_PLANE_Y || !is_cctx_allowed(cm, xd)) {
     recon_intra(cpi, x, plane, block, blk_row, blk_col, plane_bsize, tx_size,
                 txb_ctx, skip_trellis, best_tx_type, 0, &rate_cost, best_eob);
     p->dqcoeff = orig_dqcoeff;
@@ -4030,8 +4024,7 @@ int av2_txfm_uvrd(const AV2_COMP *const cpi, MACROBLOCK *x, RD_STATS *rd_stats,
 
   const int skip_trellis = 0;
   int is_cost_valid = 1;
-  if (is_cctx_allowed(&cpi->common, xd) &&
-      !cpi->sf.tx_sf.tx_type_search.skip_cctx_search) {
+  if (is_cctx_allowed(&cpi->common, xd)) {
     RD_STATS this_rd_stats;
     int64_t chroma_ref_best_rd = ref_best_rd;
     if (cpi->sf.inter_sf.perform_best_rd_based_gating_for_chroma && is_inter &&

--- a/av2/encoder/tx_search.h
+++ b/av2/encoder/tx_search.h
@@ -33,6 +33,25 @@ enum {
   FTXS_USE_TRANSFORM_DOMAIN = 1 << 2
 } UENUM1BYTE(FAST_TX_SEARCH_MODE);
 
+/*
+Gets the type to signal for the 4 way split tree in the tx partition
+type signaling.
+*/
+static INLINE int get_split4_partition(TX_PARTITION_TYPE partition) {
+  switch (partition) {
+    case TX_PARTITION_NONE:
+    case TX_PARTITION_SPLIT:
+    case TX_PARTITION_VERT:
+    case TX_PARTITION_HORZ:
+    case TX_PARTITION_VERT4:
+    case TX_PARTITION_HORZ4:
+    case TX_PARTITION_HORZ5:
+    case TX_PARTITION_VERT5: return partition;
+    default: assert(0);
+  }
+  return 0;
+}
+
 static AVM_INLINE int inter_tx_partition_cost(const MACROBLOCK *const x,
                                               TX_PARTITION_TYPE partition,
                                               BLOCK_SIZE bsize,

--- a/test/multi_layer_test.cc
+++ b/test/multi_layer_test.cc
@@ -94,6 +94,7 @@ class MultiLayerTest : public ::libavm_test::CodecTestWithParam<int>,
            start_decoding_tl1_ > 0)) {
         encoder->Control(AV2E_SET_ENABLE_REF_FRAME_MVS, 0);
         encoder->Control(AV2E_SET_ALLOW_REF_FRAME_MVS, 0);
+        encoder->Control(AV2E_SET_ENABLE_CDF_AVERAGING, 0);
       }
       if (cfg_.g_lag_in_frames > 0) {
         int gop_size = (cfg_.g_lag_in_frames - 1) / num_embedded_layers_;

--- a/test/multi_layer_test.cc
+++ b/test/multi_layer_test.cc
@@ -464,17 +464,6 @@ TEST_P(MultiLayerTest, MultiLayerTest2Embedded) {
   EXPECT_EQ(num_mismatch_, 0);
 }
 
-TEST_P(MultiLayerTest, MultiLayerTest2EmbeddedDecodeBaseOnlyImplicit) {
-  ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
-  num_temporal_layers_ = 1;
-  num_embedded_layers_ = 2;
-  decode_base_only_ = true;
-  drop_tl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
-  ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
-  EXPECT_EQ(num_mismatch_, 0);
-}
-
 TEST_P(MultiLayerTest, MultiLayerTest2EmbeddedDecodeBaseOnlyExplicit) {
   ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
   num_temporal_layers_ = 1;
@@ -492,17 +481,6 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded) {
   num_embedded_layers_ = 3;
   decode_base_only_ = false;
   drop_tl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
-  ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
-  EXPECT_EQ(num_mismatch_, 0);
-}
-
-TEST_P(MultiLayerTest, MultiLayerTest3EmbeddedDecodeBaseOnlyImplicit) {
-  ::libavm_test::Y4mVideoSource video_nonsc("park_joy_90p_8_420.y4m", 0, 20);
-  num_temporal_layers_ = 1;
-  num_embedded_layers_ = 3;
-  decode_base_only_ = true;
-  drop_sl2_ = false;
   enable_explicit_ref_frame_map_ = false;
   ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
   EXPECT_EQ(num_mismatch_, 0);
@@ -592,7 +570,7 @@ TEST_P(MultiLayerTest, MultiLayerTest2Embedded2TemporaSframe) {
   num_embedded_layers_ = 2;
   decode_base_only_ = false;
   drop_tl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
+  enable_explicit_ref_frame_map_ = true;
   enable_buffer_refresh_test_ = true;
   enable_s_frame_ = true;
   cfg_.enable_sframe = 1;
@@ -620,7 +598,7 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded3TemporalDropTL2) {
   decode_base_only_ = false;
   drop_tl2_ = true;
   drop_sl2_ = false;
-  enable_explicit_ref_frame_map_ = false;
+  enable_explicit_ref_frame_map_ = true;
   enable_buffer_refresh_test_ = false;
   ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
   EXPECT_EQ(num_mismatch_, 0);
@@ -633,7 +611,7 @@ TEST_P(MultiLayerTest, MultiLayerTest3Embedded3TemporalDropSL2) {
   decode_base_only_ = false;
   drop_tl2_ = false;
   drop_sl2_ = true;
-  enable_explicit_ref_frame_map_ = false;
+  enable_explicit_ref_frame_map_ = true;
   enable_buffer_refresh_test_ = false;
   ASSERT_NO_FATAL_FAILURE(RunLoop(&video_nonsc));
   EXPECT_EQ(num_mismatch_, 0);


### PR DESCRIPTION
Enable winner mode for motion modes

Add 6 param warp search in winner mode 

Switch 6 param search between rough and winner by tid levels

Tests - cpu-used =1
Anchor: https://github.com/AOMediaCodec/avm/commit/6e71b0c85924e61d9403b6222921cd4bb8cf870e
Results (RA):

A1 - 17 frames
A2 - 33 frames

<img width="1065" height="103" alt="MR5" src="https://github.com/user-attachments/assets/c485b51d-5a1e-4fc8-83f0-05e777e71dea" />
