### PR TITLE
Fix mismatch when end-usage=q: QP inconsistency between encoder and d…

### DIFF
--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -3222,6 +3222,84 @@ static void cdef_restoration_frame(AV2_COMP *cpi, AV2_COMMON *cm,
 #endif
 }
 
+// Reconstruct the QP state that the decoder will derive from the bitstream.
+static void sync_delta_q_for_loop_filter(AV2_COMP *cpi) {
+  AV2_COMMON *const cm = &cpi->common;
+  const DeltaQInfo *const delta_q_info = &cm->delta_q_info;
+  if (!delta_q_info->delta_q_present_flag) return;
+
+  const int max_qindex = cm->seq_params.bit_depth == AVM_BITS_8 ? MAXQ_8_BITS
+                         : cm->seq_params.bit_depth == AVM_BITS_10
+                             ? MAXQ_10_BITS
+                             : MAXQ;
+  CommonModeInfoParams *const mi_params = &cm->mi_params;
+
+  for (int tile_row = 0; tile_row < cm->tiles.rows; ++tile_row) {
+    TileInfo tile_info;
+    av2_tile_set_row(&tile_info, cm, tile_row);
+    for (int tile_col = 0; tile_col < cm->tiles.cols; ++tile_col) {
+      av2_tile_set_col(&tile_info, cm, tile_col);
+      int current_base_qindex = cm->quant_params.base_qindex;
+
+      for (int mi_row = tile_info.mi_row_start; mi_row < tile_info.mi_row_end;
+           mi_row += cm->mib_size) {
+        for (int mi_col = tile_info.mi_col_start; mi_col < tile_info.mi_col_end;
+             mi_col += cm->mib_size) {
+          const int mi_index = mi_row * mi_params->mi_stride + mi_col;
+          MB_MODE_INFO *const mbmi = mi_params->mi_grid_base[mi_index];
+          if (mbmi == NULL) continue;
+
+          const BLOCK_SIZE bsize = mbmi->sb_type[PLANE_TYPE_Y];
+          const int skip = mbmi->skip_txfm[0];
+          const int super_block_upper_left =
+              ((mi_row & (cm->mib_size - 1)) == 0) &&
+              ((mi_col & (cm->mib_size - 1)) == 0);
+          // Delta-q syntax is written only by the upper-left leaf of an SB. A
+          // full-SB skip does not signal delta-q, so the decoder keeps the
+          // previous current_base_qindex for that SB.
+          const int syntax_present =
+              (bsize != cm->sb_size || skip == 0) && super_block_upper_left;
+
+          if (syntax_present) {
+            const int reduced_delta_qindex =
+                (mbmi->current_qindex - current_base_qindex) /
+                delta_q_info->delta_q_res;
+            current_base_qindex =
+                clamp(current_base_qindex +
+                          reduced_delta_qindex * delta_q_info->delta_q_res,
+                      1, max_qindex);
+          }
+
+          /*
+           * The first leaf at the SB origin carries the delta-q syntax, but
+           * loop filtering visits every leaf MBMI. Apply the same effective
+           * base qindex to all leaf MBMIs in this SB; segmentation offsets
+           * remain per leaf.
+           */
+          const int sb_mi_row_end =
+              AVMMIN(mi_row + cm->mib_size, tile_info.mi_row_end);
+          const int sb_mi_col_end =
+              AVMMIN(mi_col + cm->mib_size, tile_info.mi_col_end);
+          for (int leaf_row = mi_row; leaf_row < sb_mi_row_end; ++leaf_row) {
+            for (int leaf_col = mi_col; leaf_col < sb_mi_col_end; ++leaf_col) {
+              MB_MODE_INFO *const leaf_mbmi =
+                  mi_params->mi_grid_base[leaf_row * mi_params->mi_stride +
+                                          leaf_col];
+              if (leaf_mbmi == NULL) continue;
+              const int seg_qindex =
+                  av2_get_qindex(&cm->seg, leaf_mbmi->segment_id,
+                                 current_base_qindex, cm->seq_params.bit_depth);
+              get_qindex_with_offsets(cm, seg_qindex,
+                                      leaf_mbmi->final_qindex_dc,
+                                      leaf_mbmi->final_qindex_ac);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 /*!\brief Select and apply in-loop deblocking filters, cdef filters, and
  * restoration filters
  *
@@ -4249,8 +4327,10 @@ static int encode_with_recode_loop_and_filter(AV2_COMP *cpi, size_t *size,
   av2_set_lr_tools(master_lr_tools_disable_mask[1], 2, &cm->features);
 
   // Pick the loop filter level for the frame.
-  if (!cm->bru.frame_inactive_flag && !cm->bridge_frame_info.is_bridge_frame)
+  if (!cm->bru.frame_inactive_flag && !cm->bridge_frame_info.is_bridge_frame) {
+    sync_delta_q_for_loop_filter(cpi);
     loopfilter_frame(cpi, cm);
+  }
   int64_t tip_as_output_sse = INT64_MAX;
   int64_t tip_as_output_rate = INT64_MAX;
 


### PR DESCRIPTION
### Problem
When delta-q syntax is not signaled for skip_txfm superblock, decoder uses last SB QP while encoder uses frame level /TPL calculated  QP, leading to reconstruction mismatch in loop filter (DBK/CDEF/LR).

### Solution
Replay delta-q state in bitstream order per tile before encoder loop filtering, refresh final_qindex_dc/ac with decoder-derived effective QP to align encoder & decoder filter QP.

### Test
- BD-Rate no regression
- Encode/decoder reconstruction pixel match

### Test Encode Command on Linux x64(end-usage=q)
```bash
./avmenc -v --test-decode=warn --usage=0 --cpu-used=0 --threads=1 -w 448 -h 960 --end-usage=q --cq-level=37 --psnr=1 --limit=65 --psnr=1 --kf-max-dist=256 --kf-min-dist=256 --lag-in-frames=35 --cpu-used=0 --passes=1 --sb-size=128 --enable-interintra-comp=0 --min-gf-interval=32 --max-gf-interval=32 --threads=64 --row-mt=1 --enable-uneven-4way-partitions=0 --enable-extended-sdp=1 --enable-palette=0 --enable-imp-msk-bld=0 --enable-fsc=0 --enable-idtx-intra=0 --enable-chroma-dctonly=1 --enable-flex-mvres=0 --enable-masked-comp=0 --enable-smooth-interintra=0 --enable-diff-wtd-comp=0 --enable-interintra-wedge=0 --enable-global-motion=0 --enable-mhccp=0 --enable-angle-delta=0 --reduced-ref-frame-mvs-mode=1 --reduced-reference-set=1 --enable-gdf=0 --enable-tip=0 --enable-bawp=0 --enable-cwp=0 --max-drl-refmvs=3 --enable-mv-traj=0 --max-reference-frames=7 --enable-warped-motion=0 --enable-intrabc=0 --enable-inter-ist=0 --enable-inter-ddt=0 --enable-ccso=0 --enable-tcq=2 -o fork_mismatch.bs ./xx.yuv  --recon=recon.yuv 
```

### recon/decode md5
<img width="966" height="230" alt="md5" src="https://github.com/user-attachments/assets/5f87c6b5-327b-46d6-9e42-c2ae51d2be7e" />

### encode bitstream
[v0d00fde0000bvttt2v3j66n5rbi0td0_fork_mismatch.bs.zip](https://github.com/user-attachments/files/30346189/v0d00fde0000bvttt2v3j66n5rbi0td0_fork_mismatch.bs.zip)
