### PR TITLE
Enable deblock filter for partition research

### DIFF
--- a/av2/common/av2_loopfilter.c
+++ b/av2/common/av2_loopfilter.c
@@ -553,7 +553,7 @@ static TX_SIZE set_lpf_parameters(
     AV2_COMMON *const cm, const MACROBLOCKD *const xd, const EDGE_DIR edge_dir,
     const uint32_t x, const uint32_t y, const int plane,
     const struct macroblockd_plane *const plane_ptr, TX_SIZE *tx_size,
-    int *mi_size_min) {
+    int *mi_size_min, const int dlk_rd_flag) {
   if (*mi_size_min) {
     *mi_size_min -= 1;
     return *tx_size;
@@ -611,7 +611,7 @@ static TX_SIZE set_lpf_parameters(
     check_sub_pu_edge(cm, xd, mbmi, plane, tree_type, scale_horz, scale_vert,
                       edge_dir, coord, &ts, &sub_pu_edge, &tx_m_partition_size);
     if (!tu_edge && !sub_pu_edge) return ts;
-    if (cm->seq_params.disable_loopfilters_across_tiles) {
+    if (cm->seq_params.disable_loopfilters_across_tiles || dlk_rd_flag) {
       if (edge_dir == VERT_EDGE)
         if (is_vert_tile_boundary(&cm->tiles, mi_col)) return ts;
       if (edge_dir == HORZ_EDGE)
@@ -812,7 +812,9 @@ static uint8_t get_lossless_flag(
 void av2_filter_block_plane_vert(AV2_COMMON *const cm,
                                  const MACROBLOCKD *const xd, const int plane,
                                  const MACROBLOCKD_PLANE *const plane_ptr,
-                                 const uint32_t mi_row, const uint32_t mi_col) {
+                                 const uint32_t mi_row, const uint32_t mi_col,
+                                 const int dlk_rd_flag,
+                                 const BLOCK_SIZE bsize) {
   if (!plane && !cm->lf.apply_deblocking_filter[0]) return;
   const int mib_size = cm->mib_size;
   const uint32_t scale_horz = plane_ptr->subsampling_x;
@@ -826,8 +828,14 @@ void av2_filter_block_plane_vert(AV2_COMMON *const cm,
   }
   uint16_t *const dst_ptr = plane_ptr->dst.buf;
   const int dst_stride = plane_ptr->dst.stride;
-  const int y_range = (mib_size >> scale_vert);
-  const int x_range = (mib_size >> scale_horz);
+  int x_range, y_range;
+  if (dlk_rd_flag) {
+    y_range = mi_size_high[bsize] >> scale_vert;
+    x_range = mi_size_wide[bsize] >> scale_horz;
+  } else {
+    y_range = (mib_size >> scale_vert);
+    x_range = (mib_size >> scale_horz);
+  }
 
   AV2_DEBLOCKING_PARAMETERS params_buf[MAX_MIB_SIZE];
   TX_SIZE tx_size_buf[MAX_MIB_SIZE] = { 0 };
@@ -852,9 +860,9 @@ void av2_filter_block_plane_vert(AV2_COMMON *const cm,
       uint32_t advance_units;
       TX_SIZE cur_tx_size = TX_4X4;
 
-      cur_tx_size = set_lpf_parameters(params, prev_x, curr_y, cm, xd,
-                                       VERT_EDGE, curr_x, curr_y, plane,
-                                       plane_ptr, tx_size, mi_size_min_height);
+      cur_tx_size = set_lpf_parameters(
+          params, prev_x, curr_y, cm, xd, VERT_EDGE, curr_x, curr_y, plane,
+          plane_ptr, tx_size, mi_size_min_height, dlk_rd_flag);
 
       if (cur_tx_size == TX_INVALID) {
         params->filter_length_neg = 0;
@@ -863,35 +871,38 @@ void av2_filter_block_plane_vert(AV2_COMMON *const cm,
         cur_tx_size = TX_4X4;
       }
 
-      const avm_bit_depth_t bit_depth = cm->seq_params.bit_depth;
-      bool is_lossless_current_block = get_lossless_flag(
-          cm, curr_x, curr_y, scale_horz, scale_vert, plane, plane_ptr);
-      bool is_lossless_prev_block = get_lossless_flag(
-          cm, prev_x, curr_y, scale_horz, scale_vert, plane, plane_ptr);
-      bool skip_deblock_lossless =
-          is_lossless_current_block && is_lossless_prev_block;
+      if (!dlk_rd_flag ||
+          !is_vert_tile_boundary(&cm->tiles, mi_col + (x << scale_horz))) {
+        const avm_bit_depth_t bit_depth = cm->seq_params.bit_depth;
+        bool is_lossless_current_block = get_lossless_flag(
+            cm, curr_x, curr_y, scale_horz, scale_vert, plane, plane_ptr);
+        bool is_lossless_prev_block = get_lossless_flag(
+            cm, prev_x, curr_y, scale_horz, scale_vert, plane, plane_ptr);
+        bool skip_deblock_lossless =
+            is_lossless_current_block && is_lossless_prev_block;
 
-      int do_filter = 1;
-      if (cm->seq_params.disable_loopfilters_across_tiles) {
-        if (is_vert_tile_boundary(&cm->tiles, mi_col + (x << scale_horz)))
-          do_filter = 0;
-      }
-      if (do_filter) {
-        if (!skip_deblock_lossless &&
-            (params->filter_length_neg || params->filter_length_pos)) {
-          if (!(is_lossless_prev_block || is_lossless_current_block)) {
-            avm_highbd_lpf_vertical_generic(
-                p, dst_stride, params->filter_length_neg,
-                params->filter_length_pos, &params->q_threshold,
-                &params->side_threshold, bit_depth, is_lossless_prev_block,
-                is_lossless_current_block);
+        int do_filter = 1;
+        if (cm->seq_params.disable_loopfilters_across_tiles) {
+          if (is_vert_tile_boundary(&cm->tiles, mi_col + (x << scale_horz)))
+            do_filter = 0;
+        }
+        if (do_filter) {
+          if (!skip_deblock_lossless &&
+              (params->filter_length_neg || params->filter_length_pos)) {
+            if (!(is_lossless_prev_block || is_lossless_current_block)) {
+              avm_highbd_lpf_vertical_generic(
+                  p, dst_stride, params->filter_length_neg,
+                  params->filter_length_pos, &params->q_threshold,
+                  &params->side_threshold, bit_depth, is_lossless_prev_block,
+                  is_lossless_current_block);
 
-          } else {
-            avm_highbd_lpf_vertical_generic_c(
-                p, dst_stride, params->filter_length_neg,
-                params->filter_length_pos, &params->q_threshold,
-                &params->side_threshold, bit_depth, is_lossless_prev_block,
-                is_lossless_current_block);
+            } else {
+              avm_highbd_lpf_vertical_generic_c(
+                  p, dst_stride, params->filter_length_neg,
+                  params->filter_length_pos, &params->q_threshold,
+                  &params->side_threshold, bit_depth, is_lossless_prev_block,
+                  is_lossless_current_block);
+            }
           }
         }
       }
@@ -911,7 +922,9 @@ void av2_filter_block_plane_vert(AV2_COMMON *const cm,
 void av2_filter_block_plane_horz(AV2_COMMON *const cm,
                                  const MACROBLOCKD *const xd, const int plane,
                                  const MACROBLOCKD_PLANE *const plane_ptr,
-                                 const uint32_t mi_row, const uint32_t mi_col) {
+                                 const uint32_t mi_row, const uint32_t mi_col,
+                                 const int dlk_rd_flag,
+                                 const BLOCK_SIZE bsize) {
   if (!plane && !cm->lf.apply_deblocking_filter[1]) return;
   const int mib_size = cm->mib_size;
   const uint32_t scale_horz = plane_ptr->subsampling_x;
@@ -925,8 +938,14 @@ void av2_filter_block_plane_horz(AV2_COMMON *const cm,
   }
   uint16_t *const dst_ptr = plane_ptr->dst.buf;
   const int dst_stride = plane_ptr->dst.stride;
-  const int y_range = (mib_size >> scale_vert);
-  const int x_range = (mib_size >> scale_horz);
+  int x_range, y_range;
+  if (dlk_rd_flag) {
+    y_range = mi_size_high[bsize] >> scale_vert;
+    x_range = mi_size_wide[bsize] >> scale_horz;
+  } else {
+    y_range = (mib_size >> scale_vert);
+    x_range = (mib_size >> scale_horz);
+  }
 
   AV2_DEBLOCKING_PARAMETERS params_buf[MAX_MIB_SIZE];
   TX_SIZE tx_size_buf[MAX_MIB_SIZE] = { 0 };
@@ -951,43 +970,47 @@ void av2_filter_block_plane_horz(AV2_COMMON *const cm,
       uint32_t advance_units;
       TX_SIZE cur_tx_size = TX_4X4;
 
-      cur_tx_size = set_lpf_parameters(params, curr_x, prev_y, cm, xd,
-                                       HORZ_EDGE, curr_x, curr_y, plane,
-                                       plane_ptr, tx_size, mi_size_min_width);
+      cur_tx_size = set_lpf_parameters(
+          params, curr_x, prev_y, cm, xd, HORZ_EDGE, curr_x, curr_y, plane,
+          plane_ptr, tx_size, mi_size_min_width, dlk_rd_flag);
       if (cur_tx_size == TX_INVALID) {
         params->filter_length_neg = 0;
         params->filter_length_pos = 0;
 
         cur_tx_size = TX_4X4;
       }
-      bool is_lossless_current_block = get_lossless_flag(
-          cm, curr_x, curr_y, scale_horz, scale_vert, plane, plane_ptr);
-      bool is_lossless_prev_block = get_lossless_flag(
-          cm, curr_x, prev_y, scale_horz, scale_vert, plane, plane_ptr);
-      bool skip_deblock_lossless =
-          is_lossless_current_block && is_lossless_prev_block;
 
-      int do_filter = 1;
-      if (cm->seq_params.disable_loopfilters_across_tiles) {
-        if (is_horz_tile_boundary(&cm->tiles, mi_row + (y << scale_vert)))
-          do_filter = 0;
-      }
-      if (do_filter) {
-        const avm_bit_depth_t bit_depth = cm->seq_params.bit_depth;
-        if (!skip_deblock_lossless &&
-            (params->filter_length_neg || params->filter_length_pos)) {
-          if (!(is_lossless_current_block || is_lossless_prev_block)) {
-            avm_highbd_lpf_horizontal_generic(
-                p, dst_stride, params->filter_length_neg,
-                params->filter_length_pos, &params->q_threshold,
-                &params->side_threshold, bit_depth, is_lossless_prev_block,
-                is_lossless_current_block);
-          } else {
-            avm_highbd_lpf_horizontal_generic_c(
-                p, dst_stride, params->filter_length_neg,
-                params->filter_length_pos, &params->q_threshold,
-                &params->side_threshold, bit_depth, is_lossless_prev_block,
-                is_lossless_current_block);
+      if (!dlk_rd_flag ||
+          !is_horz_tile_boundary(&cm->tiles, mi_row + (y << scale_vert))) {
+        bool is_lossless_current_block = get_lossless_flag(
+            cm, curr_x, curr_y, scale_horz, scale_vert, plane, plane_ptr);
+        bool is_lossless_prev_block = get_lossless_flag(
+            cm, curr_x, prev_y, scale_horz, scale_vert, plane, plane_ptr);
+        bool skip_deblock_lossless =
+            is_lossless_current_block && is_lossless_prev_block;
+
+        int do_filter = 1;
+        if (cm->seq_params.disable_loopfilters_across_tiles) {
+          if (is_horz_tile_boundary(&cm->tiles, mi_row + (y << scale_vert)))
+            do_filter = 0;
+        }
+        if (do_filter) {
+          const avm_bit_depth_t bit_depth = cm->seq_params.bit_depth;
+          if (!skip_deblock_lossless &&
+              (params->filter_length_neg || params->filter_length_pos)) {
+            if (!(is_lossless_current_block || is_lossless_prev_block)) {
+              avm_highbd_lpf_horizontal_generic(
+                  p, dst_stride, params->filter_length_neg,
+                  params->filter_length_pos, &params->q_threshold,
+                  &params->side_threshold, bit_depth, is_lossless_prev_block,
+                  is_lossless_current_block);
+            } else {
+              avm_highbd_lpf_horizontal_generic_c(
+                  p, dst_stride, params->filter_length_neg,
+                  params->filter_length_pos, &params->q_threshold,
+                  &params->side_threshold, bit_depth, is_lossless_prev_block,
+                  is_lossless_current_block);
+            }
           }
         }
       }
@@ -1031,21 +1054,21 @@ static void loop_filter_rows(YV12_BUFFER_CONFIG *frame_buffer, AV2_COMMON *cm,
           // filter vertical edges
           av2_setup_dst_planes(pd, frame_buffer, mi_row, mi_col, plane,
                                plane + 1, NULL);
-          av2_filter_block_plane_vert(cm, xd, plane, &pd[plane], mi_row,
-                                      mi_col);
+          av2_filter_block_plane_vert(cm, xd, plane, &pd[plane], mi_row, mi_col,
+                                      0, BLOCK_INVALID);
           // filter horizontal edges
           if (mi_col - mib_size >= 0) {
             av2_setup_dst_planes(pd, frame_buffer, mi_row, mi_col - mib_size,
                                  plane, plane + 1, NULL);
             av2_filter_block_plane_horz(cm, xd, plane, &pd[plane], mi_row,
-                                        mi_col - mib_size);
+                                        mi_col - mib_size, 0, BLOCK_INVALID);
           }
         }
         // filter horizontal edges
         av2_setup_dst_planes(pd, frame_buffer, mi_row, mi_col - mib_size, plane,
                              plane + 1, NULL);
         av2_filter_block_plane_horz(cm, xd, plane, &pd[plane], mi_row,
-                                    mi_col - mib_size);
+                                    mi_col - mib_size, 0, BLOCK_INVALID);
       }
     } else {
       // filter all vertical edges in every 128x128 super block
@@ -1053,8 +1076,8 @@ static void loop_filter_rows(YV12_BUFFER_CONFIG *frame_buffer, AV2_COMMON *cm,
         for (mi_col = col_start; mi_col < col_end; mi_col += mib_size) {
           av2_setup_dst_planes(pd, frame_buffer, mi_row, mi_col, plane,
                                plane + 1, NULL);
-          av2_filter_block_plane_vert(cm, xd, plane, &pd[plane], mi_row,
-                                      mi_col);
+          av2_filter_block_plane_vert(cm, xd, plane, &pd[plane], mi_row, mi_col,
+                                      0, BLOCK_INVALID);
         }
       }
 
@@ -1063,8 +1086,8 @@ static void loop_filter_rows(YV12_BUFFER_CONFIG *frame_buffer, AV2_COMMON *cm,
         for (mi_col = col_start; mi_col < col_end; mi_col += mib_size) {
           av2_setup_dst_planes(pd, frame_buffer, mi_row, mi_col, plane,
                                plane + 1, NULL);
-          av2_filter_block_plane_horz(cm, xd, plane, &pd[plane], mi_row,
-                                      mi_col);
+          av2_filter_block_plane_horz(cm, xd, plane, &pd[plane], mi_row, mi_col,
+                                      0, BLOCK_INVALID);
         }
       }
     }

--- a/av2/common/av2_loopfilter.h
+++ b/av2/common/av2_loopfilter.h
@@ -103,12 +103,14 @@ void init_tip_lf_parameter(struct AV2Common *cm, int plane_start,
 void av2_filter_block_plane_vert(struct AV2Common *const cm,
                                  const MACROBLOCKD *const xd, const int plane,
                                  const MACROBLOCKD_PLANE *const plane_ptr,
-                                 const uint32_t mi_row, const uint32_t mi_col);
+                                 const uint32_t mi_row, const uint32_t mi_col,
+                                 const int dlk_rd_flag, const BLOCK_SIZE bsize);
 
 void av2_filter_block_plane_horz(struct AV2Common *const cm,
                                  const MACROBLOCKD *const xd, const int plane,
                                  const MACROBLOCKD_PLANE *const plane_ptr,
-                                 const uint32_t mi_row, const uint32_t mi_col);
+                                 const uint32_t mi_row, const uint32_t mi_col,
+                                 const int dlk_rd_flag, const BLOCK_SIZE bsize);
 int df_quant_from_qindex(int q_index, int bit_depth);
 
 int df_side_from_qindex(int q_index, int bit_depth);

--- a/av2/common/thread_common.c
+++ b/av2/common/thread_common.c
@@ -325,7 +325,7 @@ static INLINE void thread_loop_filter_rows(
                                plane + 1, NULL);
 
           av2_filter_block_plane_vert(cm, xd, plane, &planes[plane], mi_row,
-                                      mi_col);
+                                      mi_col, 0, BLOCK_INVALID);
           sync_write(lf_sync, r, c, sb_cols, plane);
         }
       } else if (dir == 1) {
@@ -343,7 +343,7 @@ static INLINE void thread_loop_filter_rows(
           av2_setup_dst_planes(planes, frame_buffer, mi_row, mi_col, plane,
                                plane + 1, NULL);
           av2_filter_block_plane_horz(cm, xd, plane, &planes[plane], mi_row,
-                                      mi_col);
+                                      mi_col, 0, BLOCK_INVALID);
         }
       }
     } else {

--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -2263,6 +2263,9 @@ static AVM_INLINE void encode_frame_internal(AV2_COMP *cpi) {
 
   av2_enc_setup_tip_frame(cpi);
 
+  cm->lf.apply_deblocking_filter[0] = cpi->oxcf.tool_cfg.enable_deblocking;
+  if (cm->lf.apply_deblocking_filter[0]) av2_loop_filter_frame_init(cm, 0, 1);
+
   cm->current_frame.skip_mode_info.skip_mode_flag =
       check_skip_mode_enabled(cpi) && cpi->oxcf.tool_cfg.enable_skip_mode;
 

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -12,12 +12,14 @@
 
 #include "avm/avm_codec.h"
 #include "avm_ports/system_state.h"
+#include "avm_dsp/psnr.h"
 #include "av2/common/bru.h"
 #include "avm_ports/avm_timer.h"
 
 #include "av2/encoder/partition_mlp.h"
 
 #include "av2/common/av2_common_int.h"
+#include "av2/common/av2_loopfilter.h"
 #include "av2/common/blockd.h"
 #include "av2/common/common_data.h"
 #include "av2/common/enums.h"
@@ -3562,10 +3564,95 @@ static void inter_sdp_copy_luma_mode_info(PC_TREE *pc_tree,
   *mbmi = cur_pc_tree->none[INTRA_REGION]->mic;
 }
 
+static int64_t get_dist_offset_by_deblock(
+    AV2_COMP *const cpi, ThreadData *td, TileDataEnc *tile_data, MACROBLOCK *x,
+    TokenExtra **tp, PICK_MODE_CONTEXT *ctx_none, RD_STATS *const this_rdc,
+    const int mi_col, const int mi_row, const BLOCK_SIZE bsize) {
+  AV2_COMMON *const cm = &cpi->common;
+
+  const YV12_BUFFER_CONFIG *curr = &cm->cur_frame->buf;
+  const YV12_BUFFER_CONFIG *src = cpi->source;
+
+  const YV12_BUFFER_CONFIG *filtered = &cpi->trial_frame_rst;
+  int rate = 0;
+  encode_b(cpi, tile_data, td, tp, mi_row, mi_col, DRY_RUN_NORMAL, bsize,
+           PARTITION_NONE, ctx_none, &rate);
+
+  const int bw = block_size_wide[bsize];
+  const int bh = block_size_high[bsize];
+
+  int64_t rec_dist = avm_highbd_get_y_sse_part(src, curr, mi_col * MI_SIZE, bw,
+                                               mi_row * MI_SIZE, bh);
+
+  if (x->e_mbd.tree_type != LUMA_PART) {
+    const int sub_x = cm->seq_params.subsampling_x;
+    const int sub_y = cm->seq_params.subsampling_y;
+    rec_dist += avm_highbd_get_u_sse_part(
+        src, curr, mi_col * MI_SIZE >> sub_x, bw >> sub_x,
+        mi_row * MI_SIZE >> sub_y, bh >> sub_y);
+    rec_dist += avm_highbd_get_v_sse_part(
+        src, curr, mi_col * MI_SIZE >> sub_x, bw >> sub_x,
+        mi_row * MI_SIZE >> sub_y, bh >> sub_y);
+  }
+
+  if (llabs(this_rdc->dist - rec_dist) < this_rdc->dist / 50) {
+    int h_start = mi_col * MI_SIZE;
+    int v_start = mi_row * MI_SIZE;
+    int area_w = bw;
+    int area_h = bh;
+
+    MACROBLOCKD *xd = &x->e_mbd;
+    if (xd->up_available) {
+      int v_offset = bh == 4 ? 4 : 8;
+      v_start -= v_offset;
+      area_h += v_offset;
+    }
+    if (xd->left_available) {
+      int h_offset = bw == 4 ? 4 : 8;
+      h_start -= h_offset;
+      area_w += h_offset;
+    }
+
+    const int64_t unfiltered_y_dist =
+        avm_highbd_get_y_sse_part(src, curr, h_start, area_w, v_start, area_h);
+
+    uint16_t *curr_data = curr->buffers[0] + v_start * curr->y_stride + h_start;
+    uint16_t *filtered_data =
+        filtered->buffers[0] + v_start * filtered->y_stride + h_start;
+    copy_tile(area_w, area_h, curr_data, curr->y_stride, filtered_data,
+              filtered->y_stride);
+
+    const int plane = 0;
+    struct macroblockd_plane *pd = xd->plane;
+    av2_setup_dst_planes(pd, filtered, mi_row, mi_col, plane, plane + 1, NULL);
+    av2_filter_block_plane_vert(cm, xd, plane, &pd[plane], mi_row, mi_col, 1,
+                                bsize);
+
+    av2_setup_dst_planes(pd, filtered, mi_row, mi_col, plane, plane + 1, NULL);
+    av2_filter_block_plane_horz(cm, xd, plane, &pd[plane], mi_row, mi_col, 1,
+                                bsize);
+
+    const int64_t filtered_y_dist = avm_highbd_get_y_sse_part(
+        src, filtered, h_start, area_w, v_start, area_h);
+
+    const int bit_depth = cm->seq_params.bit_depth;
+    int dist_normal;  // dist is normalized to 16 * 8_bit_content_distortion
+    if (bit_depth <= 10) {
+      dist_normal = 1 << ((10 - cm->seq_params.bit_depth) * 2);
+      return dist_normal * (filtered_y_dist - unfiltered_y_dist);
+    } else {
+      dist_normal = 1 << ((cm->seq_params.bit_depth - 10) * 2);
+      return (filtered_y_dist - unfiltered_y_dist) / dist_normal;
+    }
+  } else {
+    return 0;
+  }
+}
+
 // PARTITION_NONE search.
 static void none_partition_search(
     AV2_COMP *const cpi, ThreadData *td, TileDataEnc *tile_data, MACROBLOCK *x,
-    PC_TREE *pc_tree, SIMPLE_MOTION_DATA_TREE *sms_tree,
+    TokenExtra **tp, PC_TREE *pc_tree, SIMPLE_MOTION_DATA_TREE *sms_tree,
     RD_SEARCH_MACROBLOCK_CONTEXT *x_ctx,
     PartitionSearchState *part_search_state, RD_STATS *best_rdc,
     unsigned int *pb_source_variance, int64_t *none_rd, int64_t *part_none_rd,
@@ -3610,6 +3697,16 @@ static void none_partition_search(
   // Set PARTITION_NONE context and cost.
   set_none_partition_params(cm, td, x, pc_tree, part_search_state,
                             &best_remain_rdcost, best_rdc, &pt_cost);
+  if (best_rdc->rdcost != INT64_MAX &&
+      cpi->sf.lpf_sf.enable_deblock_for_partition_search &&
+      !cpi->is_screen_content_type) {
+    // increase the remaining best cost which could have be reduced by deblock
+    // filer 1.125 (9/8) is experimental number which is not intensively tested.
+    best_remain_rdcost.rate = best_remain_rdcost.rate * 9 / 8;
+    best_remain_rdcost.dist = best_remain_rdcost.dist * 9 / 8;
+    best_remain_rdcost.rdcost = best_remain_rdcost.rdcost * 9 / 8;
+  }
+
   if (bsize == cm->sb_size)
     x->e_mbd.is_cfl_allowed_in_sdp = is_cfl_allowed_for_sdp(
         cm, &x->e_mbd, ptree_luma, PARTITION_NONE, bsize);
@@ -3658,6 +3755,16 @@ static void none_partition_search(
     av2_add_mode_search_context_to_cache(sms_data,
                                          pc_tree->none[pc_tree->region_type]);
   }
+
+  if (cpi->sf.lpf_sf.enable_deblock_for_partition_search &&
+      cm->lf.apply_deblocking_filter[0] && this_rdc->rate != INT_MAX &&
+      ctx_none != NULL && x->e_mbd.tree_type != CHROMA_PART &&
+      !cpi->is_screen_content_type) {
+    const int64_t distortion_offset = get_dist_offset_by_deblock(
+        cpi, td, tile_data, x, tp, ctx_none, this_rdc, mi_col, mi_row, bsize);
+    this_rdc->dist += distortion_offset;
+  }
+
   av2_rd_cost_update(x->rdmult, this_rdc);
 
 #if CONFIG_COLLECT_PARTITION_STATS
@@ -5384,7 +5491,7 @@ BEGIN_PARTITION_SEARCH:
   int64_t part_none_rd = INT64_MAX;
   if (!search_none_after_rect && !search_none_after_split &&
       partition_none_allowed) {
-    none_partition_search(cpi, td, tile_data, x, pc_tree, sms_tree, &x_ctx,
+    none_partition_search(cpi, td, tile_data, x, tp, pc_tree, sms_tree, &x_ctx,
                           &part_search_state, &best_rdc, &pb_source_variance,
                           none_rd, &part_none_rd, &level_banks, ptree_luma);
   }
@@ -5423,7 +5530,7 @@ BEGIN_PARTITION_SEARCH:
   }
   if (part_search_state.forced_partition == PARTITION_INVALID &&
       partition_none_allowed && search_none_after_split) {
-    none_partition_search(cpi, td, tile_data, x, pc_tree, sms_tree, &x_ctx,
+    none_partition_search(cpi, td, tile_data, x, tp, pc_tree, sms_tree, &x_ctx,
                           &part_search_state, &best_rdc, &pb_source_variance,
                           none_rd, &part_none_rd, &level_banks, ptree_luma);
   }
@@ -5494,7 +5601,7 @@ BEGIN_PARTITION_SEARCH:
       partition_none_allowed) {
     // Prune partitions based on rect results.
     prune_none_after_rect(&part_search_state, pc_tree);
-    none_partition_search(cpi, td, tile_data, x, pc_tree, sms_tree, &x_ctx,
+    none_partition_search(cpi, td, tile_data, x, tp, pc_tree, sms_tree, &x_ctx,
                           &part_search_state, &best_rdc, &pb_source_variance,
                           none_rd, &part_none_rd, &level_banks, ptree_luma);
   }

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -333,6 +333,8 @@ static void set_good_speed_features_framesize_independent(
   sf->mv_sf.fast_motion_estimation_on_block_256 = 1;
 
   sf->rd_sf.perform_coeff_opt = 1;
+
+  sf->lpf_sf.enable_deblock_for_partition_search = 1;
   if (speed >= 1) {
     sf->flexmv_sf.prune_non_one_pel_mv_using_best_mv_prec = 1;
     sf->inter_sf.selective_ref_frame = 2;
@@ -607,6 +609,7 @@ static void set_good_speed_features_framesize_independent(
     sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
 
     sf->tpl_sf.prune_starting_mv = 3;
+    sf->lpf_sf.enable_deblock_for_partition_search = 0;
   }
 
   if (speed >= 6) {
@@ -929,6 +932,7 @@ static AVM_INLINE void init_lpf_sf(LOOP_FILTER_SPEED_FEATURES *lpf_sf) {
   lpf_sf->cdef_pick_method = CDEF_FULL_SEARCH;
   lpf_sf->disable_lr_filter = 0;
   lpf_sf->wienerns_refine_iters = 2;
+  lpf_sf->enable_deblock_for_partition_search = 1;
 }
 
 static void av2_disable_ml_based_transform_sf(TX_SPEED_FEATURES *const tx_sf) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -334,7 +334,6 @@ static void set_good_speed_features_framesize_independent(
 
   sf->rd_sf.perform_coeff_opt = 1;
 
-  sf->lpf_sf.enable_deblock_for_partition_search = 1;
   if (speed >= 1) {
     sf->flexmv_sf.prune_non_one_pel_mv_using_best_mv_prec = 1;
     sf->inter_sf.selective_ref_frame = 2;
@@ -406,6 +405,7 @@ static void set_good_speed_features_framesize_independent(
 
     sf->part_sf.partition_pruning_with_mlp = 1;
     sf->part_sf.partition_pruning_with_mlp_none_thresh = 3.5f;
+    sf->lpf_sf.enable_deblock_for_partition_search = 1;
   }
 
   if (speed >= 2) {
@@ -932,7 +932,7 @@ static AVM_INLINE void init_lpf_sf(LOOP_FILTER_SPEED_FEATURES *lpf_sf) {
   lpf_sf->cdef_pick_method = CDEF_FULL_SEARCH;
   lpf_sf->disable_lr_filter = 0;
   lpf_sf->wienerns_refine_iters = 2;
-  lpf_sf->enable_deblock_for_partition_search = 1;
+  lpf_sf->enable_deblock_for_partition_search = 0;
 }
 
 static void av2_disable_ml_based_transform_sf(TX_SPEED_FEATURES *const tx_sf) {

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -987,6 +987,9 @@ typedef struct LOOP_FILTER_SPEED_FEATURES {
 
   // Number of refinement steps for WIENER_NONSEP tool
   int wienerns_refine_iters;
+
+  // enable deblock for block partition search
+  int enable_deblock_for_partition_search;
 } LOOP_FILTER_SPEED_FEATURES;
 
 typedef struct REALTIME_SPEED_FEATURES {


### PR DESCRIPTION
This feature considers the distortion reduction of deblocking filter for partition research.

-- The deblocking filter is applied to a non-split partition after the best mode is picked for the current block. The distortion improvement of the deblocking filter is used to update the best RD cost of the current none-split partition block.

This encoder side only feature provides the coding gain with slight encoding time increase. Should be a good trade-off for low speed level.

Results of 33 frame (cpu1), a1 (missing 3 sequences) and a2 (missing 1 sequence) are as follows:

+---------+--------+-------+-------+-------+----------+----------+
| Summary | Y | U | V | YUV | Enc-time | Dec-time |
+---------+--------+-------+-------+-------+----------+----------+
| A1  | -0.62% |  -0.14% | -0.49% | -0.58% | 102.06% | 100.82% |
| A2 | -0.39% | +0.15% | -0.70% | -0.38% | 102.37% | 100.56% |
+---------+--------+-------+-------+-------+----------+----------+