### PR TITLE
Add SSE2 optimization for interp_cubic()

### DIFF
--- a/av2/av2.cmake
+++ b/av2/av2.cmake
@@ -396,6 +396,7 @@ list(
   "${AVM_ROOT}/av2/encoder/x86/encodetxb_sse2.c"
   "${AVM_ROOT}/av2/encoder/x86/highbd_block_error_intrin_sse2.c"
   "${AVM_ROOT}/av2/encoder/x86/highbd_temporal_filter_sse2.c"
+  "${AVM_ROOT}/av2/encoder/x86/model_rd_sse2.c"
   "${AVM_ROOT}/av2/encoder/x86/wedge_utils_sse2.c")
 
 list(APPEND AVM_AV2_ENCODER_INTRIN_SSE3 "${AVM_ROOT}/av2/encoder/x86/ml_sse3.c")

--- a/av2/common/av2_rtcd_defs.pl
+++ b/av2/common/av2_rtcd_defs.pl
@@ -303,6 +303,9 @@ if (avm_config("CONFIG_AV2_ENCODER") eq "yes") {
   add_proto qw/void av2_get_horver_correlation_full/, " const int16_t *diff, int stride, int w, int h, float *hcorr, float *vcorr";
   specialize qw/av2_get_horver_correlation_full sse4_1 avx2 neon/;
 
+  add_proto qw/void av2_interp_cubic_rate_dist/, "const double *p1, const double *p2, double x, double rate_dist_f[2]";
+  specialize qw/av2_interp_cubic_rate_dist sse2/;
+
   add_proto qw/void av2_nn_predict/, " const float *input_nodes, const NN_CONFIG *const nn_config, int reduce_prec, float *const output";
   if (avm_config("CONFIG_EXCLUDE_SIMD_MISMATCH") ne "yes") {
     specialize qw/av2_nn_predict sse3 neon/;

--- a/av2/encoder/encodetxb.c
+++ b/av2/encoder/encodetxb.c
@@ -2581,7 +2581,6 @@ static INLINE void update_coeff_general(
     tran_low_t *qcoeff, tran_low_t *dqcoeff, uint8_t *levels,
     const qm_val_t *iqmatrix, int32_t *tmp_sign, int plane,
     coeff_info *coef_info, bool enable_parity_hiding, int *hr_level_avg) {
-  const int dqv = get_dqv(dequant, scan[si], iqmatrix);
   const int ci = scan[si];
   const tran_low_t qc = qcoeff[ci];
   const int is_last = si == (eob - 1);
@@ -2608,6 +2607,7 @@ static INLINE void update_coeff_general(
   if (qc == 0) {
     *accu_rate += limits ? base_lf_cost : base_cost;
   } else {
+    const int dqv = get_dqv(dequant, scan[si], iqmatrix);
     const int sign = (qc < 0) ? 1 : 0;
     const tran_low_t abs_qc = abs(qc);
     const tran_low_t tqc = tcoeff[ci];
@@ -2666,7 +2666,6 @@ static AVM_FORCE_INLINE void update_coeff_simple(
     tran_low_t *qcoeff, tran_low_t *dqcoeff, uint8_t *levels,
     const qm_val_t *iqmatrix, coeff_info *coef_info, bool enable_parity_hiding,
     int plane, int *hr_level_avg) {
-  const int dqv = get_dqv(dequant, scan[si], iqmatrix);
   (void)eob;
   // this simple version assumes the coeff's scan_idx is not DC (scan_idx != 0)
   // and not the last (scan_idx != eob - 1)
@@ -2709,6 +2708,7 @@ static AVM_FORCE_INLINE void update_coeff_simple(
       }
     }
   } else {
+    const int dqv = get_dqv(dequant, scan[si], iqmatrix);
     const tran_low_t abs_qc = abs(qc);
     const tran_low_t abs_tqc = abs(tcoeff[ci]);
     const tran_low_t abs_dqc = abs(dqcoeff[ci]);
@@ -2905,7 +2905,6 @@ static AVM_FORCE_INLINE void update_coeff_eob(
     int *hr_level_avg) {
   const int bwl = get_txb_bwl(tx_size);
   const int height = get_txb_high(tx_size);
-  const int dqv = get_dqv(dequant, scan[si], iqmatrix);
   assert(si != *eob - 1);
   const int ci = scan[si];
   const tran_low_t qc = qcoeff[ci];
@@ -2945,6 +2944,7 @@ static AVM_FORCE_INLINE void update_coeff_eob(
       }
     }
   } else {
+    const int dqv = get_dqv(dequant, scan[si], iqmatrix);
     int64_t rd_eob_low = INT64_MAX >> 1;
     int rate_eob_low = INT32_MAX >> 1;
     int lower_level = 0;

--- a/av2/encoder/model_rd.h
+++ b/av2/encoder/model_rd.h
@@ -126,12 +126,11 @@ static AVM_INLINE void model_rd_with_curvfit(const AV2_COMP *const cpi,
   const double sse_norm = (double)sse / num_samples;
   const double qstepsqr = (double)qstep * qstep;
   const double xqr = log2(sse_norm / qstepsqr);
-  double rate_f, dist_by_sse_norm_f;
-  av2_model_rd_curvfit(plane_bsize, sse_norm, xqr, &rate_f,
-                       &dist_by_sse_norm_f);
+  double rate_dist_f[2];
+  av2_model_rd_curvfit(plane_bsize, sse_norm, xqr, rate_dist_f);
 
-  const double dist_f = dist_by_sse_norm_f * sse_norm;
-  int rate_i = (int)(AVMMAX(0.0, rate_f * num_samples) + 0.5);
+  const double dist_f = rate_dist_f[1] * sse_norm;
+  int rate_i = (int)(AVMMAX(0.0, rate_dist_f[0] * num_samples) + 0.5);
   int64_t dist_i = (int64_t)(AVMMAX(0.0, dist_f * num_samples) + 0.5);
   avm_clear_system_state();
 

--- a/av2/encoder/rd.c
+++ b/av2/encoder/rd.c
@@ -1419,6 +1419,12 @@ static double interp_cubic(const double *p, double x) {
                           x * (3.0 * (p[1] - p[2]) + p[3] - p[0])));
 }
 
+void av2_interp_cubic_rate_dist_c(const double *p1, const double *p2, double x,
+                                  double rate_dist_f[2]) {
+  rate_dist_f[0] = interp_cubic(p1, x);
+  rate_dist_f[1] = interp_cubic(p2, x);
+}
+
 /*
 static double interp_bicubic(const double *p, int p_stride, double x,
                              double y) {
@@ -1533,7 +1539,7 @@ static const double interp_dgrid_curv[3][65] = {
 };
 
 void av2_model_rd_curvfit(BLOCK_SIZE bsize, double sse_norm, double xqr,
-                          double *rate_f, double *distbysse_f) {
+                          double rate_dist_f[2]) {
   const double x_start = -15.5;
   const double x_end = 16.5;
   const double x_step = 0.5;
@@ -1551,9 +1557,8 @@ void av2_model_rd_curvfit(BLOCK_SIZE bsize, double sse_norm, double xqr,
   assert(xi > 0);
 
   const double *prate = &interp_rgrid_curv[rcat][(xi - 1)];
-  *rate_f = interp_cubic(prate, xo);
   const double *pdist = &interp_dgrid_curv[dcat][(xi - 1)];
-  *distbysse_f = interp_cubic(pdist, xo);
+  av2_interp_cubic_rate_dist(prate, pdist, xo, rate_dist_f);
 }
 
 static void get_entropy_contexts_plane(BLOCK_SIZE plane_bsize,

--- a/av2/encoder/rd.h
+++ b/av2/encoder/rd.h
@@ -219,8 +219,23 @@ void av2_set_sad_per_bit(const struct AV2_COMP *cpi, MvCosts *mv_costs,
 void av2_model_rd_from_var_lapndz(int64_t var, unsigned int n,
                                   unsigned int qstep, int *rate, int64_t *dist);
 
+/*!\brief Estimate rate and distortion for a block.
+ *
+ * \param[in]    bsize           Block size
+ * \param[in]    sse_norm        Normalized SSE
+ * \param[in]    xqr             The log2 ratio of normalized SSE to the
+ *                               squared quantization step size, computed
+ *                               as: log2(sse_norm / qstep^2)
+ * \param[out]   rate_dist_f     Pointer to store the results
+ *                               rate_dist_f[0] stores the estimated rate
+ *                               rate_dist_f[1] stores the estimated
+ *                               distortion by normalized SSE
+ *
+ * \remark Nothing is returned. Results are saved in rate_dist_f[0]
+ * and rate_dist_f[1].
+ */
 void av2_model_rd_curvfit(BLOCK_SIZE bsize, double sse_norm, double xqr,
-                          double *rate_f, double *distbysse_f);
+                          double rate_dist_f[2]);
 
 int av2_get_switchable_rate(const MACROBLOCK *x, const MACROBLOCKD *xd,
                             InterpFilter interp_filter);

--- a/av2/encoder/x86/model_rd_sse2.c
+++ b/av2/encoder/x86/model_rd_sse2.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+#include <emmintrin.h>
+
+#include "config/av2_rtcd.h"
+
+void av2_interp_cubic_rate_dist_sse2(const double *p1, const double *p2,
+                                     double x, double rate_dist_f[2]) {
+  const __m128d half = _mm_set1_pd(0.5);
+  const __m128d two = _mm_set1_pd(2.0);
+  const __m128d three = _mm_set1_pd(3.0);
+  const __m128d four = _mm_set1_pd(4.0);
+  const __m128d five = _mm_set1_pd(5.0);
+
+  const __m128d reg_x = _mm_set1_pd(x);
+  const __m128d reg_p0 = _mm_set_pd(p2[0], p1[0]);
+  const __m128d reg_p1 = _mm_set_pd(p2[1], p1[1]);
+  const __m128d reg_p2 = _mm_set_pd(p2[2], p1[2]);
+  const __m128d reg_p3 = _mm_set_pd(p2[3], p1[3]);
+
+  // To ensure that results are bit-identical to the C code, we need to perform
+  // exactly the same sequence of operations here as in the C code.
+  // reg_res_0 = x * (3.0 * (p[1] - p[2]) + p[3] - p[0])
+  __m128d reg_res_0 = _mm_sub_pd(reg_p1, reg_p2);
+  reg_res_0 = _mm_mul_pd(three, reg_res_0);
+  reg_res_0 = _mm_add_pd(reg_res_0, reg_p3);
+  reg_res_0 = _mm_sub_pd(reg_res_0, reg_p0);
+  reg_res_0 = _mm_mul_pd(reg_x, reg_res_0);
+
+  // reg_res_1 = 2.0 * p[0] - 5.0 * p[1] + 4.0 * p[2]- p[3]
+  const __m128d regp0_x_2 = _mm_mul_pd(two, reg_p0);
+  const __m128d regp1_x_5 = _mm_mul_pd(five, reg_p1);
+  const __m128d regp2_x_4 = _mm_mul_pd(four, reg_p2);
+  __m128d reg_res_1 = _mm_sub_pd(regp0_x_2, regp1_x_5);
+  reg_res_1 = _mm_add_pd(reg_res_1, regp2_x_4);
+  reg_res_1 = _mm_sub_pd(reg_res_1, reg_p3);
+
+  // reg_res_2 = x * (reg_res_1 + reg_res_0)
+  __m128d reg_res_2 = _mm_add_pd(reg_res_1, reg_res_0);
+  reg_res_2 = _mm_mul_pd(reg_x, reg_res_2);
+
+  // reg_res_3 = p[2] - p[0] + reg_res_2
+  __m128d reg_res_3 = _mm_sub_pd(reg_p2, reg_p0);
+  reg_res_3 = _mm_add_pd(reg_res_3, reg_res_2);
+
+  // reg_res_4 = p[1] + 0.5 * x * reg_res_3
+  __m128d reg_res_4 = _mm_mul_pd(_mm_mul_pd(half, reg_x), reg_res_3);
+  reg_res_4 = _mm_add_pd(reg_p1, reg_res_4);
+
+  _mm_storeu_pd(rate_dist_f, reg_res_4);
+}

--- a/test/model_rd_test.cc
+++ b/test/model_rd_test.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "gtest/gtest.h"
+
+#include "config/av2_rtcd.h"
+#include "avm_ports/avm_timer.h"
+#include "test/acm_random.h"
+#include "test/register_state_check.h"
+
+namespace {
+
+using InterpCubicRateDistFunc = void (*)(const double *p1, const double *p2,
+                                         double x, double rate_dist_f[2]);
+
+class InterpCubicTest
+    : public ::testing::TestWithParam<InterpCubicRateDistFunc> {
+ public:
+  InterpCubicTest()
+      : target_func_(GetParam()),
+        rnd_(libavm_test::ACMRandom::DeterministicSeed()) {}
+  double GenerateRandomDouble(double min, double max) {
+    return min + (static_cast<double>(rnd_.Rand31()) / ((1U << 31) - 1)) *
+                     (max - min);
+  }
+
+ protected:
+  void CheckOutput();
+  void SpeedTest();
+  InterpCubicRateDistFunc target_func_;
+  libavm_test::ACMRandom rnd_;
+};
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(InterpCubicTest);
+
+#if ARCH_X86 || ARCH_X86_64
+/* On x86, disable the x87 unit's internal 80 bit precision for better
+ * consistency with the SSE unit's 64 bit precision.
+ */
+#include "avm_ports/x86.h"
+#define FLOATING_POINT_SET_PRECISION \
+  unsigned short x87_orig_mode = x87_set_double_precision();
+#define FLOATING_POINT_RESTORE_PRECISION x87_set_control_word(x87_orig_mode);
+#else
+#define FLOATING_POINT_SET_PRECISION
+#define FLOATING_POINT_RESTORE_PRECISION
+#endif  // ARCH_X86 || ARCH_X86_64
+
+void InterpCubicTest::CheckOutput() {
+  double p1[4], p2[4], out_ref[2], out_mod[2];
+  constexpr int kNumIters = 10000;
+  for (int iter = 0; iter < kNumIters; ++iter) {
+    for (int i = 0; i < 4; ++i) {
+      p1[i] = GenerateRandomDouble(0.0000, 4096.000000);
+      p2[i] = GenerateRandomDouble(0.0000, 16.0000);
+    }
+    const double x = GenerateRandomDouble(0.0000, 1.0000);
+
+    FLOATING_POINT_SET_PRECISION
+    av2_interp_cubic_rate_dist_c(p1, p2, x, out_ref);
+    FLOATING_POINT_RESTORE_PRECISION
+
+    API_REGISTER_STATE_CHECK(target_func_(p1, p2, x, out_mod));
+
+    EXPECT_EQ(out_ref[0], out_mod[0]) << "Error: rate_f value mismatch";
+    EXPECT_EQ(out_ref[1], out_mod[1]) << "Error: distbysse_f value mismatch";
+  }
+}
+
+void InterpCubicTest::SpeedTest() {
+  double p1[4], p2[4], out_ref[2], out_mod[2];
+
+  for (int i = 0; i < 4; ++i) {
+    p1[i] = GenerateRandomDouble(0.0000, 4096.0000);
+    p2[i] = GenerateRandomDouble(0.0000, 16.0000);
+  }
+  const double x = GenerateRandomDouble(0.0000, 1.0000);
+
+  constexpr int kNumIters = 100000000;
+
+  avm_usec_timer ref_timer, test_timer;
+  FLOATING_POINT_SET_PRECISION
+  avm_usec_timer_start(&ref_timer);
+  for (int iter = 0; iter < kNumIters; ++iter) {
+    av2_interp_cubic_rate_dist_c(p1, p2, x, out_ref);
+  }
+  avm_usec_timer_mark(&ref_timer);
+  FLOATING_POINT_RESTORE_PRECISION
+  const int elapsed_time_c =
+      static_cast<int>(avm_usec_timer_elapsed(&ref_timer));
+
+  avm_usec_timer_start(&test_timer);
+  for (int iter = 0; iter < kNumIters; ++iter) {
+    API_REGISTER_STATE_CHECK(target_func_(p1, p2, x, out_mod));
+  }
+  avm_usec_timer_mark(&test_timer);
+  const int elapsed_time_simd =
+      static_cast<int>(avm_usec_timer_elapsed(&test_timer));
+
+  printf(
+      "c_time=%d \t simd_time=%d \t "
+      "Scaling=%lf \n",
+      elapsed_time_c, elapsed_time_simd,
+      (static_cast<double>(elapsed_time_c) / elapsed_time_simd));
+}
+
+TEST_P(InterpCubicTest, CheckOutput) { CheckOutput(); }
+
+TEST_P(InterpCubicTest, DISABLED_Speed) { SpeedTest(); }
+
+#if HAVE_SSE2
+INSTANTIATE_TEST_SUITE_P(SSE2, InterpCubicTest,
+                         ::testing::Values(av2_interp_cubic_rate_dist_sse2));
+#endif  // HAVE_SSE2
+
+}  // namespace

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -220,6 +220,7 @@ if(NOT BUILD_SHARED_LIBS)
     "${AVM_ROOT}/test/horver_correlation_test.cc"
     "${AVM_ROOT}/test/masked_sad_test.cc"
     "${AVM_ROOT}/test/masked_variance_test.cc"
+    "${AVM_ROOT}/test/model_rd_test.cc"
     "${AVM_ROOT}/test/motion_vector_test.cc"
     "${AVM_ROOT}/test/noise_model_test.cc"
     "${AVM_ROOT}/test/quantize_func_test.cc"


### PR DESCRIPTION
This patch refactors av2_model_rd_curvfit() by consolidating two
interp_cubic() calls for computing rate and distortion. Also, the 
relevant SSE2 implementation for the combined interp_cubic()
function along with its corresponding unit test is added. The 
SSE2 implementation achieves ~1.21x speedup compared to the
scalar C version. (adopted from libaom:
https://aomedia-review.googlesource.com/c/aom/+/211441)

Also, unnecessary calls to the function get_dqv() in
update_coeff_general(), update_coeff_simple(), and 
update_coeff_eob() are removed.

Test results (RA)
Anchor: commit 165345b
A1 - 17 frames
A2 - 33 frames

```
--------------------------------------
Speed   Class    Encoder Instruction 
                 Count Reduction (%)
-------------------------------------
  0       A2         0.32
          A1         0.23
-------------------------------------
  1       A2         0.31            
          A1         0.21            
-------------------------------------
  2       A2         0.19            
          A1         0.10            
-------------------------------------
  3       A2         0.26            
          A1         0.11            
-------------------------------------
```
