### PR TITLE
Enhanced inter mode cache reuse

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -7491,12 +7491,30 @@ static INLINE int is_mode_intra(PREDICTION_MODE mode) {
   return mode < INTRA_MODE_END;
 }
 
+// Check whether one of the reference frames are the same as that of the cached
+// mode
+static INLINE int is_ref_frame_same_as_cache(
+    const MB_MODE_INFO *cached_mi2, const MV_REFERENCE_FRAME *ref_frame,
+    int this_mode_is_single) {
+  const int cached_mode_is_single = is_inter_singleref_mode(cached_mi2->mode);
+  if (ref_frame[0] == cached_mi2->ref_frame[0]) return 1;
+  if (!cached_mode_is_single && (ref_frame[0] == cached_mi2->ref_frame[1]))
+    return 1;
+  if (!this_mode_is_single) {
+    if (ref_frame[1] == cached_mi2->ref_frame[0]) return 1;
+    if (!cached_mode_is_single && (ref_frame[1] == cached_mi2->ref_frame[1]))
+      return 1;
+  }
+  return 0;
+}
+
 // Reuse the prediction mode in cache.
 // Returns 0 if no pruning is done, 1 if we are skipping the current mod
 // completely, 2 if we skip compound only, but still try single motion modes
 static INLINE int skip_inter_mode_with_cached_mode(
-    const AV2_COMMON *cm, const MACROBLOCK *x, PREDICTION_MODE mode,
+    const AV2_COMP *cpi, const MACROBLOCK *x, PREDICTION_MODE mode,
     const MV_REFERENCE_FRAME *ref_frame) {
+  const AV2_COMMON *const cm = &cpi->common;
   const MB_MODE_INFO *cached_mi = x->inter_mode_cache[0];
 
   // If there is no cache, then no pruning is possible.
@@ -7513,19 +7531,32 @@ static INLINE int skip_inter_mode_with_cached_mode(
       if (cached_mi2 && !is_mode_intra(cached_mi2->mode)) {
         const int cached_mode_is_single =
             is_inter_singleref_mode(cached_mi2->mode);
-        if (mode == cached_mi2->mode) return 0;
-        // if (mode == cached_mi2->mode) {
-        if (ref_frame[0] == cached_mi2->ref_frame[0]) return 0;
-        if (!cached_mode_is_single &&
-            (ref_frame[0] == cached_mi2->ref_frame[1]))
-          return 0;
-        if (!this_mode_is_single) {
-          if (ref_frame[1] == cached_mi2->ref_frame[0]) return 0;
-          if (!cached_mode_is_single &&
-              (ref_frame[1] == cached_mi2->ref_frame[1]))
+        if (cpi->sf.inter_sf.enable_enhanced_inter_mode_cache_reuse) {
+          // For single prediction mode, when reference frame is the same,
+          // return 0.
+          // For compound prediction mode, when both reference frames
+          // are the same, return 0.
+          if (cached_mode_is_single) {
+            if (ref_frame[0] == cached_mi2->ref_frame[0]) return 0;
+          } else {
+            if (ref_frame[0] == cached_mi2->ref_frame[0] &&
+                ref_frame[1] == cached_mi2->ref_frame[1])
+              return 0;
+          }
+          // When prediction mode is the same, if one
+          // of the reference frames are the same, return 0
+          if (mode == cached_mi2->mode) {
+            if (is_ref_frame_same_as_cache(cached_mi2, ref_frame,
+                                           this_mode_is_single))
+              return 0;
+          }
+        } else {
+          // Original cache reuse logic.
+          if (mode == cached_mi2->mode) return 0;
+          if (is_ref_frame_same_as_cache(cached_mi2, ref_frame,
+                                         this_mode_is_single))
             return 0;
         }
-        //}
       }
     }
   }
@@ -7603,7 +7634,7 @@ static int inter_mode_search_order_independent_skip(
     return 1;
   }
   const int cached_skip_ret =
-      skip_inter_mode_with_cached_mode(cm, x, mode, ref_frame);
+      skip_inter_mode_with_cached_mode(cpi, x, mode, ref_frame);
   if (cached_skip_ret > 0) {
     return cached_skip_ret;
   }

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -375,6 +375,8 @@ static void set_good_speed_features_framesize_independent(
     // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
     // nearest searched result beyond the cap.
     sf->mv_sf.newmv_drl_search_limit = 2;
+
+    sf->inter_sf.enable_enhanced_inter_mode_cache_reuse = 1;
     sf->inter_sf.skip_temporary_pred_for_opfl = 1;
 
     // Enable the optimized inter-SDP fast method (requires >=1 intra coded
@@ -780,6 +782,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->skip_mode_eval_based_on_rate_cost = 0;
   inter_sf->reuse_erp_mode_flag = 0;
   inter_sf->prune_warpmv_prob_thresh = 32;
+  inter_sf->enable_enhanced_inter_mode_cache_reuse = 0;
 }
 
 static AVM_INLINE void init_interp_sf(INTERP_FILTER_SPEED_FEATURES *interp_sf) {

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -743,6 +743,14 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // if a block with the same (mi_row, mi_col, bsize) is visited more than one
   // by the encoder.
   int reuse_erp_mode_flag;
+
+  // When set, enable enhanced inter mode cache reuse logic in
+  // skip_inter_mode_with_cached_mode(). It allows additional cache hits based
+  // on matching reference frames against single-ref/compound cached modes,
+  // which can avoid skipping useful inter modes during cache-based pruning.
+  // 0: original cache reuse logic.
+  // 1: enhanced cache reuse logic (more modes are searched).
+  int enable_enhanced_inter_mode_cache_reuse;
 } INTER_MODE_SPEED_FEATURES;
 
 typedef struct INTERP_FILTER_SPEED_FEATURES {


### PR DESCRIPTION
Reuse model RD when one of the following conditions are met.

- Current mode is the same as the cached mode and at least one of the reference frame is the same as the cached one

- All the reference frames is the same as the reference frame of the cached mode

Otherwise, skip processing current mode or reference frame

STATS_CHANGED

Results are tested on top of 6e71b0c85924e61d9 with cpu-used = 1.
```
+---------+-------+--------+-------+-------+----------+----------+
| Summary |   Y   |   U    |   V   |  YUV  | Enc-time | Dec-time |
+---------+-------+--------+-------+-------+----------+----------+
| A1      | 0.03% | -0.05%  | 0.00% | 0.03% | 97.8%    | 100%   |
| A2      | 0.03% | 0.41%   | 0.13% | 0.05% | 96.6%    | 100%   |
+---------+-------+--------+-------+-------+----------+----------+
```
