### PR TITLE
Refactor recursive functions for ptree traversal

### DIFF
--- a/av2/common/blockd.c
+++ b/av2/common/blockd.c
@@ -19,6 +19,89 @@
 #include "av2/common/blockd.h"
 #include "av2/common/enums.h"
 
+/*!\brief Returns number of sub blocks for partition_type. */
+static const int subblock_count[ALL_PARTITION_TYPES] = {
+  1,  // PARTITION_NONE
+  2,  // PARTITION_HORZ
+  2,  // PARTITION_VERT
+  4,  // PARTITION_HORZ_3
+  4,  // PARTITION_VERT_3
+  4,  // PARTITION_HORZ_4A
+  4,  // PARTITION_HORZ_4B
+  4,  // PARTITION_VERT_4A
+  4,  // PARTITION_VERT_4B
+  4,  // PARTITION_SPLIT
+};
+
+static const int step_multiplier[ALL_PARTITION_TYPES][4][2] = {
+  { { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 } },  // PARTITION_NONE
+  { { 0, 0 }, { 4, 0 }, { 0, 0 }, { 0, 0 } },  // PARTITION_HORZ
+  { { 0, 0 }, { 0, 4 }, { 0, 0 }, { 0, 0 } },  // PARTITION_VERT
+  { { 0, 0 }, { 2, 0 }, { 2, 4 }, { 6, 0 } },  // PARTITION_HORZ_3
+  { { 0, 0 }, { 0, 2 }, { 4, 2 }, { 0, 6 } },  // PARTITION_VERT_3
+  { { 0, 0 }, { 1, 0 }, { 3, 0 }, { 7, 0 } },  // PARTITION_HORZ_4A
+  { { 0, 0 }, { 1, 0 }, { 5, 0 }, { 7, 0 } },  // PARTITION_HORZ_4B
+  { { 0, 0 }, { 0, 1 }, { 0, 3 }, { 0, 7 } },  // PARTITION_VERT_4A
+  { { 0, 0 }, { 0, 1 }, { 0, 5 }, { 0, 7 } },  // PARTITION_VERT_4B
+  { { 0, 0 }, { 0, 4 }, { 4, 0 }, { 4, 4 } },  // PARTITION_SPLIT
+};
+
+int get_subblock_count(PARTITION_TYPE partition_type) {
+  if (partition_type > PARTITION_SPLIT) {
+    assert(0 && "Unexpected partition type");
+    return 0;
+  }
+  return subblock_count[partition_type];
+}
+
+/*!\brief Computes the layout (coordinates and sizes) of subblocks resulting
+ * from a partition. */
+void get_partition_subblock_layout(PARTITION_TYPE partition_type,
+                                   BLOCK_SIZE bsize, int mi_row, int mi_col,
+                                   BLOCK_SIZE sub_sizes[4], int mi_rows[4],
+                                   int mi_cols[4]) {
+  if (partition_type > PARTITION_SPLIT) {
+    assert(0 && "Unexpected partition type");
+    return;
+  }
+  const int eighth_step_h = block_size_high[bsize] / 8;
+  const int eighth_step_w = block_size_wide[bsize] / 8;
+  const BLOCK_SIZE part_subsize = get_partition_subsize(bsize, partition_type);
+
+  for (int sub_idx = 0; sub_idx < 4; ++sub_idx) {
+    mi_rows[sub_idx] = mi_row + step_multiplier[partition_type][sub_idx][0] *
+                                    eighth_step_h / 4;
+    mi_cols[sub_idx] = mi_col + step_multiplier[partition_type][sub_idx][1] *
+                                    eighth_step_w / 4;
+    sub_sizes[sub_idx] = part_subsize;
+  }
+  if (partition_type == PARTITION_HORZ_3 ||
+      partition_type == PARTITION_VERT_3) {
+    const BLOCK_SIZE sml_subsize =
+        get_h_partition_subsize(bsize, 0, partition_type);
+    const BLOCK_SIZE big_subsize =
+        get_h_partition_subsize(bsize, 1, partition_type);
+    sub_sizes[0] = sub_sizes[3] = sml_subsize;
+    sub_sizes[1] = sub_sizes[2] = big_subsize;
+  } else if (partition_type == PARTITION_HORZ_4A ||
+             partition_type == PARTITION_VERT_4A ||
+             partition_type == PARTITION_HORZ_4B ||
+             partition_type == PARTITION_VERT_4B) {
+    const RECT_PART_TYPE rect_type = get_rect_part_type(partition_type);
+    const UNEVEN_4WAY_PART_TYPE uneven_type =
+        get_4way_part_type(partition_type);
+    const PARTITION_TYPE p_type =
+        (rect_type == HORZ) ? PARTITION_HORZ : PARTITION_VERT;
+    const BLOCK_SIZE big_subsize = get_partition_subsize(bsize, p_type);
+    assert(big_subsize != BLOCK_INVALID);
+    const BLOCK_SIZE med_subsize = subsize_lookup[p_type][big_subsize];
+    assert(med_subsize != BLOCK_INVALID);
+    assert(part_subsize == subsize_lookup[p_type][med_subsize]);
+    sub_sizes[1] = (uneven_type == UNEVEN_4A ? med_subsize : big_subsize);
+    sub_sizes[2] = (uneven_type == UNEVEN_4A ? big_subsize : med_subsize);
+  }
+}
+
 PREDICTION_MODE av2_get_joint_mode(const MB_MODE_INFO *mi) {
   if (!mi) return DC_PRED;
   if (is_inter_block(mi, SHARED_PART) || is_intrabc_block(mi, SHARED_PART))

--- a/av2/common/blockd.h
+++ b/av2/common/blockd.h
@@ -1073,6 +1073,13 @@ static INLINE BLOCK_SIZE get_partition_subsize(BLOCK_SIZE bsize,
   }
 }
 
+int get_subblock_count(PARTITION_TYPE partition_type);
+
+void get_partition_subblock_layout(PARTITION_TYPE partition_type,
+                                   BLOCK_SIZE bsize, int mi_row, int mi_col,
+                                   BLOCK_SIZE sub_sizes[4], int mi_rows[4],
+                                   int mi_cols[4]);
+
 // Get the block size of the ith sub-block in a block partitioned via an
 // h-partition mode.
 static INLINE BLOCK_SIZE get_h_partition_subsize(BLOCK_SIZE bsize, int index,

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -1861,9 +1861,6 @@ static AVM_INLINE void decode_partition(
   // Half block width/height.
   const int hbs_w = mi_size_wide[bsize] / 2;
   const int hbs_h = mi_size_high[bsize] / 2;
-  // One-eighth block width/height.
-  const int ebs_w = mi_size_wide[bsize] / 8;
-  const int ebs_h = mi_size_high[bsize] / 8;
   PARTITION_TYPE partition;
   const int has_rows = (mi_row + hbs_h) < cm->mi_params.mi_rows;
   const int has_cols = (mi_col + hbs_w) < cm->mi_params.mi_cols;
@@ -2017,77 +2014,19 @@ static AVM_INLINE void decode_partition(
       }
     }
 
-    switch (partition) {
-      case PARTITION_HORZ_4A:
-      case PARTITION_HORZ_4B:
-      case PARTITION_VERT_4A:
-      case PARTITION_VERT_4B:
-      case PARTITION_SPLIT:
-        ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-        ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-        ptree->sub_tree[2] = av2_alloc_ptree_node(ptree, 2);
-        ptree->sub_tree[3] = av2_alloc_ptree_node(ptree, 3);
+    if (partition == PARTITION_NONE) {
+      xd->is_cfl_allowed_in_sdp = is_cfl_allowed_in_sdp;
+    } else {
+      const int num_subblocks = get_subblock_count(partition);
+      for (int sub_idx = 0; sub_idx < num_subblocks; ++sub_idx) {
+        ptree->sub_tree[sub_idx] = av2_alloc_ptree_node(ptree, sub_idx);
+        ptree->sub_tree[sub_idx]->is_cfl_allowed_for_this_chroma_partition =
+            is_cfl_allowed_in_sdp;
         if (is_intra_sdp_enabled && xd->tree_type == SHARED_PART) {
-          ptree_luma->sub_tree[0] = av2_alloc_ptree_node(ptree_luma, 0);
-          ptree_luma->sub_tree[1] = av2_alloc_ptree_node(ptree_luma, 1);
-          ptree_luma->sub_tree[2] = av2_alloc_ptree_node(ptree_luma, 2);
-          ptree_luma->sub_tree[3] = av2_alloc_ptree_node(ptree_luma, 3);
+          ptree_luma->sub_tree[sub_idx] =
+              av2_alloc_ptree_node(ptree_luma, sub_idx);
         }
-        break;
-      case PARTITION_HORZ:
-      case PARTITION_VERT:
-        ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-        ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-
-        if (is_intra_sdp_enabled && xd->tree_type == SHARED_PART) {
-          ptree_luma->sub_tree[0] = av2_alloc_ptree_node(ptree_luma, 0);
-          ptree_luma->sub_tree[1] = av2_alloc_ptree_node(ptree_luma, 1);
-        }
-        break;
-      case PARTITION_HORZ_3:
-      case PARTITION_VERT_3:
-        ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-        ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-        ptree->sub_tree[2] = av2_alloc_ptree_node(ptree, 2);
-        ptree->sub_tree[3] = av2_alloc_ptree_node(ptree, 3);
-
-        if (is_intra_sdp_enabled && xd->tree_type == SHARED_PART) {
-          ptree_luma->sub_tree[0] = av2_alloc_ptree_node(ptree_luma, 0);
-          ptree_luma->sub_tree[1] = av2_alloc_ptree_node(ptree_luma, 1);
-          ptree_luma->sub_tree[2] = av2_alloc_ptree_node(ptree_luma, 2);
-          ptree_luma->sub_tree[3] = av2_alloc_ptree_node(ptree_luma, 3);
-        }
-        break;
-      default: break;
-    }
-    switch (partition) {
-      case PARTITION_NONE:
-        xd->is_cfl_allowed_in_sdp = is_cfl_allowed_in_sdp;
-        break;
-      case PARTITION_HORZ_4A:
-      case PARTITION_HORZ_4B:
-      case PARTITION_VERT_4A:
-      case PARTITION_VERT_4B:
-      case PARTITION_HORZ_3:
-      case PARTITION_VERT_3:
-      case PARTITION_SPLIT:
-        ptree->sub_tree[0]->is_cfl_allowed_for_this_chroma_partition =
-            is_cfl_allowed_in_sdp;
-        ptree->sub_tree[1]->is_cfl_allowed_for_this_chroma_partition =
-            is_cfl_allowed_in_sdp;
-        ptree->sub_tree[2]->is_cfl_allowed_for_this_chroma_partition =
-            is_cfl_allowed_in_sdp;
-        ptree->sub_tree[3]->is_cfl_allowed_for_this_chroma_partition =
-            is_cfl_allowed_in_sdp;
-        break;
-      case PARTITION_HORZ:
-      case PARTITION_VERT:
-        ptree->sub_tree[0]->is_cfl_allowed_for_this_chroma_partition =
-            is_cfl_allowed_in_sdp;
-        ptree->sub_tree[1]->is_cfl_allowed_for_this_chroma_partition =
-            is_cfl_allowed_in_sdp;
-        break;
-      default: break;
+      }
     }
   } else {
     partition = ptree->partition;
@@ -2146,108 +2085,21 @@ static AVM_INLINE void decode_partition(
                        mi_col << MI_SIZE_LOG2);
   }
 
-#define DEC_BLOCK_STX_ARG
-#define DEC_BLOCK_EPT_ARG partition,
-#define DEC_BLOCK(db_r, db_c, db_subsize, index)                               \
-  block_visit[parse_decode_flag](pbi, td, DEC_BLOCK_STX_ARG(db_r), (db_c),     \
-                                 reader, DEC_BLOCK_EPT_ARG(db_subsize), ptree, \
-                                 index)
-#define DEC_PARTITION(db_r, db_c, db_subsize, index)                 \
-  decode_partition(pbi, td, DEC_BLOCK_STX_ARG(db_r), (db_c), reader, \
-                   (db_subsize), sbi, ptree->sub_tree[(index)],      \
-                   get_partition_subtree_const(ptree_luma, index),   \
-                   parse_decode_flag)
-
-  switch (partition) {
-    case PARTITION_NONE: DEC_BLOCK(mi_row, mi_col, subsize, 0); break;
-    case PARTITION_HORZ:
-      DEC_PARTITION(mi_row, mi_col, subsize, 0);
-      DEC_PARTITION(mi_row + hbs_h, mi_col, subsize, 1);
-      break;
-    case PARTITION_VERT:
-      DEC_PARTITION(mi_row, mi_col, subsize, 0);
-      DEC_PARTITION(mi_row, mi_col + hbs_w, subsize, 1);
-      break;
-    case PARTITION_HORZ_4A: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_HORZ][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_HORZ][bsize_med]);
-      int this_mi_row = mi_row;
-      DEC_PARTITION(this_mi_row, mi_col, subsize, 0);
-      this_mi_row += ebs_h;
-      DEC_PARTITION(this_mi_row, mi_col, bsize_med, 1);
-      this_mi_row += 2 * ebs_h;
-      DEC_PARTITION(this_mi_row, mi_col, bsize_big, 2);
-      this_mi_row += 4 * ebs_h;
-      DEC_PARTITION(this_mi_row, mi_col, subsize, 3);
-      break;
+  if (partition == PARTITION_NONE) {
+    block_visit[parse_decode_flag](pbi, td, mi_row, mi_col, reader, partition,
+                                   subsize, ptree, 0);
+  } else {
+    BLOCK_SIZE sub_sizes[4];
+    int mi_rows[4], mi_cols[4];
+    get_partition_subblock_layout(partition, bsize, mi_row, mi_col, sub_sizes,
+                                  mi_rows, mi_cols);
+    const int num_subblocks = get_subblock_count(partition);
+    for (int sub_idx = 0; sub_idx < num_subblocks; ++sub_idx) {
+      decode_partition(pbi, td, mi_rows[sub_idx], mi_cols[sub_idx], reader,
+                       sub_sizes[sub_idx], sbi, ptree->sub_tree[sub_idx],
+                       get_partition_subtree_const(ptree_luma, sub_idx),
+                       parse_decode_flag);
     }
-    case PARTITION_HORZ_4B: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_HORZ][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_HORZ][bsize_med]);
-      int this_mi_row = mi_row;
-      DEC_PARTITION(this_mi_row, mi_col, subsize, 0);
-      this_mi_row += ebs_h;
-      DEC_PARTITION(this_mi_row, mi_col, bsize_big, 1);
-      this_mi_row += 4 * ebs_h;
-      DEC_PARTITION(this_mi_row, mi_col, bsize_med, 2);
-      this_mi_row += 2 * ebs_h;
-      DEC_PARTITION(this_mi_row, mi_col, subsize, 3);
-      break;
-    }
-    case PARTITION_VERT_4A: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_VERT);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_VERT][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_VERT][bsize_med]);
-      int this_mi_col = mi_col;
-      DEC_PARTITION(mi_row, this_mi_col, subsize, 0);
-      this_mi_col += ebs_w;
-      DEC_PARTITION(mi_row, this_mi_col, bsize_med, 1);
-      this_mi_col += 2 * ebs_w;
-      DEC_PARTITION(mi_row, this_mi_col, bsize_big, 2);
-      this_mi_col += 4 * ebs_w;
-      DEC_PARTITION(mi_row, this_mi_col, subsize, 3);
-      break;
-    }
-    case PARTITION_VERT_4B: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_VERT);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_VERT][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_VERT][bsize_med]);
-      int this_mi_col = mi_col;
-      DEC_PARTITION(mi_row, this_mi_col, subsize, 0);
-      this_mi_col += ebs_w;
-      DEC_PARTITION(mi_row, this_mi_col, bsize_big, 1);
-      this_mi_col += 4 * ebs_w;
-      DEC_PARTITION(mi_row, this_mi_col, bsize_med, 2);
-      this_mi_col += 2 * ebs_w;
-      DEC_PARTITION(mi_row, this_mi_col, subsize, 3);
-      break;
-    }
-    case PARTITION_HORZ_3:
-    case PARTITION_VERT_3: {
-      for (int i = 0; i < 4; ++i) {
-        BLOCK_SIZE this_bsize = get_h_partition_subsize(bsize, i, partition);
-        const int offset_r = get_h_partition_offset_mi_row(bsize, i, partition);
-        const int offset_c = get_h_partition_offset_mi_col(bsize, i, partition);
-
-        assert(this_bsize != BLOCK_INVALID);
-        assert(offset_r >= 0 && offset_c >= 0);
-
-        const int this_mi_row = mi_row + offset_r;
-        const int this_mi_col = mi_col + offset_c;
-
-        DEC_PARTITION(this_mi_row, this_mi_col, this_bsize, i);
-      }
-      break;
-    }
-    case PARTITION_SPLIT:
-      DEC_PARTITION(mi_row, mi_col, subsize, 0);
-      DEC_PARTITION(mi_row, mi_col + hbs_w, subsize, 1);
-      DEC_PARTITION(mi_row + hbs_h, mi_col, subsize, 2);
-      DEC_PARTITION(mi_row + hbs_h, mi_col + hbs_w, subsize, 3);
-      break;
-    default: assert(0 && "Invalid partition type");
   }
 
   PARTITION_TREE *parent = ptree->parent;
@@ -2257,16 +2109,12 @@ static AVM_INLINE void decode_partition(
         ptree->region_type == INTRA_REGION) {
       // decode chroma part in one intra region
       xd->tree_type = CHROMA_PART;
-      DEC_BLOCK(mi_row, mi_col, bsize, 0);
+      block_visit[parse_decode_flag](pbi, td, mi_row, mi_col, reader, partition,
+                                     bsize, ptree, 0);
       // reset back to shared part
       xd->tree_type = SHARED_PART;
     }
   }
-
-#undef DEC_PARTITION
-#undef DEC_BLOCK
-#undef DEC_BLOCK_EPT_ARG
-#undef DEC_BLOCK_STX_ARG
 
   if (parse_decode_flag & 1) {
     update_ext_partition_context(xd, mi_row, mi_col, subsize, bsize, partition);

--- a/av2/encoder/bitstream.c
+++ b/av2/encoder/bitstream.c
@@ -2816,10 +2816,6 @@ static AVM_INLINE void write_modes_sb(
   const CommonModeInfoParams *const mi_params = &cm->mi_params;
   MACROBLOCKD *const xd = &cpi->td.mb.e_mbd;
   assert(bsize < BLOCK_SIZES_ALL);
-  const int hbs_w = mi_size_wide[bsize] / 2;
-  const int hbs_h = mi_size_high[bsize] / 2;
-  const int ebs_w = mi_size_wide[bsize] / 8;
-  const int ebs_h = mi_size_high[bsize] / 8;
   assert(ptree);
 
   if (mi_row >= mi_params->mi_rows || mi_col >= mi_params->mi_cols) {
@@ -2917,200 +2913,31 @@ static AVM_INLINE void write_modes_sb(
       // if partition tree changes, rebuild recursive tree
       ptree->partition = p;
       partition = p;
-      subsize = get_partition_subsize(bsize, partition);
-      switch (p) {
-        case PARTITION_HORZ_4A:
-        case PARTITION_HORZ_4B:
-        case PARTITION_VERT_4A:
-        case PARTITION_VERT_4B:
-        case PARTITION_SPLIT:
-          ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-          ptree->sub_tree[0]->partition = PARTITION_NONE;
-          ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-          ptree->sub_tree[1]->partition = PARTITION_NONE;
-          ptree->sub_tree[2] = av2_alloc_ptree_node(ptree, 2);
-          ptree->sub_tree[2]->partition = PARTITION_NONE;
-          ptree->sub_tree[3] = av2_alloc_ptree_node(ptree, 3);
-          ptree->sub_tree[3]->partition = PARTITION_NONE;
-          break;
-        case PARTITION_HORZ:
-        case PARTITION_VERT:
-          ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-          ptree->sub_tree[0]->partition = PARTITION_NONE;
-          ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-          ptree->sub_tree[1]->partition = PARTITION_NONE;
-          break;
-        case PARTITION_HORZ_3:
-        case PARTITION_VERT_3:
-          ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-          ptree->sub_tree[0]->partition = PARTITION_NONE;
-          ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-          ptree->sub_tree[1]->partition = PARTITION_NONE;
-          ptree->sub_tree[2] = av2_alloc_ptree_node(ptree, 2);
-          ptree->sub_tree[2]->partition = PARTITION_NONE;
-          ptree->sub_tree[3] = av2_alloc_ptree_node(ptree, 3);
-          ptree->sub_tree[3]->partition = PARTITION_NONE;
-          break;
-        default: break;
+      if (partition != PARTITION_NONE) {
+        const int num_subblocks = get_subblock_count(partition);
+        for (int sub_idx = 0; sub_idx < num_subblocks; ++sub_idx) {
+          ptree->sub_tree[sub_idx] = av2_alloc_ptree_node(ptree, sub_idx);
+          ptree->sub_tree[sub_idx]->partition = PARTITION_NONE;
+        }
       }
     }
   }
-  switch (partition) {
-    case PARTITION_NONE:
-      write_modes_b(
-          cpi, tile, w,
-          (intra_sdp_enabled && xd->tree_type == CHROMA_PART) ? tok_chroma
-                                                              : tok,
-          (intra_sdp_enabled && xd->tree_type == CHROMA_PART) ? tok_chroma_end
-                                                              : tok_end,
-          mi_row, mi_col);
-      break;
-    case PARTITION_HORZ:
+  if (partition == PARTITION_NONE) {
+    bool use_chroma_tok = intra_sdp_enabled && xd->tree_type == CHROMA_PART;
+    write_modes_b(cpi, tile, w, use_chroma_tok ? tok_chroma : tok,
+                  use_chroma_tok ? tok_chroma_end : tok_end, mi_row, mi_col);
+  } else {
+    BLOCK_SIZE sub_sizes[4];
+    int mi_rows[4], mi_cols[4];
+    get_partition_subblock_layout(partition, bsize, mi_row, mi_col, sub_sizes,
+                                  mi_rows, mi_cols);
+    const int num_subblocks = get_subblock_count(partition);
+    for (int sub_idx = 0; sub_idx < num_subblocks; ++sub_idx) {
       write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[0],
-                     get_partition_subtree_const(ptree_luma, 0), mi_row, mi_col,
-                     subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[1],
-                     get_partition_subtree_const(ptree_luma, 1), mi_row + hbs_h,
-                     mi_col, subsize);
-      break;
-    case PARTITION_VERT:
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[0],
-                     get_partition_subtree_const(ptree_luma, 0), mi_row, mi_col,
-                     subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[1],
-                     get_partition_subtree_const(ptree_luma, 1), mi_row,
-                     mi_col + hbs_w, subsize);
-      break;
-    case PARTITION_HORZ_4A: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_HORZ][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_HORZ][bsize_med]);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[0],
-                     get_partition_subtree_const(ptree_luma, 0), mi_row, mi_col,
-                     subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[1],
-                     get_partition_subtree_const(ptree_luma, 1), mi_row + ebs_h,
-                     mi_col, bsize_med);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[2],
-                     get_partition_subtree_const(ptree_luma, 2),
-                     mi_row + 3 * ebs_h, mi_col, bsize_big);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[3],
-                     get_partition_subtree_const(ptree_luma, 3),
-                     mi_row + 7 * ebs_h, mi_col, subsize);
-      break;
+                     ptree->sub_tree[sub_idx],
+                     get_partition_subtree_const(ptree_luma, sub_idx),
+                     mi_rows[sub_idx], mi_cols[sub_idx], sub_sizes[sub_idx]);
     }
-    case PARTITION_HORZ_4B: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_HORZ][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_HORZ][bsize_med]);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[0],
-                     get_partition_subtree_const(ptree_luma, 0), mi_row, mi_col,
-                     subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[1],
-                     get_partition_subtree_const(ptree_luma, 1), mi_row + ebs_h,
-                     mi_col, bsize_big);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[2],
-                     get_partition_subtree_const(ptree_luma, 2),
-                     mi_row + 5 * ebs_h, mi_col, bsize_med);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[3],
-                     get_partition_subtree_const(ptree_luma, 3),
-                     mi_row + 7 * ebs_h, mi_col, subsize);
-      break;
-    }
-    case PARTITION_VERT_4A: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_VERT);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_VERT][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_VERT][bsize_med]);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[0],
-                     get_partition_subtree_const(ptree_luma, 0), mi_row, mi_col,
-                     subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[1],
-                     get_partition_subtree_const(ptree_luma, 1), mi_row,
-                     mi_col + ebs_w, bsize_med);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[2],
-                     get_partition_subtree_const(ptree_luma, 2), mi_row,
-                     mi_col + 3 * ebs_w, bsize_big);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[3],
-                     get_partition_subtree_const(ptree_luma, 3), mi_row,
-                     mi_col + 7 * ebs_w, subsize);
-      break;
-    }
-    case PARTITION_VERT_4B: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_VERT);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_VERT][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_VERT][bsize_med]);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[0],
-                     get_partition_subtree_const(ptree_luma, 0), mi_row, mi_col,
-                     subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[1],
-                     get_partition_subtree_const(ptree_luma, 1), mi_row,
-                     mi_col + ebs_w, bsize_big);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[2],
-                     get_partition_subtree_const(ptree_luma, 2), mi_row,
-                     mi_col + 5 * ebs_w, bsize_med);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[3],
-                     get_partition_subtree_const(ptree_luma, 3), mi_row,
-                     mi_col + 7 * ebs_w, subsize);
-      break;
-    }
-    case PARTITION_HORZ_3:
-    case PARTITION_VERT_3:
-      for (int i = 0; i < 4; ++i) {
-        BLOCK_SIZE this_bsize = get_h_partition_subsize(bsize, i, partition);
-        const int offset_r = get_h_partition_offset_mi_row(bsize, i, partition);
-        const int offset_c = get_h_partition_offset_mi_col(bsize, i, partition);
-
-        assert(this_bsize != BLOCK_INVALID);
-        assert(offset_r >= 0 && offset_c >= 0);
-
-        const int this_mi_row = mi_row + offset_r;
-        const int this_mi_col = mi_col + offset_c;
-
-        write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                       ptree->sub_tree[i],
-                       get_partition_subtree_const(ptree_luma, i), this_mi_row,
-                       this_mi_col, this_bsize);
-      }
-      break;
-    case PARTITION_SPLIT:
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[0],
-                     get_partition_subtree_const(ptree_luma, 0), mi_row, mi_col,
-                     subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[1],
-                     get_partition_subtree_const(ptree_luma, 1), mi_row,
-                     mi_col + hbs_w, subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[2],
-                     get_partition_subtree_const(ptree_luma, 2), mi_row + hbs_h,
-                     mi_col, subsize);
-      write_modes_sb(cpi, tile, w, tok, tok_end, tok_chroma, tok_chroma_end,
-                     ptree->sub_tree[3],
-                     get_partition_subtree_const(ptree_luma, 3), mi_row + hbs_h,
-                     mi_col + hbs_w, subsize);
-      break;
-    default: assert(0); break;
   }
   if (!is_sb_root && !frame_is_intra_only(cm) && !cm->seq_params.monochrome &&
       parent && partition && parent->region_type != INTRA_REGION &&

--- a/av2/encoder/context_tree.c
+++ b/av2/encoder/context_tree.c
@@ -20,32 +20,6 @@ static const BLOCK_SIZE square[MAX_SB_SIZE_LOG2 - 1] = {
   BLOCK_64X64, BLOCK_128X128, BLOCK_256X256,
 };
 
-static const int subblock_count[ALL_PARTITION_TYPES] = {
-  1,  // PARTITION_NONE
-  2,  // PARTITION_HORZ
-  2,  // PARTITION_VERT
-  4,  // PARTITION_HORZ_3
-  4,  // PARTITION_VERT_3
-  4,  // PARTITION_HORZ_4A
-  4,  // PARTITION_HORZ_4B
-  4,  // PARTITION_VERT_4A
-  4,  // PARTITION_VERT_4B
-  4,  // PARTITION_SPLIT
-};
-
-static const int step_multiplier[ALL_PARTITION_TYPES][4][2] = {
-  { { 0, 0 }, { 0, 0 }, { 0, 0 }, { 0, 0 } },  // PARTITION_NONE
-  { { 0, 0 }, { 4, 0 }, { 0, 0 }, { 0, 0 } },  // PARTITION_HORZ
-  { { 0, 0 }, { 0, 4 }, { 0, 0 }, { 0, 0 } },  // PARTITION_VERT
-  { { 0, 0 }, { 2, 0 }, { 2, 4 }, { 6, 0 } },  // PARTITION_HORZ_3
-  { { 0, 0 }, { 0, 2 }, { 4, 2 }, { 0, 6 } },  // PARTITION_VERT_3
-  { { 0, 0 }, { 1, 0 }, { 3, 0 }, { 7, 0 } },  // PARTITION_HORZ_4A
-  { { 0, 0 }, { 1, 0 }, { 5, 0 }, { 7, 0 } },  // PARTITION_HORZ_4B
-  { { 0, 0 }, { 0, 1 }, { 0, 3 }, { 0, 7 } },  // PARTITION_VERT_4A
-  { { 0, 0 }, { 0, 1 }, { 0, 5 }, { 0, 7 } },  // PARTITION_VERT_4B
-  { { 0, 0 }, { 0, 4 }, { 4, 0 }, { 4, 4 } },  // PARTITION_SPLIT
-};
-
 /*!\brief Retrieves the array of child PC_TREE nodes corresponding to a specific
  * partition type and region. */
 PC_TREE *const *get_child_pc_trees(const PC_TREE *pc_tree,
@@ -70,66 +44,10 @@ PC_TREE *const *get_child_pc_trees(const PC_TREE *pc_tree,
     case PARTITION_SPLIT: child_nodes = pc_tree->split[region]; break;
   }
   // No child blocks for partition none.
-  *num_sub_parts = partition == PARTITION_NONE ? 0 : subblock_count[partition];
+  *num_sub_parts =
+      partition == PARTITION_NONE ? 0 : get_subblock_count(partition);
 
   return child_nodes;
-}
-
-/*!\brief Returns number of sub blocks for partition_type. */
-int get_subblock_count(PARTITION_TYPE partition_type) {
-  if (partition_type >= ALL_PARTITION_TYPES) {
-    assert(0 && "Unexpected partition type");
-    return 0;
-  }
-  return subblock_count[partition_type];
-}
-
-/*!\brief Computes the layout (coordinates and sizes) of subblocks resulting
- * from a partition. */
-void get_partition_subblock_layout(PARTITION_TYPE partition_type,
-                                   BLOCK_SIZE bsize, int mi_row, int mi_col,
-                                   BLOCK_SIZE sub_sizes[4], int mi_rows[4],
-                                   int mi_cols[4]) {
-  if (partition_type >= ALL_PARTITION_TYPES) {
-    assert(0 && "Unexpected partition type");
-    return;
-  }
-  const int eighth_step_h = block_size_high[bsize] / 8;
-  const int eighth_step_w = block_size_wide[bsize] / 8;
-  const BLOCK_SIZE part_subsize = get_partition_subsize(bsize, partition_type);
-
-  for (int sub_idx = 0; sub_idx < 4; ++sub_idx) {
-    mi_rows[sub_idx] = mi_row + step_multiplier[partition_type][sub_idx][0] *
-                                    eighth_step_h / 4;
-    mi_cols[sub_idx] = mi_col + step_multiplier[partition_type][sub_idx][1] *
-                                    eighth_step_w / 4;
-    sub_sizes[sub_idx] = part_subsize;
-  }
-  if (partition_type == PARTITION_HORZ_3 ||
-      partition_type == PARTITION_VERT_3) {
-    const BLOCK_SIZE sml_subsize =
-        get_h_partition_subsize(bsize, 0, partition_type);
-    const BLOCK_SIZE big_subsize =
-        get_h_partition_subsize(bsize, 1, partition_type);
-    sub_sizes[0] = sub_sizes[3] = sml_subsize;
-    sub_sizes[1] = sub_sizes[2] = big_subsize;
-  } else if (partition_type == PARTITION_HORZ_4A ||
-             partition_type == PARTITION_VERT_4A ||
-             partition_type == PARTITION_HORZ_4B ||
-             partition_type == PARTITION_VERT_4B) {
-    const RECT_PART_TYPE rect_type = get_rect_part_type(partition_type);
-    const UNEVEN_4WAY_PART_TYPE uneven_type =
-        get_4way_part_type(partition_type);
-    const PARTITION_TYPE p_type =
-        (rect_type == HORZ) ? PARTITION_HORZ : PARTITION_VERT;
-    const BLOCK_SIZE big_subsize = get_partition_subsize(bsize, p_type);
-    assert(big_subsize != BLOCK_INVALID);
-    const BLOCK_SIZE med_subsize = subsize_lookup[p_type][big_subsize];
-    assert(med_subsize != BLOCK_INVALID);
-    assert(part_subsize == subsize_lookup[p_type][med_subsize]);
-    sub_sizes[1] = (uneven_type == UNEVEN_4A ? med_subsize : big_subsize);
-    sub_sizes[2] = (uneven_type == UNEVEN_4A ? big_subsize : med_subsize);
-  }
 }
 
 void av2_copy_tree_context(PICK_MODE_CONTEXT *dst_ctx,

--- a/av2/encoder/context_tree.h
+++ b/av2/encoder/context_tree.h
@@ -148,13 +148,6 @@ PC_TREE *const *get_child_pc_trees(const PC_TREE *pc_tree,
                                    PARTITION_TYPE partition, REGION_TYPE region,
                                    int *num_sub_parts);
 
-int get_subblock_count(PARTITION_TYPE partition_type);
-
-void get_partition_subblock_layout(PARTITION_TYPE partition_type,
-                                   BLOCK_SIZE bsize, int mi_row, int mi_col,
-                                   BLOCK_SIZE sub_sizes[4], int mi_rows[4],
-                                   int mi_cols[4]);
-
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -978,9 +978,6 @@ static AVM_INLINE void bridge_frame_decode_partition(
   // Half block width/height.
   const int hbs_w = mi_size_wide[bsize] / 2;
   const int hbs_h = mi_size_high[bsize] / 2;
-  // One-eighth block width/height.
-  const int ebs_w = mi_size_wide[bsize] / 8;
-  const int ebs_h = mi_size_high[bsize] / 8;
   PARTITION_TYPE partition;
   const int has_rows = (mi_row + hbs_h) < cm->mi_params.mi_rows;
   const int has_cols = (mi_col + hbs_w) < cm->mi_params.mi_cols;
@@ -1054,77 +1051,20 @@ static AVM_INLINE void bridge_frame_decode_partition(
     ptree->region_type = parent->region_type;
   }
 
-  switch (partition) {
-    case PARTITION_HORZ_4A:
-    case PARTITION_HORZ_4B:
-    case PARTITION_VERT_4A:
-    case PARTITION_VERT_4B:
-    case PARTITION_SPLIT:
-      ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-      ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-      ptree->sub_tree[2] = av2_alloc_ptree_node(ptree, 2);
-      ptree->sub_tree[3] = av2_alloc_ptree_node(ptree, 3);
-      if (is_intra_sdp_enabled && xd->tree_type == SHARED_PART) {
-        ptree_luma->sub_tree[0] = av2_alloc_ptree_node(ptree_luma, 0);
-        ptree_luma->sub_tree[1] = av2_alloc_ptree_node(ptree_luma, 1);
-        ptree_luma->sub_tree[2] = av2_alloc_ptree_node(ptree_luma, 2);
-        ptree_luma->sub_tree[3] = av2_alloc_ptree_node(ptree_luma, 3);
-      }
-      break;
-    case PARTITION_HORZ:
-    case PARTITION_VERT:
-      ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-      ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-
-      if (is_intra_sdp_enabled && xd->tree_type == SHARED_PART) {
-        ptree_luma->sub_tree[0] = av2_alloc_ptree_node(ptree_luma, 0);
-        ptree_luma->sub_tree[1] = av2_alloc_ptree_node(ptree_luma, 1);
-      }
-      break;
-    case PARTITION_HORZ_3:
-    case PARTITION_VERT_3:
-      ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-      ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-      ptree->sub_tree[2] = av2_alloc_ptree_node(ptree, 2);
-      ptree->sub_tree[3] = av2_alloc_ptree_node(ptree, 3);
-
-      if (is_intra_sdp_enabled && xd->tree_type == SHARED_PART) {
-        ptree_luma->sub_tree[0] = av2_alloc_ptree_node(ptree_luma, 0);
-        ptree_luma->sub_tree[1] = av2_alloc_ptree_node(ptree_luma, 1);
-        ptree_luma->sub_tree[2] = av2_alloc_ptree_node(ptree_luma, 2);
-        ptree_luma->sub_tree[3] = av2_alloc_ptree_node(ptree_luma, 3);
-      }
-      break;
-    default: break;
-  }
-  switch (partition) {
-    case PARTITION_NONE:
-      xd->is_cfl_allowed_in_sdp = is_cfl_allowed_in_sdp;
-      break;
-    case PARTITION_HORZ_4A:
-    case PARTITION_HORZ_4B:
-    case PARTITION_VERT_4A:
-    case PARTITION_VERT_4B:
-    case PARTITION_HORZ_3:
-    case PARTITION_VERT_3:
-    case PARTITION_SPLIT:
-      ptree->sub_tree[0]->is_cfl_allowed_for_this_chroma_partition =
+  if (partition == PARTITION_NONE) {
+    xd->is_cfl_allowed_in_sdp = is_cfl_allowed_in_sdp;
+  } else {
+    const int num_subblocks = get_subblock_count(partition);
+    const bool alloc_luma =
+        is_intra_sdp_enabled && xd->tree_type == SHARED_PART;
+    for (int sub_idx = 0; sub_idx < num_subblocks; ++sub_idx) {
+      ptree->sub_tree[sub_idx] = av2_alloc_ptree_node(ptree, sub_idx);
+      ptree->sub_tree[sub_idx]->is_cfl_allowed_for_this_chroma_partition =
           is_cfl_allowed_in_sdp;
-      ptree->sub_tree[1]->is_cfl_allowed_for_this_chroma_partition =
-          is_cfl_allowed_in_sdp;
-      ptree->sub_tree[2]->is_cfl_allowed_for_this_chroma_partition =
-          is_cfl_allowed_in_sdp;
-      ptree->sub_tree[3]->is_cfl_allowed_for_this_chroma_partition =
-          is_cfl_allowed_in_sdp;
-      break;
-    case PARTITION_HORZ:
-    case PARTITION_VERT:
-      ptree->sub_tree[0]->is_cfl_allowed_for_this_chroma_partition =
-          is_cfl_allowed_in_sdp;
-      ptree->sub_tree[1]->is_cfl_allowed_for_this_chroma_partition =
-          is_cfl_allowed_in_sdp;
-      break;
-    default: break;
+      if (alloc_luma)
+        ptree_luma->sub_tree[sub_idx] =
+            av2_alloc_ptree_node(ptree_luma, sub_idx);
+    }
   }
 
   const BLOCK_SIZE subsize = get_partition_subsize(bsize, partition);
@@ -1172,133 +1112,29 @@ static AVM_INLINE void bridge_frame_decode_partition(
                        mi_col << MI_SIZE_LOG2);
   }
 
-#define BRIDGE_FRAME_DEC_BLOCK_STX_ARG
-#define BRIDGE_FRAME_DEC_BLOCK_EPT_ARG partition,
-#define BRIDGE_FRAME_DEC_BLOCK(db_r, db_c, db_subsize, index) \
-  bridge_frame_predict_inter_block(cm, xd)
-#define BRIDGE_FRAME_DEC_PARTITION(db_r, db_c, db_subsize, index)  \
-  bridge_frame_decode_partition(                                   \
-      cpi, td, tile, BRIDGE_FRAME_DEC_BLOCK_STX_ARG(db_r), (db_c), \
-      (db_subsize), sbi, ptree->sub_tree[(index)],                 \
-      get_partition_subtree_const(ptree_luma, index))
-
-  switch (partition) {
-    case PARTITION_NONE:
-      bridge_frame_set_offsets(cm, xd, subsize, mi_row, mi_col, parent, 0,
-                               partition);
-      // from av2_read_mode_info
-      MB_MODE_INFO *const mi = xd->mi[0];
-      if (xd->tree_type == SHARED_PART)
-        mi->sb_type[PLANE_TYPE_UV] = mi->sb_type[PLANE_TYPE_Y];
-      BRIDGE_FRAME_DEC_BLOCK(mi_row, mi_col, subsize, 0);
-      break;
-    case PARTITION_HORZ:
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, mi_col, subsize, 0);
-      if ((mi_row + hbs_h) < cm->mi_params.mi_rows)
-        BRIDGE_FRAME_DEC_PARTITION(mi_row + hbs_h, mi_col, subsize, 1);
-      break;
-    case PARTITION_VERT:
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, mi_col, subsize, 0);
-      if ((mi_col + hbs_w) < cm->mi_params.mi_cols)
-        BRIDGE_FRAME_DEC_PARTITION(mi_row, mi_col + hbs_w, subsize, 1);
-      break;
-    case PARTITION_HORZ_4A: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_HORZ][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_HORZ][bsize_med]);
-      int this_mi_row = mi_row;
-      BRIDGE_FRAME_DEC_PARTITION(this_mi_row, mi_col, subsize, 0);
-      this_mi_row += ebs_h;
-      if (this_mi_row >= cm->mi_params.mi_rows) break;
-      BRIDGE_FRAME_DEC_PARTITION(this_mi_row, mi_col, bsize_med, 1);
-      this_mi_row += 2 * ebs_h;
-      if (this_mi_row >= cm->mi_params.mi_rows) break;
-      BRIDGE_FRAME_DEC_PARTITION(this_mi_row, mi_col, bsize_big, 2);
-      this_mi_row += 4 * ebs_h;
-      if (this_mi_row >= cm->mi_params.mi_rows) break;
-      BRIDGE_FRAME_DEC_PARTITION(this_mi_row, mi_col, subsize, 3);
-      break;
-    }
-    case PARTITION_HORZ_4B: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_HORZ][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_HORZ][bsize_med]);
-      int this_mi_row = mi_row;
-      BRIDGE_FRAME_DEC_PARTITION(this_mi_row, mi_col, subsize, 0);
-      this_mi_row += ebs_h;
-      if (this_mi_row >= cm->mi_params.mi_rows) break;
-      BRIDGE_FRAME_DEC_PARTITION(this_mi_row, mi_col, bsize_big, 1);
-      this_mi_row += 4 * ebs_h;
-      if (this_mi_row >= cm->mi_params.mi_rows) break;
-      BRIDGE_FRAME_DEC_PARTITION(this_mi_row, mi_col, bsize_med, 2);
-      this_mi_row += 2 * ebs_h;
-      if (this_mi_row >= cm->mi_params.mi_rows) break;
-      BRIDGE_FRAME_DEC_PARTITION(this_mi_row, mi_col, subsize, 3);
-      break;
-    }
-    case PARTITION_VERT_4A: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_VERT);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_VERT][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_VERT][bsize_med]);
-      int this_mi_col = mi_col;
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, this_mi_col, subsize, 0);
-      this_mi_col += ebs_w;
-      if (this_mi_col >= cm->mi_params.mi_cols) break;
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, this_mi_col, bsize_med, 1);
-      this_mi_col += 2 * ebs_w;
-      if (this_mi_col >= cm->mi_params.mi_cols) break;
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, this_mi_col, bsize_big, 2);
-      this_mi_col += 4 * ebs_w;
-      if (this_mi_col >= cm->mi_params.mi_cols) break;
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, this_mi_col, subsize, 3);
-      break;
-    }
-    case PARTITION_VERT_4B: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_VERT);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_VERT][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_VERT][bsize_med]);
-      int this_mi_col = mi_col;
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, this_mi_col, subsize, 0);
-      this_mi_col += ebs_w;
-      if (this_mi_col >= cm->mi_params.mi_cols) break;
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, this_mi_col, bsize_big, 1);
-      this_mi_col += 4 * ebs_w;
-      if (this_mi_col >= cm->mi_params.mi_cols) break;
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, this_mi_col, bsize_med, 2);
-      this_mi_col += 2 * ebs_w;
-      if (this_mi_col >= cm->mi_params.mi_cols) break;
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, this_mi_col, subsize, 3);
-      break;
-    }
-    case PARTITION_HORZ_3:
-    case PARTITION_VERT_3: {
-      for (int i = 0; i < 4; ++i) {
-        BLOCK_SIZE this_bsize = get_h_partition_subsize(bsize, i, partition);
-        const int offset_r = get_h_partition_offset_mi_row(bsize, i, partition);
-        const int offset_c = get_h_partition_offset_mi_col(bsize, i, partition);
-
-        assert(this_bsize != BLOCK_INVALID);
-        assert(offset_r >= 0 && offset_c >= 0);
-
-        const int this_mi_row = mi_row + offset_r;
-        const int this_mi_col = mi_col + offset_c;
-        if (partition == PARTITION_HORZ_3) {
-          if (this_mi_row >= cm->mi_params.mi_rows) break;
-        } else {
-          if (this_mi_col >= cm->mi_params.mi_cols) break;
-        }
-
-        BRIDGE_FRAME_DEC_PARTITION(this_mi_row, this_mi_col, this_bsize, i);
+  if (partition == PARTITION_NONE) {
+    bridge_frame_set_offsets(cm, xd, subsize, mi_row, mi_col, parent, 0,
+                             partition);
+    // from av2_read_mode_info
+    MB_MODE_INFO *const mi = xd->mi[0];
+    if (xd->tree_type == SHARED_PART)
+      mi->sb_type[PLANE_TYPE_UV] = mi->sb_type[PLANE_TYPE_Y];
+    bridge_frame_predict_inter_block(cm, xd);
+  } else {
+    BLOCK_SIZE sub_sizes[4];
+    int mi_rows[4], mi_cols[4];
+    get_partition_subblock_layout(partition, bsize, mi_row, mi_col, sub_sizes,
+                                  mi_rows, mi_cols);
+    const int num_subblocks = get_subblock_count(partition);
+    for (int sub_idx = 0; sub_idx < num_subblocks; ++sub_idx) {
+      if (mi_rows[sub_idx] < cm->mi_params.mi_rows &&
+          mi_cols[sub_idx] < cm->mi_params.mi_cols) {
+        bridge_frame_decode_partition(
+            cpi, td, tile, mi_rows[sub_idx], mi_cols[sub_idx],
+            sub_sizes[sub_idx], sbi, ptree->sub_tree[sub_idx],
+            get_partition_subtree_const(ptree_luma, sub_idx));
       }
-      break;
     }
-    case PARTITION_SPLIT:
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, mi_col, subsize, 0);
-      BRIDGE_FRAME_DEC_PARTITION(mi_row, mi_col + hbs_w, subsize, 1);
-      BRIDGE_FRAME_DEC_PARTITION(mi_row + hbs_h, mi_col, subsize, 2);
-      BRIDGE_FRAME_DEC_PARTITION(mi_row + hbs_h, mi_col + hbs_w, subsize, 3);
-      break;
-    default: assert(0 && "Invalid partition type");
   }
 
   parent = ptree->parent;
@@ -1310,16 +1146,11 @@ static AVM_INLINE void bridge_frame_decode_partition(
       xd->tree_type = CHROMA_PART;
       bridge_frame_set_offsets(cm, xd, bsize, mi_row, mi_col, parent, 0,
                                partition);
-      BRIDGE_FRAME_DEC_BLOCK(mi_row, mi_col, bsize, 0);
+      bridge_frame_predict_inter_block(cm, xd);
       // reset back to shared part
       xd->tree_type = SHARED_PART;
     }
   }
-
-#undef BRIDGE_FRAME_DEC_PARTITION
-#undef BRIDGE_FRAME_DEC_BLOCK
-#undef BRIDGE_FRAME_DEC_BLOCK_EPT_ARG
-#undef BRIDGE_FRAME_DEC_BLOCK_STX_ARG
 }
 
 static AVM_INLINE void bridge_frame_decode_partition_sb(

--- a/av2/encoder/mv_prec.c
+++ b/av2/encoder/mv_prec.c
@@ -397,114 +397,18 @@ static AVM_INLINE void collect_mv_stats_sb(MV_STATS *mv_stats,
     return;
   const PARTITION_TYPE partition = ptree->partition;
 
-  const BLOCK_SIZE subsize = get_partition_subsize(bsize, partition);
-
-  const int hbs_w = mi_size_wide[bsize] / 2;
-  const int hbs_h = mi_size_high[bsize] / 2;
-  const int ebs_w = mi_size_wide[bsize] / 8;
-  const int ebs_h = mi_size_high[bsize] / 8;
-  switch (partition) {
-    case PARTITION_NONE:
-      collect_mv_stats_b(mv_stats, cpi, mi_row, mi_col);
-      break;
-    case PARTITION_HORZ:
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col, subsize,
-                          ptree->sub_tree[0]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + hbs_h, mi_col, subsize,
-                          ptree->sub_tree[1]);
-      break;
-    case PARTITION_VERT:
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col, subsize,
-                          ptree->sub_tree[0]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col + hbs_w, subsize,
-                          ptree->sub_tree[1]);
-      break;
-    case PARTITION_SPLIT:
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col, subsize,
-                          ptree->sub_tree[0]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col + hbs_w, subsize,
-                          ptree->sub_tree[1]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + hbs_h, mi_col, subsize,
-                          ptree->sub_tree[2]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + hbs_h, mi_col + hbs_w,
-                          subsize, ptree->sub_tree[3]);
-      break;
-    case PARTITION_HORZ_4A: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);
-      assert(bsize_big < BLOCK_SIZES_ALL);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_HORZ][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_HORZ][bsize_med]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col, subsize,
-                          ptree->sub_tree[0]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + ebs_h, mi_col, bsize_med,
-                          ptree->sub_tree[1]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + 3 * ebs_h, mi_col, bsize_big,
-                          ptree->sub_tree[2]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + 7 * ebs_h, mi_col, subsize,
-                          ptree->sub_tree[3]);
-      break;
+  if (partition == PARTITION_NONE) {
+    collect_mv_stats_b(mv_stats, cpi, mi_row, mi_col);
+  } else {
+    BLOCK_SIZE sub_sizes[4];
+    int mi_rows[4], mi_cols[4];
+    get_partition_subblock_layout(partition, bsize, mi_row, mi_col, sub_sizes,
+                                  mi_rows, mi_cols);
+    const int num_subblocks = get_subblock_count(partition);
+    for (int sub_idx = 0; sub_idx < num_subblocks; ++sub_idx) {
+      collect_mv_stats_sb(mv_stats, cpi, mi_rows[sub_idx], mi_cols[sub_idx],
+                          sub_sizes[sub_idx], ptree->sub_tree[sub_idx]);
     }
-    case PARTITION_HORZ_4B: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);
-      assert(bsize_big < BLOCK_SIZES_ALL);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_HORZ][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_HORZ][bsize_med]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col, subsize,
-                          ptree->sub_tree[0]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + ebs_h, mi_col, bsize_big,
-                          ptree->sub_tree[1]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + 5 * ebs_h, mi_col, bsize_med,
-                          ptree->sub_tree[2]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row + 7 * ebs_h, mi_col, subsize,
-                          ptree->sub_tree[3]);
-      break;
-    }
-    case PARTITION_VERT_4A: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_VERT);
-      assert(bsize_big < BLOCK_SIZES_ALL);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_VERT][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_VERT][bsize_med]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col, subsize,
-                          ptree->sub_tree[0]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col + ebs_w, bsize_med,
-                          ptree->sub_tree[1]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col + 3 * ebs_w, bsize_big,
-                          ptree->sub_tree[2]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col + 7 * ebs_w, subsize,
-                          ptree->sub_tree[3]);
-      break;
-    }
-    case PARTITION_VERT_4B: {
-      const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_VERT);
-      assert(bsize_big < BLOCK_SIZES_ALL);
-      const BLOCK_SIZE bsize_med = subsize_lookup[PARTITION_VERT][bsize_big];
-      assert(subsize == subsize_lookup[PARTITION_VERT][bsize_med]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col, subsize,
-                          ptree->sub_tree[0]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col + ebs_w, bsize_big,
-                          ptree->sub_tree[1]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col + 5 * ebs_w, bsize_med,
-                          ptree->sub_tree[2]);
-      collect_mv_stats_sb(mv_stats, cpi, mi_row, mi_col + 7 * ebs_w, subsize,
-                          ptree->sub_tree[3]);
-      break;
-    }
-    case PARTITION_HORZ_3:
-    case PARTITION_VERT_3: {
-      for (int i = 0; i < 4; ++i) {
-        const BLOCK_SIZE this_bsize =
-            get_h_partition_subsize(bsize, i, partition);
-        const int offset_mr =
-            get_h_partition_offset_mi_row(bsize, i, partition);
-        const int offset_mc =
-            get_h_partition_offset_mi_col(bsize, i, partition);
-
-        collect_mv_stats_sb(mv_stats, cpi, mi_row + offset_mr,
-                            mi_col + offset_mc, this_bsize, ptree->sub_tree[i]);
-      }
-      break;
-    }
-    default: assert(0);
   }
 }
 

--- a/av2/encoder/mv_prec.c
+++ b/av2/encoder/mv_prec.c
@@ -427,7 +427,7 @@ static AVM_INLINE void collect_mv_stats_sb(MV_STATS *mv_stats,
       collect_mv_stats_sb(mv_stats, cpi, mi_row + hbs_h, mi_col, subsize,
                           ptree->sub_tree[2]);
       collect_mv_stats_sb(mv_stats, cpi, mi_row + hbs_h, mi_col + hbs_w,
-                          subsize, ptree->sub_tree[0]);
+                          subsize, ptree->sub_tree[3]);
       break;
     case PARTITION_HORZ_4A: {
       const BLOCK_SIZE bsize_big = get_partition_subsize(bsize, PARTITION_HORZ);

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -1948,54 +1948,14 @@ static void encode_sb(const AV2_COMP *const cpi, ThreadData *td,
     }
     if (partition == PARTITION_NONE) {
       xd->is_cfl_allowed_in_sdp = is_cfl_allowed_in_sdp;
-    }
-
-    switch (partition) {
-      case PARTITION_HORZ_4A:
-      case PARTITION_HORZ_4B:
-      case PARTITION_VERT_4A:
-      case PARTITION_VERT_4B:
-      case PARTITION_SPLIT:
-        ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-        ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-        ptree->sub_tree[2] = av2_alloc_ptree_node(ptree, 2);
-        ptree->sub_tree[3] = av2_alloc_ptree_node(ptree, 3);
-        break;
-      case PARTITION_HORZ:
-      case PARTITION_VERT:
-        ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-        ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-        break;
-      case PARTITION_HORZ_3:
-      case PARTITION_VERT_3:
-        ptree->sub_tree[0] = av2_alloc_ptree_node(ptree, 0);
-        ptree->sub_tree[1] = av2_alloc_ptree_node(ptree, 1);
-        ptree->sub_tree[2] = av2_alloc_ptree_node(ptree, 2);
-        ptree->sub_tree[3] = av2_alloc_ptree_node(ptree, 3);
-        break;
-      default: break;
-    }
-    for (int i = 0; i < 4; ++i) sub_tree[i] = ptree->sub_tree[i];
-
-    switch (partition) {
-      case PARTITION_HORZ_4A:
-      case PARTITION_HORZ_4B:
-      case PARTITION_VERT_4A:
-      case PARTITION_VERT_4B:
-      case PARTITION_SPLIT:
-      case PARTITION_HORZ_3:
-      case PARTITION_VERT_3:
-        for (int i = 0; i < 4; ++i)
-          sub_tree[i]->is_cfl_allowed_for_this_chroma_partition =
-              is_cfl_allowed_in_sdp;
-        break;
-      case PARTITION_HORZ:
-      case PARTITION_VERT:
-        for (int i = 0; i < 2; ++i)
-          sub_tree[i]->is_cfl_allowed_for_this_chroma_partition =
-              is_cfl_allowed_in_sdp;
-        break;
-      default: break;
+    } else {
+      int num_sub_parts = get_subblock_count(partition);
+      for (int sub_idx = 0; sub_idx < num_sub_parts; ++sub_idx) {
+        sub_tree[sub_idx] = ptree->sub_tree[sub_idx] =
+            av2_alloc_ptree_node(ptree, sub_idx);
+        sub_tree[sub_idx]->is_cfl_allowed_for_this_chroma_partition =
+            is_cfl_allowed_in_sdp;
+      }
     }
     if (!cm->seq_params.enable_cfl_intra && !cm->seq_params.enable_mhccp) {
       xd->is_cfl_allowed_in_sdp = CFL_DISALLOWED_FOR_CHROMA;


### PR DESCRIPTION
This change refactors the ptree traversal functions to reduce the code length. Also, this change fixes a bug due to a typo in `collect_mv_stats_sb()`.