### PR TITLE
Add macro for maximum qp selection

### DIFF
--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -103,6 +103,11 @@ extern "C" {
 
 #define MIN_BSIZE_WARP_DELTA 8
 
+#define MAXQ_FOR_GIVEN_BIT_DEPTH(bit_depth)    \
+  ((bit_depth) == AVM_BITS_8    ? MAXQ_8_BITS  \
+   : (bit_depth) == AVM_BITS_10 ? MAXQ_10_BITS \
+                                : MAXQ)
+
 /*!\cond */
 
 #if CONFIG_PARAKIT_COLLECT_DATA

--- a/av2/common/quant_common.c
+++ b/av2/common/quant_common.c
@@ -99,9 +99,7 @@ int av2_q_clamped(int qindex, int delta, int base_dc_delta_q,
     q_clamped = 0;
   else
     q_clamped = clamp(qindex + base_dc_delta_q + delta, 1,
-                      bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-                      : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                 : MAXQ);
+                      MAXQ_FOR_GIVEN_BIT_DEPTH(bit_depth));
   return q_clamped;
 }
 // Add the deltaq offset value
@@ -142,10 +140,8 @@ static int32_t get_q(int qindex, int delta, avm_bit_depth_t bit_depth) {
     return ac_qlookup_QTX[0];
   }
 
-  const int q_clamped = clamp(qindex + delta, 1,
-                              bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-                              : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                         : MAXQ);
+  const int q_clamped =
+      clamp(qindex + delta, 1, MAXQ_FOR_GIVEN_BIT_DEPTH(bit_depth));
   return qlookup(q_clamped);
 }
 
@@ -165,10 +161,7 @@ int av2_get_qindex(const struct segmentation *seg, int segment_id,
     const int data = get_segdata(seg, segment_id, SEG_LVL_ALT_Q);
     const int seg_qindex = base_qindex + data;
 
-    return clamp(seg_qindex, 0,
-                 bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-                 : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                            : MAXQ);
+    return clamp(seg_qindex, 0, MAXQ_FOR_GIVEN_BIT_DEPTH(bit_depth));
   } else {
     return base_qindex;
   }

--- a/av2/decoder/decodemv.c
+++ b/av2/decoder/decodemv.c
@@ -1497,9 +1497,7 @@ static void read_delta_q_params(AV2_COMMON *const cm, MACROBLOCKD *const xd,
     /* Normative: Clamp to [1,MAXQ] to not interfere with lossless mode */
     xd->current_base_qindex =
         clamp(xd->current_base_qindex, 1,
-              cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-              : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                        : MAXQ);
+              MAXQ_FOR_GIVEN_BIT_DEPTH(cm->seq_params.bit_depth));
   }
 }
 

--- a/av2/encoder/aq_cyclicrefresh.c
+++ b/av2/encoder/aq_cyclicrefresh.c
@@ -44,9 +44,7 @@ CYCLIC_REFRESH *av2_cyclic_refresh_alloc(int mi_rows, int mi_cols,
          : bit_depth == AVM_BITS_10
              ? (MAXQ_10_BITS <= (QINDEX_RANGE_10_BITS - 1))
              : (MAXQ <= (QINDEX_RANGE - 1)));
-  const uint16_t qinit = bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-                         : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                    : MAXQ;
+  const uint16_t qinit = MAXQ_FOR_GIVEN_BIT_DEPTH(bit_depth);
   for (int i = 0; i < mi_rows * mi_cols; ++i) cr->last_coded_q_map[i] = qinit;
 
   cr->avg_frame_low_motion = 0.0;
@@ -428,9 +426,7 @@ void av2_cyclic_refresh_setup(AV2_COMP *const cpi) {
     if (cm->current_frame.frame_type == KEY_FRAME) {
       for (int i = 0; i <= (cm->mi_params.mi_rows * cm->mi_params.mi_cols); i++)
         cr->last_coded_q_map[i] =
-            cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-            : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                      : MAXQ;
+            MAXQ_FOR_GIVEN_BIT_DEPTH(cm->seq_params.bit_depth);
 
       cr->sb_index = 0;
     }
@@ -477,10 +473,7 @@ void av2_cyclic_refresh_setup(AV2_COMP *const cpi) {
 
     const int qindex2 = clamp(
         quant_params->base_qindex + quant_params->y_dc_delta_q + qindex_delta,
-        0,
-        cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-        : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                  : MAXQ);
+        0, MAXQ_FOR_GIVEN_BIT_DEPTH(cm->seq_params.bit_depth));
 
     cr->rdmult = av2_compute_rd_mult(cpi, qindex2);
 

--- a/av2/encoder/encodeframe_utils.c
+++ b/av2/encoder/encodeframe_utils.c
@@ -1077,10 +1077,7 @@ int av2_get_q_for_deltaq_objective(AV2_COMP *const cpi, BLOCK_SIZE bsize,
   offset = AVMMAX(offset, -delta_q_info->delta_q_res * 9 + 1);
   int qindex = cm->quant_params.base_qindex + offset;
 
-  qindex =
-      AVMMIN(qindex, cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-                     : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                               : MAXQ);
+  qindex = AVMMIN(qindex, MAXQ_FOR_GIVEN_BIT_DEPTH(cm->seq_params.bit_depth));
   qindex = AVMMAX(qindex, MINQ);
 
   return qindex;

--- a/av2/encoder/ratectrl.c
+++ b/av2/encoder/ratectrl.c
@@ -1078,9 +1078,7 @@ static int apply_tcq_qp_offset(const AV2_COMP *cpi, int qp_tcq) {
   } else {
     tcq_qp_offset_shift = 0;
   }
-  int max_qp = bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-               : bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                          : MAXQ;
+  int max_qp = MAXQ_FOR_GIVEN_BIT_DEPTH(bit_depth);
   return clamp(qp_tcq + tcq_qp_offset_shift, 0, max_qp);
 }
 

--- a/av2/encoder/rd.c
+++ b/av2/encoder/rd.c
@@ -711,11 +711,8 @@ int av2_get_deltaq_offset(const AV2_COMP *cpi, int qindex, double beta) {
       qindex++;
       q = av2_dc_quant_QTX(qindex, 0, cpi->common.seq_params.base_y_dc_delta_q,
                            cpi->common.seq_params.bit_depth);
-    } while (newq > q &&
-             (qindex <
-              (cpi->common.seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-               : cpi->common.seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                                 : MAXQ)));
+    } while (newq > q && (qindex < MAXQ_FOR_GIVEN_BIT_DEPTH(
+                                       cpi->common.seq_params.bit_depth)));
   }
   return qindex - orig_qindex;
 }
@@ -811,10 +808,7 @@ static void set_block_thresholds(const AV2_COMMON *cm, RD_OPT *rd) {
         clamp(av2_get_qindex(&cm->seg, segment_id, cm->quant_params.base_qindex,
                              cm->seq_params.bit_depth) +
                   cm->quant_params.y_dc_delta_q,
-              0,
-              cm->seq_params.bit_depth == AVM_BITS_8    ? MAXQ_8_BITS
-              : cm->seq_params.bit_depth == AVM_BITS_10 ? MAXQ_10_BITS
-                                                        : MAXQ);
+              0, MAXQ_FOR_GIVEN_BIT_DEPTH(cm->seq_params.bit_depth));
 
     const int q = compute_rd_thresh_factor(
         qindex, cm->seq_params.base_y_dc_delta_q, cm->seq_params.bit_depth);


### PR DESCRIPTION
This change adds a macro `MAXQ_FOR_GIVEN_BIT_DEPTH()` and replaces the ternary operators used to compute max-qp using the macro.

No stats changed.