### PR TITLE
av2_get_chroma_format_idc: more monochrome checks

### DIFF
--- a/av2/common/annexA.c
+++ b/av2/common/annexA.c
@@ -192,7 +192,13 @@ int av2_check_profile_interop_conformance(
   avm_codec_err_t err = av2_get_chroma_format_idc(
       seq_params->subsampling_x, seq_params->subsampling_y, monochrome,
       &chroma_format_idc);
-  (void)err;
+  if (err != AVM_CODEC_OK) {
+    avm_internal_error(
+        error_info,
+        is_decoder ? AVM_CODEC_UNSUP_BITSTREAM : AVM_CODEC_INVALID_PARAM,
+        "Unsupported subsampling_x = %d, subsampling_y = %d.",
+        seq_params->subsampling_x, seq_params->subsampling_y);
+  }
 
   const int is_420 = (chroma_format_idc == CHROMA_FORMAT_420);
   const int is_422 = (chroma_format_idc == CHROMA_FORMAT_422);

--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -3075,7 +3075,11 @@ static INLINE avm_codec_err_t
 av2_get_chroma_format_idc(int subsampling_x, int subsampling_y, int monochrome,
                           uint32_t *seq_chroma_format_idc) {
   if (monochrome) {
-    *seq_chroma_format_idc = CHROMA_FORMAT_400;
+    if (subsampling_x == 1 && subsampling_y == 1) {
+      *seq_chroma_format_idc = CHROMA_FORMAT_400;
+    } else {
+      return AVM_CODEC_UNSUP_BITSTREAM;
+    }
   } else if (subsampling_x == 1 && subsampling_y == 1) {
     *seq_chroma_format_idc = CHROMA_FORMAT_420;
   } else if (subsampling_x == 1 && subsampling_y == 0) {

--- a/av2/encoder/bitstream_fgm.c
+++ b/av2/encoder/bitstream_fgm.c
@@ -175,9 +175,14 @@ int write_fgm_obu(AV2_COMP *cpi, struct film_grain_model *fgm,
   int fgm_bit_map = 1 << (fgm->fgm_id);
   avm_wb_write_literal(&wb, fgm_bit_map, MAX_FGM_NUM);
   uint32_t chroma_format_idc = CHROMA_FORMAT_420;
-  av2_get_chroma_format_idc(cm->seq_params.subsampling_x,
-                            cm->seq_params.subsampling_y,
-                            cm->seq_params.monochrome, &chroma_format_idc);
+  avm_codec_err_t err = av2_get_chroma_format_idc(
+      cm->seq_params.subsampling_x, cm->seq_params.subsampling_y,
+      cm->seq_params.monochrome, &chroma_format_idc);
+  if (err != AVM_CODEC_OK) {
+    avm_internal_error(
+        &cm->error, err, "Unsupported subsampling_x = %d, subsampling_y = %d.",
+        cm->seq_params.subsampling_x, cm->seq_params.subsampling_y);
+  }
   avm_wb_write_uvlc(&wb, chroma_format_idc);
 
   for (int fgm_pos = 0; fgm_pos < 1; fgm_pos++) {


### PR DESCRIPTION
In AV2, monochrome requires subsampling_x == 1 && subsampling_y == 1. (This somewhat arbitrary constraint comes from AV1.)

Also check the return value of av2_get_chroma_format_idc() at a few call sites.