### PR TITLE
Add enable_low_complexity_decode (LC) mode

### DIFF
--- a/apps/avmenc.c
+++ b/apps/avmenc.c
@@ -304,6 +304,7 @@ const arg_def_t *av2_key_val_args[] = {
   &g_av2_codec_arg_defs.enable_joint_mvd,
   &g_av2_codec_arg_defs.enable_keyframe_filtering,
   &g_av2_codec_arg_defs.enable_lf_sub_pu,
+  &g_av2_codec_arg_defs.enable_low_complexity_decode,
   &g_av2_codec_arg_defs.enable_masked_comp,
   &g_av2_codec_arg_defs.enable_mfh_obu_signaling,
   &g_av2_codec_arg_defs.enable_mhccp,
@@ -632,6 +633,7 @@ static void init_config(cfg_options_t *config) {
   config->scan_type_info_present_flag = 0;
   config->enable_mfh_obu_signaling = 0;
   config->operating_points_count = 1;
+  config->enable_low_complexity_decode = 0;
 }
 
 int read_icc_profile(struct AvxEncoderConfig *global, const char *file) {

--- a/av2/arg_defs.c
+++ b/av2/arg_defs.c
@@ -886,6 +886,10 @@ const av2_codec_arg_definitions_t g_av2_codec_arg_defs = {
   .use_short_metadata = ARG_DEF(NULL, "use-short-metadata", 1,
                                 "Use short metadata OBU format "
                                 "(0: GROUP format [default], 1: SHORT format)"),
+  .enable_low_complexity_decode =
+      ARG_DEF(NULL, "enable-low-complexity-decode", 1,
+              "Enable low complexity decode "
+              "(0: false (default), 1: true)"),
 #endif  // CONFIG_AV2_ENCODER
   .enable_short_refresh_frame_flags =
       ARG_DEF(NULL, "enable-short-refresh-frame-flags", 1,

--- a/av2/arg_defs.h
+++ b/av2/arg_defs.h
@@ -278,6 +278,7 @@ typedef struct av2_codec_arg_definitions {
   arg_def_t dpb_size;
   arg_def_t enable_bru;
   arg_def_t disable_loopfilters_across_tiles;
+  arg_def_t enable_low_complexity_decode;
 #endif  // CONFIG_AV2_ENCODER
   arg_def_t frame_hash_metadata;
   arg_def_t frame_hash_per_plane;

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -1751,10 +1751,16 @@ static avm_codec_err_t set_encoder_config(AV2EncoderConfig *oxcf,
       extra_cfg->force_deferred_frames_for_ras_test;
 
   // Now, low complexity decode mode is only supported for good-quality
-  // encoding speed 1 and above. This can be further modified if needed.
+  // encoding. This can be further modified if needed.
   oxcf->enable_low_complexity_decode =
       extra_cfg->enable_low_complexity_decode &&
-      cfg->g_usage == AVM_USAGE_GOOD_QUALITY && oxcf->speed >= 1;
+      cfg->g_usage == AVM_USAGE_GOOD_QUALITY;
+  if (extra_cfg->enable_low_complexity_decode &&
+      cfg->g_usage != AVM_USAGE_GOOD_QUALITY) {
+    fprintf(stderr,
+            "Warning: setting enable_low_complexity_decode to 0 since it "
+            "requires good-quality usage.\n");
+  }
 
   if (update_config) {
     update_encoder_config(&cfg->encoder_cfg, extra_cfg);

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -245,6 +245,7 @@ struct av2_extracfg {
   int buffer_refresh_multi_layers_test[REF_FRAMES];
   int multi_layers_lag_test;
   int force_deferred_frames_for_ras_test;
+  unsigned int enable_low_complexity_decode;
 };
 
 // Example subgop configs. Currently not used by default.
@@ -574,6 +575,7 @@ static struct av2_extracfg default_extra_cfg = {
   { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // buffer_refresh_multi_layers_test
   0,      // multi_layers_test for nozero lag
   0,      // force_deferred_frames_for_ras_test
+  0,      // enable_low_complexity_decode
 };
 // clang-format on
 
@@ -855,6 +857,8 @@ static avm_codec_err_t validate_config(avm_codec_alg_priv_t *ctx,
 
   RANGE_CHECK(extra_cfg, reduced_tx_type_set, 0, 3);
 
+  RANGE_CHECK_HI(extra_cfg, enable_low_complexity_decode, 1);
+
   return AVM_CODEC_OK;
 }
 
@@ -1027,6 +1031,7 @@ static void update_encoder_config(cfg_options_t *cfg,
   cfg->enable_ext_seg = extra_cfg->enable_ext_seg;
   cfg->dpb_size = extra_cfg->dpb_size;
   cfg->operating_points_count = extra_cfg->operating_points_count;
+  cfg->enable_low_complexity_decode = extra_cfg->enable_low_complexity_decode;
 }
 
 static void update_default_encoder_config(const cfg_options_t *cfg,
@@ -1146,6 +1151,7 @@ static void update_default_encoder_config(const cfg_options_t *cfg,
   extra_cfg->scan_type_info_present_flag = cfg->scan_type_info_present_flag;
   extra_cfg->enable_mfh_obu_signaling = cfg->enable_mfh_obu_signaling;
   extra_cfg->operating_points_count = cfg->operating_points_count;
+  extra_cfg->enable_low_complexity_decode = cfg->enable_low_complexity_decode;
 }
 
 static double convert_qp_offset(int qp, int qp_offset, int bit_depth) {
@@ -1743,6 +1749,12 @@ static avm_codec_err_t set_encoder_config(AV2EncoderConfig *oxcf,
   oxcf->unit_test_cfg.multi_layers_lag_test = extra_cfg->multi_layers_lag_test;
   oxcf->unit_test_cfg.force_deferred_frames_for_ras_test =
       extra_cfg->force_deferred_frames_for_ras_test;
+
+  // Now, low complexity decode mode is only supported for good-quality
+  // encoding speed 1 and above. This can be further modified if needed.
+  oxcf->enable_low_complexity_decode =
+      extra_cfg->enable_low_complexity_decode &&
+      cfg->g_usage == AVM_USAGE_GOOD_QUALITY && oxcf->speed >= 1;
 
   if (update_config) {
     update_encoder_config(&cfg->encoder_cfg, extra_cfg);
@@ -2752,6 +2764,14 @@ static avm_codec_err_t ctrl_set_force_deferred_frames_for_ras_test(
   struct av2_extracfg extra_cfg = ctx->extra_cfg;
   extra_cfg.force_deferred_frames_for_ras_test =
       CAST(AV2E_SET_FORCE_DEFERRED_FRAMES_FOR_RAS_TEST, args);
+  return update_extra_cfg(ctx, &extra_cfg);
+}
+
+static avm_codec_err_t ctrl_set_enable_low_complexity_decode(
+    avm_codec_alg_priv_t *ctx, va_list args) {
+  struct av2_extracfg extra_cfg = ctx->extra_cfg;
+  extra_cfg.enable_low_complexity_decode =
+      CAST(AV2E_SET_ENABLE_LOW_COMPLEXITY_DECODE, args);
   return update_extra_cfg(ctx, &extra_cfg);
 }
 
@@ -4528,6 +4548,11 @@ static avm_codec_err_t encoder_set_option(avm_codec_alg_priv_t *ctx,
                                   err_string)) {
     extra_cfg.enable_bru = avm_arg_parse_int_helper(&arg, err_string);
   } else if (avm_arg_match_helper(
+                 &arg, &g_av2_codec_arg_defs.enable_low_complexity_decode, argv,
+                 err_string)) {
+    extra_cfg.enable_low_complexity_decode =
+        avm_arg_parse_int_helper(&arg, err_string);
+  } else if (avm_arg_match_helper(
                  &arg, &g_av2_codec_arg_defs.disable_loopfilters_across_tiles,
                  argv, err_string)) {
     extra_cfg.disable_loopfilters_across_tiles =
@@ -4713,6 +4738,8 @@ static avm_codec_ctrl_fn_map_t encoder_ctrl_maps[] = {
   { AV2E_SET_MONOTONIC_OUTPUT_ORDER, ctrl_set_monotonic_output_order },
   { AV2E_SET_FORCE_DEFERRED_FRAMES_FOR_RAS_TEST,
     ctrl_set_force_deferred_frames_for_ras_test },
+  { AV2E_SET_ENABLE_LOW_COMPLEXITY_DECODE,
+    ctrl_set_enable_low_complexity_decode },
 
   // Getters
   { AVME_GET_LAST_QUANTIZER, ctrl_get_quantizer },
@@ -4864,7 +4891,8 @@ static const avm_codec_enc_cfg_t encoder_usage_cfg[] = {
           NULL, 0, 0,
           0,  // enable_mfh_obu_signaling
           1,
-      },  // cfg
+          0,  // enable_low_complexity_decode
+      },      // cfg
   },
   {
       // NOLINT
@@ -4999,7 +5027,8 @@ static const avm_codec_enc_cfg_t encoder_usage_cfg[] = {
           NULL, 0, 0,
           0,  // enable_mfh_obu_signaling
           1,
-      },  // cfg
+          0,  // enable_low_complexity_decode
+      },      // cfg
   },
 };
 

--- a/av2/encoder/encoder.h
+++ b/av2/encoder/encoder.h
@@ -1212,6 +1212,9 @@ typedef struct AV2EncoderConfig {
 
   // 0-31 = manually set operating_points_cnt_minus_1
   int operating_points_count;
+
+  // Enable the low complexity decode mode.
+  unsigned int enable_low_complexity_decode;
   /*!\endcond */
 } AV2EncoderConfig;
 

--- a/avm/avm_encoder.h
+++ b/avm/avm_encoder.h
@@ -682,7 +682,9 @@ typedef struct cfg_options {
   int operating_points_count;
 
   /*!\brief enable the low complexity decode mode
-   *
+   * If 0, disables the low complexity decode mode (default).
+   * If 1 and the usage is good-quality, enables the low complexity decode
+   * mode.
    */
   unsigned int enable_low_complexity_decode;
 } cfg_options_t;

--- a/avm/avm_encoder.h
+++ b/avm/avm_encoder.h
@@ -680,6 +680,11 @@ typedef struct cfg_options {
    *
    */
   int operating_points_count;
+
+  /*!\brief enable the low complexity decode mode
+   *
+   */
+  unsigned int enable_low_complexity_decode;
 } cfg_options_t;
 
 /*!\brief Encoded Frame Flags

--- a/avm/avmcx.h
+++ b/avm/avmcx.h
@@ -1249,6 +1249,11 @@ enum avme_enc_control_id {
    * the restricted_prediction_switch output ordering path.
    */
   AV2E_SET_FORCE_DEFERRED_FRAMES_FOR_RAS_TEST = 185,
+
+  /*!\brief Codec control function to enable the low complexity decode mode,
+   * unsigned int parameter. Value of zero means this mode is disabled.
+   */
+  AV2E_SET_ENABLE_LOW_COMPLEXITY_DECODE = 186,
 };
 
 /*!\brief avm 1-D scaling mode
@@ -1776,6 +1781,9 @@ AVM_CTRL_USE_TYPE(AV2E_SET_MONOTONIC_OUTPUT_ORDER, int)
 
 AVM_CTRL_USE_TYPE(AV2E_SET_FORCE_DEFERRED_FRAMES_FOR_RAS_TEST, int)
 #define AVME_CTRL_AV2E_SET_FORCE_DEFERRED_FRAMES_FOR_RAS_TEST
+
+AVM_CTRL_USE_TYPE(AV2E_SET_ENABLE_LOW_COMPLEXITY_DECODE, unsigned int)
+#define AVME_CTRL_AV2E_SET_ENABLE_LOW_COMPLEXITY_DECODE
 /*!\endcond */
 /*! @} - end defgroup avm_encoder */
 #ifdef __cplusplus

--- a/avm/avmcx.h
+++ b/avm/avmcx.h
@@ -1251,7 +1251,8 @@ enum avme_enc_control_id {
   AV2E_SET_FORCE_DEFERRED_FRAMES_FOR_RAS_TEST = 185,
 
   /*!\brief Codec control function to enable the low complexity decode mode,
-   * unsigned int parameter. Value of zero means this mode is disabled.
+   * unsigned int parameter. Value of zero disables this mode. Value of one and
+   * (g_usage == AVM_USAGE_GOOD_QUALITY) enables this mode.
    */
   AV2E_SET_ENABLE_LOW_COMPLEXITY_DECODE = 186,
 };

--- a/common/args.c
+++ b/common/args.c
@@ -170,6 +170,7 @@ int parse_cfg(const char *file, cfg_options_t *config) {
     GET_PARAMS(crop_win_top_offset);
     GET_PARAMS(crop_win_bottom_offset);
     GET_PARAMS(operating_points_count);
+    GET_PARAMS(enable_low_complexity_decode);
 
     fprintf(stderr, "\nInvalid parameter: %s", left);
     exit(-1);


### PR DESCRIPTION
Introduced an encoder option: "enable_low_complexity_decode" (LC mode) to target reduced decoding complexity. This mode is disabled by default. Also added related API control for ongoing LC mode development.