### PR TITLE
Fix array subscript out of bounds warning in rdopt.c

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -9274,9 +9274,10 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
     }
 
     const int ref_frame_index = COMPACT_INDEX0_NRS(ref_frame);
-    const int ref_frame_cost = comp_pred
-                                   ? ref_costs_comp[ref_frame][second_ref_frame]
-                                   : ref_costs_single[ref_frame_index];
+    const int sec_ref_frame_index = COMPACT_INDEX1_NRS(second_ref_frame);
+    const int ref_frame_cost =
+        comp_pred ? ref_costs_comp[ref_frame_index][sec_ref_frame_index]
+                  : ref_costs_single[ref_frame_index];
     const int compmode_cost = (comp_ref_allowed && !is_tip_ref_frame(ref_frame))
                                   ? comp_inter_cost[comp_pred]
                                   : 0;


### PR DESCRIPTION
Use compact reference indices (COMPACT_INDEX0_NRS) when indexing ref_costs_comp in av2_rd_pick_inter_mode_sb to prevent out-of-bounds array access warning on 8x8 ref_costs_comp array.