### PR TITLE
Transform partition encoder speedup

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -1333,6 +1333,7 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
   if (cpi->oxcf.mode == GOOD && speed >= 0) {
     const int qindex_thresh = 135 + qindex_offset;
     const int qindex_thresh2 = 113 + qindex_offset;
+    const int qindex_thresh4 = 160 + qindex_offset;
     if (cpi->oxcf.gf_cfg.lag_in_frames == 0) {
       if (cm->quant_params.base_qindex <= (frame_is_intra_only(&cpi->common)
                                                ? qindex_thresh2
@@ -1340,7 +1341,8 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
         sf->tx_sf.restrict_tx_partition_type_search = 2;
       }
     } else {
-      if (cm->quant_params.base_qindex <= qindex_thresh2) {
+      if (cm->quant_params.base_qindex <=
+          ((speed < 1) ? qindex_thresh2 : qindex_thresh4)) {
         sf->tx_sf.restrict_tx_partition_type_search = 1;
       }
     }


### PR DESCRIPTION
Tweak the speed feature 'restrict_tx_partition_type_search'.

Anchor: 41fc9bf31dcbecb6d6943441fe3e5be0962ff70c
Test condition: CTC, RA, 33 frames, speed 1

```
+---------+--------+--------+--------+--------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time |
+---------+--------+--------+--------+--------+----------+
| A1      |  0.07% |  0.04% |  0.04% |  0.07% | 96.91%   |
| A2      |  0.05% |  0.03% |  0.22% |  0.05% | 96.22%   |
|avg wo b2|  0.06% |  0.04% | -0.02% |  0.06% | 96.24%   |
+---------+--------+--------+--------+--------+----------+

```

STATS_CHANGED