### PR TITLE
decoder: check profile interop conformance ASAP

### DIFF
--- a/av2/common/annexA.c
+++ b/av2/common/annexA.c
@@ -196,6 +196,14 @@ static avm_codec_err_t check_mlayer_count(int profile_idc, int seq_max_mcount) {
 }
 
 // Checks the profile conformance -- Top-level function
+//
+// Checks the following members of seq_params:
+//   * seq_params->seq_profile_idc
+//   * seq_params->bit_depth
+//   * seq_params->monochrome
+//   * seq_params->subsampling_x
+//   * seq_params->subsampling_y
+//   * seq_params->seq_max_mlayer_cnt
 int av2_check_profile_interop_conformance(
     struct SequenceHeader *seq_params,
     struct avm_internal_error_info *error_info, int is_decoder) {

--- a/av2/decoder/obu.c
+++ b/av2/decoder/obu.c
@@ -599,6 +599,12 @@ static uint32_t read_sequence_header_obu(AV2Decoder *pbi, int xlayer_id,
     seq_params->monotonic_output_order_flag = avm_rb_read_bit(rb);
   }
 
+  if (!av2_check_profile_interop_conformance(seq_params, &cm->error, 1)) {
+    avm_internal_error(&cm->error, AVM_CODEC_UNSUP_BITSTREAM,
+                       "Unsupported profile, bitdepth, chroma format or number "
+                       "of embedded layers");
+  }
+
   const int num_bits_width = avm_rb_read_literal(rb, 4) + 1;
   const int num_bits_height = avm_rb_read_literal(rb, 4) + 1;
   const int max_frame_width = avm_rb_read_literal(rb, num_bits_width) + 1;
@@ -686,12 +692,6 @@ static uint32_t read_sequence_header_obu(AV2Decoder *pbi, int xlayer_id,
       }
       av2_read_tlayer_dependency_info(seq_params, rb);
     }
-  }
-
-  if (!av2_check_profile_interop_conformance(seq_params, &cm->error, 1)) {
-    avm_internal_error(
-        &cm->error, AVM_CODEC_UNSUP_BITSTREAM,
-        "Unsupported Bitdepth, Chroma format or number of embedded layers");
   }
 
   av2_read_sequence_header(rb, seq_params);


### PR DESCRIPTION
read_sequence_header_obu() should call
av2_check_profile_interop_conformance() as soon as it has read all the members of seq_params checked by that function. This allows the av2_max_level_bitrate() call in read_sequence_header_obu() to assume seq_params->seq_profile_idc is a supported profile.

Document the members of seq_params checked by
av2_check_profile_interop_conformance().