### PR TITLE
Simplify and rename reconstruct_tile_info_max_tile

### DIFF
--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -4124,51 +4124,31 @@ static AVM_INLINE void setup_frame_size_with_refs(
                                        &cm->error);
 }
 
-// Reconstructs the tile information
-static void reconstruct_tile_info_max_tile(
-    AV2_COMMON *const cm, const TileInfoSyntax *const tile_params) {
-  CommonTileParams *const tiles = &cm->tiles;
+// Reuses the tile information
+static void reuse_tile_params(CommonTileParams *tiles,
+                              const TileInfoSyntax *tile_params) {
   const CommonTileParams *const tile_info = &tile_params->tile_info;
-  int width_sb = tile_info->sb_cols;
-  int height_sb = tile_info->sb_rows;
 
   tiles->uniform_spacing = tile_info->uniform_spacing;
 
-  // Read tile columns
+  // Reuse tile columns
   if (tiles->uniform_spacing) {
     tiles->log2_cols = tile_info->log2_cols;
   } else {
-    int i;
-    int start_sb;
-    for (i = 0, start_sb = 0; width_sb > 0 && i < MAX_TILE_COLS; i++) {
-      const int size_sb =
-          tile_info->col_start_sb[i + 1] - tile_info->col_start_sb[i];
-      tiles->col_start_sb[i] = start_sb;
-      start_sb += size_sb;
-      width_sb -= size_sb;
+    for (int i = 0; i <= tile_info->cols; i++) {
+      tiles->col_start_sb[i] = tile_info->col_start_sb[i];
     }
-    tiles->cols = i;
-    tiles->col_start_sb[i] = start_sb + width_sb;
-    assert(width_sb == 0);
+    tiles->cols = tile_info->cols;
   }
   av2_calculate_tile_cols(tiles);
-  // Read tile rows
+  // Reuse tile rows
   if (tiles->uniform_spacing) {
-    // tiles->log2_rows = tile_params->log2_rows + 1;
     tiles->log2_rows = tile_info->log2_rows;
   } else {
-    int i;
-    int start_sb;
-    for (i = 0, start_sb = 0; height_sb > 0 && i < MAX_TILE_ROWS; i++) {
-      const int size_sb =
-          tile_info->row_start_sb[i + 1] - tile_info->row_start_sb[i];
-      tiles->row_start_sb[i] = start_sb;
-      start_sb += size_sb;
-      height_sb -= size_sb;
+    for (int i = 0; i <= tile_info->rows; i++) {
+      tiles->row_start_sb[i] = tile_info->row_start_sb[i];
     }
-    tiles->rows = i;
-    tiles->row_start_sb[i] = start_sb + height_sb;
-    assert(height_sb == 0);
+    tiles->rows = tile_info->rows;
   }
   av2_calculate_tile_rows(tiles);
 }
@@ -4251,7 +4231,7 @@ static AVM_INLINE void read_tile_info(AV2Decoder *const pbi,
       reuse = 1;
   }
   if (reuse) {
-    reconstruct_tile_info_max_tile(cm, tile_params);
+    reuse_tile_params(&cm->tiles, tile_params);
   } else {
     read_tile_info_max_tile(cm, rb);
   }


### PR DESCRIPTION
reconstruct_tile_info_max_tile() is called after
read_tile_syntax_info(). So it can copy the tile_info->col_start_sb[] and tile_info->row_start_sb[] arrays and their sizes tile_info->cols and tile_info->rows directly.

Rename the function to reuse_tile_info().