### PR TITLE
Fast method for AMVD with newmv mode

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -9222,6 +9222,13 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
         continue;
       }
 
+      if (sf->inter_sf.prune_amvd_newmv &&
+          cm->current_frame.pyramid_level >= 4 && (mbmi->mode == NEWMV)) {
+        if (mbmi->use_amvd && search_state.best_mbmode.mode != mbmi->mode) {
+          continue;
+        }
+      }
+
       // Skip single-ref NEWMV / WARP_NEWMV when prior-mode RD for this
       // ref frame is far from the best across all refs. See
       // prune_newmv_modes_by_prior_rd() for source selection and

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -380,6 +380,7 @@ static void set_good_speed_features_framesize_independent(
     // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
     // nearest searched result beyond the cap.
     sf->mv_sf.newmv_drl_search_limit = 2;
+    sf->inter_sf.prune_amvd_newmv = 1;
 
     sf->tx_sf.tx_type_search.skip_tx_search = 1;
     sf->tx_sf.tx_type_search.eob_adapt_skip_tx_search = true;
@@ -796,6 +797,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->skip_mode_eval_based_on_rate_cost = 0;
   inter_sf->reuse_erp_mode_flag = 0;
   inter_sf->prune_warpmv_prob_thresh = 32;
+  inter_sf->prune_amvd_newmv = 0;
   inter_sf->enable_enhanced_inter_mode_cache_reuse = 0;
 }
 

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -759,6 +759,11 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // 0: original cache reuse logic.
   // 1: enhanced cache reuse logic (more modes are searched).
   int enable_enhanced_inter_mode_cache_reuse;
+
+  // When set, skip AMVD evaluation for NEWMV if the
+  // current best mode is not the same mode as the one being evaluated, because
+  // AMVD on top of these modes is unlikely to win over the non-AMVD best mode.
+  int prune_amvd_newmv;
 } INTER_MODE_SPEED_FEATURES;
 
 typedef struct INTERP_FILTER_SPEED_FEATURES {


### PR DESCRIPTION
Add a tid based fast method for AMVD under newmv mode.

The results are tested on top of commit 5c2906938fcc38504.

Class A1 and A2 results are llisted below.

```
+---------+--------+--------+--------+--------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time |
+---------+--------+--------+--------+--------+----------+
| A1      |  0.07% |  -0.12% |  -0.03% |  0.05% | 98.2%   |
| A2      |  0.06% |  00.14% |  -0.24% |  0.05% | 97.9%   |
+---------+--------+--------+--------+--------+----------+
```
STATS_CHANGED