### PR TITLE
Check the requirement on is_first_tile_group

### DIFF
--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -9606,6 +9606,14 @@ int32_t av2_read_tilegroup_header(
   send_first_tile_group_indication &= obu_type != OBU_BRIDGE_FRAME;
   if (send_first_tile_group_indication)
     is_first_tile_group = avm_rb_read_bit(rb);
+  // It is a requirement of bitstream conformance that SeenFrameHeader is not
+  // equal to is_first_tile_group.
+  if (pbi->seen_frame_header == is_first_tile_group) {
+    avm_internal_error(
+        &cm->error, AVM_CODEC_CORRUPT_FRAME,
+        "SeenFrameHeader (%d) is equal to is_first_tile_group (%d)",
+        pbi->seen_frame_header, is_first_tile_group);
+  }
   *first_tile_group_in_frame = is_first_tile_group;
 
   if (is_first_tile_group) {


### PR DESCRIPTION
Check the requirement of bitstream conformance that SeenFrameHeader is not equal to is_first_tile_group. If this requirement is not met, the decoder may skip the read_uncompressed_header() call in av2_read_tilegroup_header(), which eventually leads to a null pointer dereference.

Fixes https://github.com/AOMediaCodec/avm/issues/5142.