### PR TITLE
Add the void cast to the tp_orig variable itself

### DIFF
--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -5554,7 +5554,7 @@ bool av2_rd_pick_partition(
   const TokenExtra *const tp_orig = *tp;
   PartitionSearchState part_search_state;
 
-  (void)*tp_orig;
+  (void)tp_orig;
   assert(pc_tree != NULL);
   assert(bsize < BLOCK_SIZES_ALL);
 


### PR DESCRIPTION
The void cast is used to ignore the tp_orig variable in Release builds
because tp_orig is only used in an assert(). So the void cast should be
applied to the variable itself rather than the expression *tp_orig.

This is a port from libaom:
 fd74e18c14 Add the void cast to the tp_orig variable itself
