### PR TITLE
Adaptive tx search level

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -354,6 +354,8 @@ static void set_good_speed_features_framesize_independent(
 
     sf->tx_sf.adaptive_tx_type_search_idx = 4;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
+    sf->tx_sf.enable_adaptive_tx_search_level = true;
+
     sf->tx_sf.prune_intra_ist_stx_by_zero_eob = true;
 
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 2 : 1;
@@ -850,6 +852,7 @@ static AVM_INLINE void init_tx_sf(TX_SPEED_FEATURES *tx_sf) {
   tx_sf->restrict_tx_partition_type_search = 0;
   tx_sf->prune_inter_tx_part_rd_eval = false;
   tx_sf->enable_tx_partition = true;
+  tx_sf->enable_adaptive_tx_search_level = false;
   tx_sf->prune_intra_ist_stx_by_zero_eob = false;
 }
 

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -877,7 +877,8 @@ typedef struct TX_SPEED_FEATURES {
 
   // Enable txfm partition search
   bool enable_tx_partition;
-
+  // Enable adaptive tx search level
+  bool enable_adaptive_tx_search_level;
   // Enable adaptive TCQ threshold:
   bool enable_adaptive_tcq_threshold;
 

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -112,9 +112,15 @@ static const int tx_partition_prune_level[2][6] = { { 0, 1, 3, 3, 2, 3 },
 
 // look-up table of transform type pruning level used to prune the evaluation of
 // transform type based on best rd and eob.
-static const int tx_type_prune_level[2][6] = { { 0, 1, 2, 1, 2, 3 },
-                                               { 0, 1, 3, 3, 2, 3 } };
-
+static const int tx_type_prune_level[2][6] = {
+  { 0, 1, 2, 1, 2, 3 },  // eob >= max_eob / 8
+  { 0, 1, 3, 3, 2, 3 }   // eob < max_eob / 8
+};
+static const int tx_type_prune_level_3regions[3][6] = {
+  { 0, 1, 2, 1, 1, 3 },  // eob >= max_eob / 4
+  { 0, 1, 2, 1, 2, 3 },  // max_eob / 12 <= eob < max_eob / 4
+  { 0, 1, 3, 3, 3, 3 },  // eob < max_eob / 8
+};
 static INLINE uint32_t get_block_residue_hash(MACROBLOCK *x, BLOCK_SIZE bsize) {
   const int rows = block_size_high[bsize];
   const int cols = block_size_wide[bsize];
@@ -2694,9 +2700,19 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
         // Terminate the search early, If the best rd is higher than the
         // reference best rd and number of coded coefficients are smaller
         // than a threshold.
-        const int search_level =
-            tx_type_prune_level[mb_plane->eobs[block] < max_eob / 8]
-                               [tx_sf->adaptive_tx_type_search_idx];
+        int search_level = 0;
+        if (tx_sf->enable_adaptive_tx_search_level) {
+          const int eob_level = mb_plane->eobs[block] >= max_eob / 4    ? 0
+                                : mb_plane->eobs[block] >= max_eob / 12 ? 1
+                                                                        : 2;
+          search_level =
+              tx_type_prune_level_3regions[eob_level]
+                                          [tx_sf->adaptive_tx_type_search_idx];
+        } else {
+          search_level =
+              tx_type_prune_level[mb_plane->eobs[block] < max_eob / 8]
+                                 [tx_sf->adaptive_tx_type_search_idx];
+        }
         if (search_level &&
             (best_rd - (best_rd >> search_level)) > ref_best_rd) {
           skip_idx = true;

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -119,7 +119,7 @@ static const int tx_type_prune_level[2][6] = {
 static const int tx_type_prune_level_3regions[3][6] = {
   { 0, 1, 2, 1, 1, 3 },  // eob >= max_eob / 4
   { 0, 1, 2, 1, 2, 3 },  // max_eob / 12 <= eob < max_eob / 4
-  { 0, 1, 3, 3, 3, 3 },  // eob < max_eob / 8
+  { 0, 1, 3, 3, 3, 3 },  // eob < max_eob / 12
 };
 static INLINE uint32_t get_block_residue_hash(MACROBLOCK *x, BLOCK_SIZE bsize) {
   const int rows = block_size_high[bsize];
@@ -2702,9 +2702,9 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
         // than a threshold.
         int search_level = 0;
         if (tx_sf->enable_adaptive_tx_search_level) {
-          const int eob_level = mb_plane->eobs[block] >= max_eob / 4    ? 0
-                                : mb_plane->eobs[block] >= max_eob / 12 ? 1
-                                                                        : 2;
+          const int eob_level = (mb_plane->eobs[block] >= (max_eob / 4))    ? 0
+                                : (mb_plane->eobs[block] >= (max_eob / 12)) ? 1
+                                                                            : 2;
           search_level =
               tx_type_prune_level_3regions[eob_level]
                                           [tx_sf->adaptive_tx_type_search_idx];


### PR DESCRIPTION
Introduce 3 EOB levels adaptive tx search pruning.
eob_level = 0: eob >= max_eob / 4
eob_level = 1: max_eob / 12 <= eob < max_eob / 4
eob_level = 2: eob < max_eob / 12

Anchor: https://github.com/AOMediaCodec/avm/commit/0d25d5803a23907057f2ef018462425bc823a9c2
Tests: cpu-used =1, RA
A1 - 17 frames
A2 - 33 frames

```
+---------+--------+--------+--------+--------+----------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time | Dec-time |
+---------+--------+--------+--------+--------+----------+----------+
| A1      |  0.09% | -0.06% | -0.99% |  0.03% | 96.4%    | 99.5%    |
| A2      |  0.09% | -0.35% | -0.20% |  0.06% | 97.7%    | 99.6%    |
+---------+--------+--------+--------+--------+----------+----------+
```