### PR TITLE
Skip AMVD modes for NEAR NEWMV, NEW NEARMV modes

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -9222,6 +9222,10 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
         continue;
       }
 
+      if (sf->inter_sf.skip_amvd_new_near_near_new_modes && amvd_inverted &&
+          mbmi->use_amvd && cm->current_frame.pyramid_level > 3)
+        continue;
+
       // Skip single-ref NEWMV / WARP_NEWMV when prior-mode RD for this
       // ref frame is far from the best across all refs. See
       // prune_newmv_modes_by_prior_rd() for source selection and

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -339,6 +339,7 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.prune_newmv_modes_using_prior_rd = 1;
     sf->inter_sf.share_motion_mode_prune_pool = 1;
     sf->inter_sf.prune_compound_using_single_ref = 1;
+    sf->inter_sf.skip_amvd_new_near_near_new_modes = 1;
     // TODO (Yeqing Wu): need to be tuned for speed > 1.
     sf->inter_sf.skip_compound_prune_top_refs_num_ref0 = 1;
     sf->inter_sf.skip_compound_prune_top_refs_num_ref1 = 2;
@@ -772,6 +773,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->skip_repeated_full_newmv = 0;
   inter_sf->inter_mode_rd_model_estimation = 0;
   inter_sf->prune_compound_using_single_ref = 0;
+  inter_sf->skip_amvd_new_near_near_new_modes = 0;
   inter_sf->skip_compound_prune_top_refs_num_ref0 = 0;
   inter_sf->skip_compound_prune_top_refs_num_ref1 = 0;
   inter_sf->prune_refinemv_by_ref_idx = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -649,6 +649,10 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // the single reference modes, it is one of the two best performers.
   int prune_compound_using_single_ref;
 
+  // skip amvd for new near and near new modes for both regular
+  // and opfl modes by tid
+  int skip_amvd_new_near_near_new_modes;
+
   // Top-ref0 / top-ref1 cutoffs used inside the prune_compound_using_single_ref
   // pruning. Compound pairs with refs[0] <
   // skip_compound_prune_top_refs_num_ref0 AND refs[1] <


### PR DESCRIPTION
Skip AMVD modes for NEAR NEWMV, NEW NEARMV, NEAR NEWMV OPFL and NEW NEARMV OPFL

Skip AMVD modes when tid level is greater than 3

Results:
Anchor: 0d25d5803a23907057f2ef018462425bc823a9c2

```
+---------+-------+-------+--------+-------+----------+----------+
| Summary |   Y   |   U   |   V    |  YUV  | Enc-time | Dec-time |
+---------+-------+-------+--------+-------+----------+----------+
| A1      | 0.06% | 0.09% | 0.17%  | 0.07% | 97.6%    | 99.7%    |
| A2      | 0.04% | 0.13% | -0.04% | 0.04% | 97.1%    | 101.3%   |
+---------+-------+-------+--------+-------+----------+----------+
```
