### PR TITLE
Add warp interintra in winner based on wrl index

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -3308,6 +3308,14 @@ static int64_t motion_mode_rd(
            warp_inter_intra++) {
         for (int warp_ref_idx = 0; warp_ref_idx < warp_ref_idx_limit;
              warp_ref_idx++) {
+          // Search warp interintra in winner mode for remaing wrl indices
+          // if warp interintra is selected in rough mode
+          if (cpi->sf.inter_sf.enable_warp_inter_intra_in_winner &&
+              (eval_motion_mode != (warp_inter_intra && warp_ref_idx < 2)))
+            continue;
+          assert(IMPLIES(cpi->sf.inter_sf.enable_warp_inter_intra_in_winner &&
+                             !eval_motion_mode,
+                         (!warp_inter_intra || warp_ref_idx >= 2)));
           for (int warpmv_with_mvd_flag = 0; warpmv_with_mvd_flag < 2;
                warpmv_with_mvd_flag++) {
             const MotionModeTrialParams trial = {
@@ -8410,10 +8418,13 @@ static const unsigned int num_winner_motion_modes[3] = { 0, 10, 6 };
 // Returns true if a mode is added to the winner mode check.
 static AVM_INLINE int is_check_in_winner(const AV2_COMP *cpi,
                                          const MB_MODE_INFO *const mbmi) {
-  if (!cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode) return 0;
   PREDICTION_MODE this_mode = mbmi->mode;
-
-  if (this_mode == WARP_NEWMV) return 1;
+  if (cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode) {
+    if (this_mode == WARP_NEWMV) return 1;
+  }
+  if (cpi->sf.inter_sf.enable_warp_inter_intra_in_winner) {
+    if (this_mode == WARPMV && mbmi->warp_inter_intra) return 1;
+  }
   return 0;
 }
 // Adds a motion mode to the candidate list for motion_mode_for_winner_cand

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -388,6 +388,7 @@ static void set_good_speed_features_framesize_independent(
     sf->tx_sf.adaptive_tcq_threshold_qidx = 185;
     sf->inter_sf.enable_enhanced_inter_mode_cache_reuse = 1;
     sf->inter_sf.skip_temporary_pred_for_opfl = 1;
+    sf->inter_sf.enable_warp_inter_intra_in_winner = 1;
 
     // Enable the optimized inter-SDP fast method (requires >=1 intra coded
     // block, prunes when inter-mode ratio exceeds 50%, and early skips when
@@ -748,6 +749,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->adaptive_rd_thresh = 0;
   inter_sf->model_based_post_interp_filter_breakout = 0;
   inter_sf->skip_temporary_pred_for_opfl = 0;
+  inter_sf->enable_warp_inter_intra_in_winner = 0;
   inter_sf->reduce_inter_modes = 0;
   inter_sf->alt_ref_search_fp = 0;
   inter_sf->disable_switchable_refinemv = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -731,7 +731,8 @@ typedef struct INTER_MODE_SPEED_FEATURES {
 
   // skip temporary predictions for opfl modes
   int skip_temporary_pred_for_opfl;
-
+  // Enable warp inter intra in winner mode.
+  int enable_warp_inter_intra_in_winner;
   // Reuse compound type rd decision when exact match is found
   // 0: No reuse
   // 1: Reuse the compound type rd data


### PR DESCRIPTION
Search warp interintra in rough mode when wrl index is greater than or equal to 2

Search warp interintra in winner mode for remaing wrl indices if warp interintra is selected in rough mode

Search warp interintra in winner mode for warpmv with mvd flag if warp interintra is selected in rough mode with warpmv with mvd flag off

Anchor: ef64fa8137f58586f3e4c1a8ffcb34872e7f3c0d
Results:

```
+---------+-------+--------+-------+-------+----------+----------+
| Summary |   Y   |   U    |   V   |  YUV  | Enc-time | Dec-time |
+---------+-------+--------+-------+-------+----------+----------+
| A1      | 0.07% | -0.01% | 0.23% | 0.07% | 97.6%    | 100.1%   |
| A2      | 0.05% | -0.03% | 0.28% | 0.06% | 96.8%    | 99.0%    |
+---------+-------+--------+-------+-------+----------+----------+
```
