### PR TITLE
Pruning compound reference frame search in speed >= 1

### DIFF
--- a/av2/common/entropymode.h
+++ b/av2/common/entropymode.h
@@ -46,8 +46,6 @@ extern "C" {
 
 #define COMPREF_BIT_TYPES 2
 #define RANKED_REF0_TO_PRUNE 3
-// The number of reference pictures for the same reference compound mode
-#define SAME_REF_COMPOUND_PRUNE 2
 #define MAX_REFS_ARF 4
 
 #define WIENERNS_4PART_CTX_MAX 1

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -99,6 +99,7 @@
 
 #define DEF_MAX_DRL_REFMVS 4
 #define DEF_MAX_DRL_REFBVS 4
+#define NUM_SAME_REF_COMPOUND 2
 #if CONFIG_ENTROPY_STATS
 FRAME_COUNTS aggregate_fc;
 #endif  // CONFIG_ENTROPY_STATS
@@ -483,7 +484,7 @@ void av2_init_seq_coding_tools(AV2_COMP *cpi, SequenceHeader *seq,
   // Disable frame by frame update for now. Can be changed later.
   seq->allow_frame_max_bvp_drl_bits = 0;
   seq->num_same_ref_compound =
-      seq->single_picture_header_flag ? 0 : SAME_REF_COMPOUND_PRUNE;
+      seq->single_picture_header_flag ? 0 : NUM_SAME_REF_COMPOUND;
 
   seq->max_frame_width = frm_dim_cfg->forced_max_frame_width
                              ? frm_dim_cfg->forced_max_frame_width

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -2260,6 +2260,35 @@ static AVM_INLINE void update_inter_mode_rd(HandleInterModeArgs *args,
   if (rd < *p) *p = rd;
 }
 
+// Priority list of cross compound reference pairs ordered based on selection
+// frequency.
+static const int comp_ref_priority[15][2] = {
+  { 0, 1 }, { 0, 2 }, { 0, 3 }, { 1, 2 }, { 0, 4 },
+  { 0, 5 }, { 2, 3 }, { 1, 4 }, { 1, 3 }, { 1, 5 },
+  { 2, 5 }, { 0, 6 }, { 1, 6 }, { 2, 4 }, { 2, 6 },
+};
+
+// Returns 1 if a compound reference pair (ref_frame, second_ref_frame) should
+// be pruned based on the reduce_comp_refs speed feature limit.
+static AVM_INLINE int prune_comp_ref_by_priority(
+    const INTER_MODE_SPEED_FEATURES *inter_sf, PREDICTION_MODE mode,
+    int ref_frame, int second_ref_frame) {
+  const int reduce_comp_refs = inter_sf->reduce_comp_refs;
+  if (!reduce_comp_refs || ref_frame == second_ref_frame) return 0;
+
+  // In compound modes other than NEAR_NEARMV and NEAR_NEARMV_OPTFLOW, search
+  // top-N compound reference pairs in the priority list.
+  if (mode == NEAR_NEARMV || mode == NEAR_NEARMV_OPTFLOW) return 0;
+  const int limit = AVMMIN(reduce_comp_refs, 15);
+  for (int ref_idx = 0; ref_idx < limit; ++ref_idx) {
+    if (comp_ref_priority[ref_idx][0] == ref_frame &&
+        comp_ref_priority[ref_idx][1] == second_ref_frame) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
 // Returns 1 if a single-ref mode (e.g. NEWMV or GLOBALMV) for this ref frame
 // should be skipped because the matching reference RD is not within
 // (1 / slack_denom) of the best reference RD across all ref frames. Decision
@@ -9169,6 +9198,11 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
     }
 
     if (comp_pred && !(cm->ref_frame_flags & (1 << second_ref_frame))) continue;
+
+    if (comp_pred && prune_comp_ref_by_priority(&sf->inter_sf, this_mode,
+                                                ref_frame, second_ref_frame)) {
+      continue;
+    }
 
     const MV_REFERENCE_FRAME ref_frames[2] = { ref_frame, second_ref_frame };
     init_mbmi(mbmi, this_mode, ref_frames, cm, xd, xd->sbi);

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -341,6 +341,7 @@ static void set_good_speed_features_framesize_independent(
     // TODO (Yeqing Wu): need to be tuned for speed > 1.
     sf->inter_sf.skip_compound_prune_top_refs_num_ref0 = 1;
     sf->inter_sf.skip_compound_prune_top_refs_num_ref1 = 2;
+    sf->inter_sf.reduce_comp_refs = 2;
     sf->inter_sf.disable_switchable_refinemv = 1;
     sf->inter_sf.prune_refinemv_by_ref_idx = 1;
     sf->inter_sf.prune_interintra_by_ref_idx = 1;
@@ -751,6 +752,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->reduce_inter_modes = 0;
   inter_sf->alt_ref_search_fp = 0;
   inter_sf->disable_switchable_refinemv = 0;
+  inter_sf->reduce_comp_refs = 0;
   inter_sf->selective_ref_frame = 0;
   inter_sf->prune_newmv_modes_using_prior_rd = 0;
   inter_sf->share_motion_mode_prune_pool = 0;
@@ -1110,6 +1112,11 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
 
     cpi->common.seq_params.enable_masked_compound &=
         !sf->inter_sf.disable_masked_comp;
+
+    if (sf->inter_sf.reduce_comp_refs) {
+      cpi->common.seq_params.num_same_ref_compound =
+          AVMMIN(cpi->common.seq_params.num_same_ref_compound, 1);
+    }
 
     if (sf->intra_sf.skip_intra_dip_search) {
       cpi->common.seq_params.enable_intra_dip = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -579,6 +579,13 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // 2 implies prune horiz, vert and extended partition
   int prune_ref_frames;
 
+  // When set to N>0, this flag limits the maximum number of compound
+  // reference frame combinations evaluated in the RD search. For all compound
+  // modes, same reference compound is restricted to (0,0). For non-NEAR_NEARMV
+  // and non-NEAR_NEARMV_OPTFLOW modes, the evaluation is limited to top N
+  // compound reference combinations in priority order.
+  int reduce_comp_refs;
+
   // Prune reference frames for ALTREF
   int alt_ref_search_fp;
 


### PR DESCRIPTION
Introduce a speed feature for speed >= 1 to
1. Allow only one same reference compound (0,0) and disallow (1,1)
2. Define a priority array for compound reference pairs based on selection frequency, and only allow the top 2 in the array for all compound modes other than NEAR_NEARMV and NEAR_NEARMV_OPTFLOW

The macro SAME_REF_COMPOUND_PRUNE in entropymode.h is renamed and moved to encoder.c because it is only used by the encoder.

RA 33 frames, speed 1
Anchor: 8fbe5622b2

    +---------+--------+--------+--------+--------+----------+----------+
    | Summary |   Y    |   U    |   V    |  YUV   | Enc-time | Dec-time |
    +---------+--------+--------+--------+--------+----------+----------+
    | A1      | +0.01% | +0.06% | -0.05% | +0.01% | 97.9%    | 100.0%   |
    | A2      | +0.04% | +0.00% | +0.35% | +0.04% | 97.4%    | 100.6%   |
    | Avg     | +0.03% | +0.02% | +0.23% | +0.03% | 97.6%    | 100.4%   |
    +---------+--------+--------+--------+--------+----------+----------+
