### PR TITLE
Clean up unused ref_frame_sign_bias[] in `AV2Common` structure

### DIFF
--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -2829,14 +2829,8 @@ typedef struct AV2Common {
    */
   int tpl_mvs_mem_size_col;
   /*!
-   * ref_frame_sign_bias[k] is 1 if relative distance between reference 'k' and
-   * current frame is positive; and 0 otherwise.
-   */
-  int ref_frame_sign_bias[INTER_REFS_PER_FRAME];
-  /*!
    * ref_frame_side[k] is 1 if relative distance between reference 'k' and
    * current frame is positive, -1 if relative distance is 0; and 0 otherwise.
-   * TODO(jingning): This can be combined with sign_bias later.
    */
   int8_t ref_frame_side[INTER_REFS_PER_FRAME];
   /*!

--- a/av2/common/mvref_common.c
+++ b/av2/common/mvref_common.c
@@ -2939,15 +2939,6 @@ void av2_setup_frame_buf_refs(AV2_COMMON *cm) {
   }
 }
 
-void av2_setup_frame_sign_bias(AV2_COMMON *cm) {
-  memset(&cm->ref_frame_sign_bias, 0, sizeof(cm->ref_frame_sign_bias));
-  for (int ref_frame = 0; ref_frame < cm->ref_frames_info.num_future_refs;
-       ++ref_frame) {
-    const int index = cm->ref_frames_info.future_refs[ref_frame];
-    cm->ref_frame_sign_bias[index] = 1;
-  }
-}
-
 // Get the temporal distance of start_frame to its closest ref frame
 // that has interpolation property relative to current frame. Interpolation
 // means start_frame and its ref frame are on two sides of current frame

--- a/av2/common/mvref_common.h
+++ b/av2/common/mvref_common.h
@@ -501,7 +501,6 @@ static AVM_INLINE void get_mv_projection(MV *output, MV ref, int num, int den) {
 }
 
 void av2_setup_frame_buf_refs(AV2_COMMON *cm);
-void av2_setup_frame_sign_bias(AV2_COMMON *cm);
 void av2_setup_skip_mode_allowed(AV2_COMMON *cm);
 void av2_setup_motion_field(AV2_COMMON *cm);
 void av2_setup_ref_frame_sides(AV2_COMMON *cm);

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -9015,8 +9015,6 @@ static int read_uncompressed_header(AV2Decoder *pbi, OBU_TYPE obu_type,
 
   av2_setup_frame_buf_refs(cm);
 
-  av2_setup_frame_sign_bias(cm);
-
   cm->cur_frame->frame_type = current_frame->frame_type;
   cm->cur_frame->is_restricted_switch_frame =
       (current_frame->frame_type == S_FRAME &&

--- a/av2/encoder/encode_strategy.c
+++ b/av2/encoder/encode_strategy.c
@@ -966,7 +966,6 @@ static int denoise_and_encode(AV2_COMP *const cpi, uint8_t *const dest,
       av2_set_speed_features_framesize_dependent(cpi, oxcf->speed);
       av2_set_rd_speed_thresholds(cpi);
       av2_setup_frame_buf_refs(cm);
-      av2_setup_frame_sign_bias(cm);
       av2_frame_init_quantizer(cpi);
       av2_setup_past_independence(cm);
 

--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -2388,7 +2388,6 @@ void av2_encode_frame(AV2_COMP *cpi) {
   av2_setup_frame_buf_refs(cm);
   enforce_max_ref_frames(cpi, &cm->ref_frame_flags);
   set_rel_frame_dist(cm, &cpi->ref_frame_dist_info, cm->ref_frame_flags);
-  av2_setup_frame_sign_bias(cm);
   cpi->palette_pixel_num = 0;
 #if CONFIG_MISMATCH_DEBUG
   mismatch_reset_frame(num_planes);


### PR DESCRIPTION
The `ref_frame_sign_bias` array in the `AV2Common` structure is populated in `av2_setup_frame_sign_bias()` but never used. This patch cleans up the unused array and the associated code.