### PR TITLE
Tweak adaptive_tx_type_search speed feature

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -1390,6 +1390,11 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
           ((speed < 1) ? qindex_thresh2 : qindex_thresh4)) {
         sf->tx_sf.restrict_tx_partition_type_search = 1;
       }
+
+      if (speed >= 1 && cm->quant_params.base_qindex <= qindex_thresh2) {
+        sf->tx_sf.adaptive_tx_type_search_idx = 5;
+        sf->tx_sf.adaptive_tx_partition_type_search_idx = 5;
+      }
     }
 
     if (cm->quant_params.base_qindex <= qindex_thresh &&


### PR DESCRIPTION
Tweak adaptive_tx_type_search speed feature

Anchor: 6d405a307dc47579befa9642a8d700e6c443d82a

Test condition: CTC, RA, 33 frames, speed 1
```
+---------+--------+--------+--------+--------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time |
+---------+--------+--------+--------+--------+----------+
| A1      |  0.01% | -0.03% |  0.08% |  0.01% | 99.14%   |
| A2      |  0.02% |  0.05% |  0.03% |  0.02% | 97.98%   |
|avg wo b2|  0.02% |  0.04% |  0.04% |  0.02% | 97.69%   |
+---------+--------+--------+--------+--------+----------+
```
STATS_CHANGED