### PR TITLE
Check i<MAX_TILE_COLS in read_tile_syntax_info()

### DIFF
--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -4153,6 +4153,74 @@ static void reuse_tile_params(CommonTileParams *tiles,
   av2_calculate_tile_rows(tiles);
 }
 
+static void read_tile_syntax_info(CommonTileParams *tiles,
+                                  struct avm_read_bit_buffer *rb) {
+  int width_sb = tiles->sb_cols;
+  int height_sb = tiles->sb_rows;
+
+  tiles->uniform_spacing = avm_rb_read_bit(rb);
+
+  // Read tile columns
+  if (tiles->uniform_spacing) {
+    tiles->log2_cols = tiles->min_log2_cols;
+    while (tiles->log2_cols < tiles->max_log2_cols) {
+      if (!avm_rb_read_bit(rb)) {
+        break;
+      }
+      tiles->log2_cols++;
+    }
+  } else {
+    int i;
+    int start_sb;
+    for (i = 0, start_sb = 0; width_sb > 0; i++) {
+      if (i >= MAX_TILE_COLS) {
+        rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
+                          "SeqTileCols cannot be greater than MAX_TILE_COLS");
+      }
+      const int size_sb =
+          1 + rb_read_uniform(rb, AVMMIN(width_sb, tiles->max_width_sb));
+      tiles->col_start_sb[i] = start_sb;
+      start_sb += size_sb;
+      width_sb -= size_sb;
+    }
+    assert(width_sb == 0);
+    assert(start_sb == tiles->sb_cols);
+    tiles->cols = i;
+    tiles->col_start_sb[i] = start_sb;
+  }
+  av2_calculate_tile_cols(tiles);
+
+  // Read tile rows
+  if (tiles->uniform_spacing) {
+    tiles->log2_rows = tiles->min_log2_rows;
+    while (tiles->log2_rows < tiles->max_log2_rows) {
+      if (!avm_rb_read_bit(rb)) {
+        break;
+      }
+      tiles->log2_rows++;
+    }
+  } else {
+    int i;
+    int start_sb;
+    for (i = 0, start_sb = 0; height_sb > 0; i++) {
+      if (i >= MAX_TILE_ROWS) {
+        rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
+                          "SeqTileRows cannot be greater than MAX_TILE_ROWS");
+      }
+      const int size_sb =
+          1 + rb_read_uniform(rb, AVMMIN(height_sb, tiles->max_height_sb));
+      tiles->row_start_sb[i] = start_sb;
+      start_sb += size_sb;
+      height_sb -= size_sb;
+    }
+    assert(height_sb == 0);
+    assert(start_sb == tiles->sb_rows);
+    tiles->rows = i;
+    tiles->row_start_sb[i] = start_sb;
+  }
+  av2_calculate_tile_rows(tiles);
+}
+
 static AVM_INLINE void read_tile_info(AV2Decoder *const pbi,
                                       struct avm_read_bit_buffer *const rb) {
   AV2_COMMON *const cm = &pbi->common;
@@ -5849,73 +5917,6 @@ void av2_read_conformance_window(struct avm_read_bit_buffer *rb,
     conf->conf_win_top_offset = 0;
     conf->conf_win_bottom_offset = 0;
   }
-}
-
-static void read_tile_syntax_info(CommonTileParams *tile_info,
-                                  struct avm_read_bit_buffer *rb) {
-  tile_info->uniform_spacing = avm_rb_read_bit(rb);
-
-  // Read tile columns
-  if (tile_info->uniform_spacing) {
-    tile_info->log2_cols = tile_info->min_log2_cols;
-    while (tile_info->log2_cols < tile_info->max_log2_cols) {
-      if (!avm_rb_read_bit(rb)) {
-        break;
-      }
-      tile_info->log2_cols++;
-    }
-  } else {
-    int i;
-    int start_sb;
-    int width_sb = tile_info->sb_cols;
-    for (i = 0, start_sb = 0; width_sb > 0; i++) {
-      if (i >= MAX_TILE_COLS) {
-        rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
-                          "SeqTileCols cannot be greater than MAX_TILE_COLS");
-      }
-      const int size_sb =
-          1 + rb_read_uniform(rb, AVMMIN(width_sb, tile_info->max_width_sb));
-      tile_info->col_start_sb[i] = start_sb;
-      start_sb += size_sb;
-      width_sb -= size_sb;
-    }
-    assert(width_sb == 0);
-    assert(start_sb == tile_info->sb_cols);
-    tile_info->cols = i;
-    tile_info->col_start_sb[i] = start_sb;
-  }
-  av2_calculate_tile_cols(tile_info);
-
-  // Read tile rows
-  if (tile_info->uniform_spacing) {
-    tile_info->log2_rows = tile_info->min_log2_rows;
-    while (tile_info->log2_rows < tile_info->max_log2_rows) {
-      if (!avm_rb_read_bit(rb)) {
-        break;
-      }
-      tile_info->log2_rows++;
-    }
-  } else {
-    int i;
-    int start_sb;
-    int height_sb = tile_info->sb_rows;
-    for (i = 0, start_sb = 0; height_sb > 0; i++) {
-      if (i >= MAX_TILE_ROWS) {
-        rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
-                          "SeqTileRows cannot be greater than MAX_TILE_ROWS");
-      }
-      const int size_sb =
-          1 + rb_read_uniform(rb, AVMMIN(height_sb, tile_info->max_height_sb));
-      tile_info->row_start_sb[i] = start_sb;
-      start_sb += size_sb;
-      height_sb -= size_sb;
-    }
-    assert(height_sb == 0);
-    assert(start_sb == tile_info->sb_rows);
-    tile_info->rows = i;
-    tile_info->row_start_sb[i] = start_sb;
-  }
-  av2_calculate_tile_rows(tile_info);
 }
 
 // Reads the tile information in the sequence header

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -5927,7 +5927,14 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
     int i;
     int start_sb;
     int width_sb = tile_info->sb_cols;
-    for (i = 0, start_sb = 0; width_sb > 0 && i < MAX_TILE_COLS; i++) {
+    for (i = 0, start_sb = 0; width_sb > 0; i++) {
+      if (i >= MAX_TILE_COLS) {
+        if (rb->error_handler) {
+          rb->error_handler(rb->error_handler_data, AVM_CODEC_UNSUP_BITSTREAM,
+                            "The decoder only supports MAX_TILE_COLS tiles.");
+        }
+        return;
+      }
       const int size_sb =
           1 + rb_read_uniform(rb, AVMMIN(width_sb, tile_info->max_width_sb));
       tile_info->col_start_sb[i] = start_sb;
@@ -5955,7 +5962,14 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
     int i;
     int start_sb;
     int height_sb = tile_info->sb_rows;
-    for (i = 0, start_sb = 0; height_sb > 0 && i < MAX_TILE_ROWS; i++) {
+    for (i = 0, start_sb = 0; height_sb > 0; i++) {
+      if (i >= MAX_TILE_ROWS) {
+        if (rb->error_handler) {
+          rb->error_handler(rb->error_handler_data, AVM_CODEC_UNSUP_BITSTREAM,
+                            "The decoder only supports MAX_TILE_ROWS tiles.");
+        }
+        return;
+      }
       const int size_sb =
           1 + rb_read_uniform(rb, AVMMIN(height_sb, tile_info->max_height_sb));
       tile_info->row_start_sb[i] = start_sb;

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -5929,11 +5929,8 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
     int width_sb = tile_info->sb_cols;
     for (i = 0, start_sb = 0; width_sb > 0; i++) {
       if (i >= MAX_TILE_COLS) {
-        if (rb->error_handler) {
-          rb->error_handler(rb->error_handler_data, AVM_CODEC_UNSUP_BITSTREAM,
-                            "The decoder only supports MAX_TILE_COLS tiles.");
-        }
-        return;
+        rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
+                          "TileCols cannot be greater than MAX_TILE_COLS");
       }
       const int size_sb =
           1 + rb_read_uniform(rb, AVMMIN(width_sb, tile_info->max_width_sb));
@@ -5941,9 +5938,10 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
       start_sb += size_sb;
       width_sb -= size_sb;
     }
-    tile_info->cols = i;
-    tile_info->col_start_sb[i] = start_sb + width_sb;
     assert(width_sb == 0);
+    assert(start_sb == tile_info->sb_cols);
+    tile_info->cols = i;
+    tile_info->col_start_sb[i] = start_sb;
   }
   tile_info->min_log2_rows =
       AVMMAX(tile_info->min_log2 - tile_info->log2_cols, 0);
@@ -5964,11 +5962,8 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
     int height_sb = tile_info->sb_rows;
     for (i = 0, start_sb = 0; height_sb > 0; i++) {
       if (i >= MAX_TILE_ROWS) {
-        if (rb->error_handler) {
-          rb->error_handler(rb->error_handler_data, AVM_CODEC_UNSUP_BITSTREAM,
-                            "The decoder only supports MAX_TILE_ROWS tiles.");
-        }
-        return;
+        rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
+                          "TileRows cannot be greater than MAX_TILE_ROWS");
       }
       const int size_sb =
           1 + rb_read_uniform(rb, AVMMIN(height_sb, tile_info->max_height_sb));
@@ -5976,9 +5971,10 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
       start_sb += size_sb;
       height_sb -= size_sb;
     }
-    tile_info->rows = i;
-    tile_info->row_start_sb[i] = start_sb + height_sb;
     assert(height_sb == 0);
+    assert(start_sb == tile_info->sb_rows);
+    tile_info->rows = i;
+    tile_info->row_start_sb[i] = start_sb;
   }
   av2_calculate_tile_rows(tile_info);
 }

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -4153,63 +4153,6 @@ static void reuse_tile_params(CommonTileParams *tiles,
   av2_calculate_tile_rows(tiles);
 }
 
-static AVM_INLINE void read_tile_info_max_tile(
-    AV2_COMMON *const cm, struct avm_read_bit_buffer *const rb) {
-  CommonTileParams *const tiles = &cm->tiles;
-  int width_sb = tiles->sb_cols;
-  int height_sb = tiles->sb_rows;
-
-  tiles->uniform_spacing = avm_rb_read_bit(rb);
-
-  // Read tile columns
-  if (tiles->uniform_spacing) {
-    tiles->log2_cols = tiles->min_log2_cols;
-    while (tiles->log2_cols < tiles->max_log2_cols) {
-      if (!avm_rb_read_bit(rb)) {
-        break;
-      }
-      tiles->log2_cols++;
-    }
-  } else {
-    int i;
-    int start_sb;
-    for (i = 0, start_sb = 0; width_sb > 0 && i < MAX_TILE_COLS; i++) {
-      const int size_sb =
-          1 + rb_read_uniform(rb, AVMMIN(width_sb, tiles->max_width_sb));
-      tiles->col_start_sb[i] = start_sb;
-      start_sb += size_sb;
-      width_sb -= size_sb;
-    }
-    tiles->cols = i;
-    tiles->col_start_sb[i] = start_sb + width_sb;
-  }
-  av2_calculate_tile_cols(tiles);
-
-  // Read tile rows
-  if (tiles->uniform_spacing) {
-    tiles->log2_rows = tiles->min_log2_rows;
-    while (tiles->log2_rows < tiles->max_log2_rows) {
-      if (!avm_rb_read_bit(rb)) {
-        break;
-      }
-      tiles->log2_rows++;
-    }
-  } else {
-    int i;
-    int start_sb;
-    for (i = 0, start_sb = 0; height_sb > 0 && i < MAX_TILE_ROWS; i++) {
-      const int size_sb =
-          1 + rb_read_uniform(rb, AVMMIN(height_sb, tiles->max_height_sb));
-      tiles->row_start_sb[i] = start_sb;
-      start_sb += size_sb;
-      height_sb -= size_sb;
-    }
-    tiles->rows = i;
-    tiles->row_start_sb[i] = start_sb + height_sb;
-  }
-  av2_calculate_tile_rows(tiles);
-}
-
 static AVM_INLINE void read_tile_info(AV2Decoder *const pbi,
                                       struct avm_read_bit_buffer *const rb) {
   AV2_COMMON *const cm = &pbi->common;
@@ -4233,7 +4176,7 @@ static AVM_INLINE void read_tile_info(AV2Decoder *const pbi,
   if (reuse) {
     reuse_tile_params(&cm->tiles, tile_params);
   } else {
-    read_tile_info_max_tile(cm, rb);
+    read_tile_syntax_info(&cm->tiles, rb);
   }
 
   if (cm->bru.enabled) {
@@ -5908,10 +5851,8 @@ void av2_read_conformance_window(struct avm_read_bit_buffer *rb,
   }
 }
 
-static void read_tile_syntax_info(TileInfoSyntax *tile_params,
+static void read_tile_syntax_info(CommonTileParams *tile_info,
                                   struct avm_read_bit_buffer *rb) {
-  tile_params->allow_tile_info_change = avm_rb_read_bit(rb);
-  CommonTileParams *tile_info = &tile_params->tile_info;
   tile_info->uniform_spacing = avm_rb_read_bit(rb);
 
   // Read tile columns
@@ -5930,7 +5871,7 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
     for (i = 0, start_sb = 0; width_sb > 0; i++) {
       if (i >= MAX_TILE_COLS) {
         rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
-                          "TileCols cannot be greater than MAX_TILE_COLS");
+                          "SeqTileCols cannot be greater than MAX_TILE_COLS");
       }
       const int size_sb =
           1 + rb_read_uniform(rb, AVMMIN(width_sb, tile_info->max_width_sb));
@@ -5943,8 +5884,6 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
     tile_info->cols = i;
     tile_info->col_start_sb[i] = start_sb;
   }
-  tile_info->min_log2_rows =
-      AVMMAX(tile_info->min_log2 - tile_info->log2_cols, 0);
   av2_calculate_tile_cols(tile_info);
 
   // Read tile rows
@@ -5963,7 +5902,7 @@ static void read_tile_syntax_info(TileInfoSyntax *tile_params,
     for (i = 0, start_sb = 0; height_sb > 0; i++) {
       if (i >= MAX_TILE_ROWS) {
         rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
-                          "TileRows cannot be greater than MAX_TILE_ROWS");
+                          "SeqTileRows cannot be greater than MAX_TILE_ROWS");
       }
       const int size_sb =
           1 + rb_read_uniform(rb, AVMMIN(height_sb, tile_info->max_height_sb));
@@ -5987,7 +5926,8 @@ static void read_sequence_tile_info(struct SequenceHeader *seq_params,
                           seq_params->max_frame_width,
                           seq_params->mib_size_log2, seq_params->mib_size_log2,
                           seq_params->seq_max_level_idx, seq_params->seq_tier);
-  read_tile_syntax_info(&seq_params->tile_params, rb);
+  seq_params->tile_params.allow_tile_info_change = avm_rb_read_bit(rb);
+  read_tile_syntax_info(&seq_params->tile_params.tile_info, rb);
 }
 
 static void read_sequence_tile_config(struct SequenceHeader *seq_params,

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -4153,11 +4153,8 @@ static void reuse_tile_params(CommonTileParams *tiles,
   av2_calculate_tile_rows(tiles);
 }
 
-static void read_tile_syntax_info(CommonTileParams *tiles,
-                                  struct avm_read_bit_buffer *rb) {
-  int width_sb = tiles->sb_cols;
-  int height_sb = tiles->sb_rows;
-
+static void read_tile_params(CommonTileParams *tiles,
+                             struct avm_read_bit_buffer *rb) {
   tiles->uniform_spacing = avm_rb_read_bit(rb);
 
   // Read tile columns
@@ -4172,10 +4169,11 @@ static void read_tile_syntax_info(CommonTileParams *tiles,
   } else {
     int i;
     int start_sb;
+    int width_sb = tiles->sb_cols;
     for (i = 0, start_sb = 0; width_sb > 0; i++) {
       if (i >= MAX_TILE_COLS) {
         rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
-                          "SeqTileCols cannot be greater than MAX_TILE_COLS");
+                          "tileCols cannot be greater than MAX_TILE_COLS");
       }
       const int size_sb =
           1 + rb_read_uniform(rb, AVMMIN(width_sb, tiles->max_width_sb));
@@ -4202,10 +4200,11 @@ static void read_tile_syntax_info(CommonTileParams *tiles,
   } else {
     int i;
     int start_sb;
+    int height_sb = tiles->sb_rows;
     for (i = 0, start_sb = 0; height_sb > 0; i++) {
       if (i >= MAX_TILE_ROWS) {
         rb->error_handler(rb->error_handler_data, AVM_CODEC_CORRUPT_FRAME,
-                          "SeqTileRows cannot be greater than MAX_TILE_ROWS");
+                          "tileRows cannot be greater than MAX_TILE_ROWS");
       }
       const int size_sb =
           1 + rb_read_uniform(rb, AVMMIN(height_sb, tiles->max_height_sb));
@@ -4244,7 +4243,7 @@ static AVM_INLINE void read_tile_info(AV2Decoder *const pbi,
   if (reuse) {
     reuse_tile_params(&cm->tiles, tile_params);
   } else {
-    read_tile_syntax_info(&cm->tiles, rb);
+    read_tile_params(&cm->tiles, rb);
   }
 
   if (cm->bru.enabled) {
@@ -5928,7 +5927,7 @@ static void read_sequence_tile_info(struct SequenceHeader *seq_params,
                           seq_params->mib_size_log2, seq_params->mib_size_log2,
                           seq_params->seq_max_level_idx, seq_params->seq_tier);
   seq_params->tile_params.allow_tile_info_change = avm_rb_read_bit(rb);
-  read_tile_syntax_info(&seq_params->tile_params.tile_info, rb);
+  read_tile_params(&seq_params->tile_params.tile_info, rb);
 }
 
 static void read_sequence_tile_config(struct SequenceHeader *seq_params,


### PR DESCRIPTION
Otherwise `width_sb` may not be 0.

---

https://av2.aomedia.org/v1.0.0/index.html#tile_params_semantics says:

> If uniform_tile_spacing_flag is equal to 0, it is a requirement of bitstream conformance that startSb is equal to sbCols when the loop writing sbColStarts exits.
>
> Note: The requirements on startSb ensure that the sizes of each tile add up to the full size of the frame when measured in superblocks.

So the `width_sb == 0` assertion at line 5959 makes sense.

However, the related code in https://av2.aomedia.org/v1.0.0/index.html#tile_params_syntax has no bound on `i`:

```py
widestTileSb = 1	
startSb = 0	
for ( i = 0; startSb < sbCols; i++ ) {	
  sbColStarts[ i ] = startSb	
  n = Min(sbCols - startSb, maxTileWidthSb)	
  width_in_sbs_minus_1	# ns(n)
  sizeSb = width_in_sbs_minus_1 + 1	
  widestTileSb = Max( sizeSb, widestTileSb )	
  startSb += sizeSb	
}
tileCols = i	
tileColsLog2 = tile_log2(1, tileCols)
```

whereas the implementation only loops as long as `i < MAX_TILE_COLS`.

---

This was found with a libavif fuzz target (b/540849406).