### PR TITLE
Add a speed level for intra region in inter frames

### DIFF
--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -4496,8 +4496,8 @@ static AVM_INLINE void prune_ext_partitions_3way(
 
 // Early termination of SDP for intra blocks in inter frames
 static INLINE void early_termination_inter_sdp(PC_TREE *pc_tree,
-                                               float *total_count,
-                                               float *inter_mode_count) {
+                                               unsigned int *total_count,
+                                               unsigned int *inter_mode_count) {
   REGION_TYPE cur_region_type = pc_tree->region_type;
   if (pc_tree->partitioning == PARTITION_NONE) {
     if (pc_tree->none[cur_region_type] == NULL) return;
@@ -4599,17 +4599,29 @@ static INLINE void search_intra_region_partitioning(
   MACROBLOCKD *const xd = &x->e_mbd;
   assert(pc_tree != NULL);
 
-  // Add one encoder fast method for early terminating inter-sdp
-  float total_count = 0;
-  float inter_mode_count = 0;
-  early_termination_inter_sdp(pc_tree, &total_count, &inter_mode_count);
-  // if over 60% of the coded blocks under this region are inter coded blocks,
-  // skip the rdo for inter-sdp
-  if (total_count * 0.7 < inter_mode_count) return;
-
-  pc_tree->region_type = INTRA_REGION;
   // store the current best partitioning
   PARTITION_TYPE cur_best_partitioning = pc_tree->partitioning;
+
+  // Add one encoder fast method for early terminating inter-sdp
+  unsigned int total_count = 0;
+  unsigned int inter_mode_count = 0;
+  early_termination_inter_sdp(pc_tree, &total_count, &inter_mode_count);
+  if (cpi->sf.part_sf.inter_sdp_fast_method_level >= 1) {
+    // Optimized fast method (enabled at cpu-used >= 1):
+    // Check whether there are at least 1 intra coded blocks under this region
+    if (total_count - inter_mode_count < 1) return;
+    if (inter_mode_count * 2 > total_count) return;
+    // if current best partitioning is partition_none, early skip
+    if (cur_best_partitioning == PARTITION_NONE) return;
+  } else {
+    // Original fast method (used at cpu-used == 0):
+    // if over 70% of the coded blocks under this region are inter coded blocks,
+    // skip the rdo for inter-sdp
+    if (total_count * 7 / 10 < inter_mode_count) return;
+  }
+
+  pc_tree->region_type = INTRA_REGION;
+
   pc_tree->partitioning = PARTITION_NONE;
 
   RD_STATS *sum_rdc = &part_search_state->sum_rdc;

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -374,6 +374,11 @@ static void set_good_speed_features_framesize_independent(
     // nearest searched result beyond the cap.
     sf->mv_sf.newmv_drl_search_limit = 2;
     sf->inter_sf.skip_temporary_pred_for_opfl = 1;
+
+    // Enable the optimized inter-SDP fast method (requires >=1 intra coded
+    // block, prunes when inter-mode ratio exceeds 50%, and early skips when
+    // the current best partitioning is PARTITION_NONE).
+    sf->part_sf.inter_sdp_fast_method_level = 1;
   }
 
   if (speed >= 2) {
@@ -669,6 +674,7 @@ static AVM_INLINE void init_part_sf(PARTITION_SPEED_FEATURES *part_sf) {
   part_sf->ext_recur_depth_level = 0;
   part_sf->prune_rect_with_split_depth = 0;
   part_sf->prune_part_h_with_partition_boundary = 0;
+  part_sf->inter_sdp_fast_method_level = 0;
 #if CONFIG_ML_PART_SPLIT
   part_sf->prune_split_with_ml = 0;
   part_sf->prune_none_with_ml = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -422,6 +422,15 @@ typedef struct PARTITION_SPEED_FEATURES {
   // the current best partition's boundary after searching NONE, HORZ, VERT, and
   // H-parts.
   int prune_part_4_with_partition_boundary;
+
+  // Controls the early termination fast method for inter-SDP (search of intra
+  // region partitioning in inter frames).
+  // 0: Use the original fast method that early-terminates inter-SDP when more
+  //    than 70% of the coded blocks under this region are inter coded.
+  // 1: Use the optimized fast method that additionally requires at least one
+  //    intra coded block, prunes when inter ratio exceeds 50%, and early skips
+  //    when current best partitioning is PARTITION_NONE.
+  int inter_sdp_fast_method_level;
 #if CONFIG_ML_PART_SPLIT
   int prune_split_with_ml;
   int prune_split_ml_level;


### PR DESCRIPTION
Squash merge branch 'leo/inter-sdp-mr' into 'avm-encoder-development' Add a speed level for inter sdp fast method:

1) Early terminate inter-sdp when there is no intra coded blocks in the this region after searching mixed intra and inter region;
2) Early terminate inter-sdp when more than half of the blocks are inter -coded;
3) Early terminate inter-sdp when the best block partitioning is partition-none

STATS_CHANGED

cpu-use-1 is at commit 6e71b0c859 is used as anchor.

A1 - 17 frames (0.02% loss with 95.3% run-time)
A2 - 33 frames (0.09% loss with 94.6% run-time)

```
+---------+-------+--------+-------+-------+----------+----------+
| Summary |   Y   |   U    |   V   |  YUV  | Enc-time | Dec-time |
+---------+-------+--------+-------+-------+----------+----------+
| A1      | 0.01% | 0.17%  | 0.11% | 0.02% | 95.3%    | 100%   |
| A2      | 0.07% | 0.14%  | 0.42% | 0.09% | 94.6%    | 100%   |
+---------+-------+--------+-------+-------+----------+----------+
```


