### PR TITLE
Prune uneven 4A/4B partitions with neighbor block boundaries

### DIFF
--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -6050,6 +6050,21 @@ static INLINE bool av2_skip_reference_buffer_update(
   return clear_multiple_insert_in_one && ref_index != first_ref_index;
 }
 
+// Returns the starting mi location of chroma reference block for the current
+// mbmi, by setting `chroma_mi_row_start` and `chroma_mi_col_start`.
+static INLINE void av2_get_chroma_start_location(const MB_MODE_INFO *mbmi,
+                                                 TREE_TYPE tree_type,
+                                                 int *chroma_mi_row_start,
+                                                 int *chroma_mi_col_start) {
+  if (tree_type == SHARED_PART) {
+    *chroma_mi_row_start = mbmi->chroma_ref_info.mi_row_chroma_base;
+    *chroma_mi_col_start = mbmi->chroma_ref_info.mi_col_chroma_base;
+  } else {
+    *chroma_mi_row_start = mbmi->chroma_mi_row_start;
+    *chroma_mi_col_start = mbmi->chroma_mi_col_start;
+  }
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -6056,6 +6056,7 @@ static INLINE void av2_get_chroma_start_location(const MB_MODE_INFO *mbmi,
                                                  TREE_TYPE tree_type,
                                                  int *chroma_mi_row_start,
                                                  int *chroma_mi_col_start) {
+  assert(tree_type == SHARED_PART || tree_type == CHROMA_PART);
   if (tree_type == SHARED_PART) {
     *chroma_mi_row_start = mbmi->chroma_ref_info.mi_row_chroma_base;
     *chroma_mi_col_start = mbmi->chroma_ref_info.mi_col_chroma_base;

--- a/av2/common/av2_loopfilter.c
+++ b/av2/common/av2_loopfilter.c
@@ -138,22 +138,6 @@ void av2_loop_filter_frame_init(AV2_COMMON *cm, int plane_start,
   }
 }
 
-// Returns the starting mi location of chroma reference block for the current
-// mbmi, by setting `chroma_mi_row_start` and `chroma_mi_col_start`.
-static void get_chroma_start_location(const MB_MODE_INFO *mbmi,
-                                      TREE_TYPE tree_type,
-                                      int *chroma_mi_row_start,
-                                      int *chroma_mi_col_start) {
-  assert(tree_type == SHARED_PART || tree_type == CHROMA_PART);
-  if (tree_type == SHARED_PART) {
-    *chroma_mi_row_start = mbmi->chroma_ref_info.mi_row_chroma_base;
-    *chroma_mi_col_start = mbmi->chroma_ref_info.mi_col_chroma_base;
-  } else {
-    *chroma_mi_row_start = mbmi->chroma_mi_row_start;
-    *chroma_mi_col_start = mbmi->chroma_mi_col_start;
-  }
-}
-
 // Returns true if we are at the transform boundary.
 static bool is_tu_edge_helper(TX_SIZE tx_size, EDGE_DIR edge_dir,
                               int relative_row, int relative_col) {
@@ -193,7 +177,8 @@ static TX_SIZE get_transform_size(const MACROBLOCKD *const xd,
     int mi_row_start = mbmi->mi_row_start;
     int mi_col_start = mbmi->mi_col_start;
     if (plane != AVM_PLANE_Y) {
-      get_chroma_start_location(mbmi, tree_type, &mi_row_start, &mi_col_start);
+      av2_get_chroma_start_location(mbmi, tree_type, &mi_row_start,
+                                    &mi_col_start);
     }
     *tu_edge = is_tu_edge_helper(
         tx_size, edge_dir, (mi_row - mi_row_start) >> plane_ptr->subsampling_y,
@@ -211,8 +196,8 @@ static TX_SIZE get_transform_size(const MACROBLOCKD *const xd,
                                     plane_ptr->subsampling_y);
     int chroma_mi_row_start;
     int chroma_mi_col_start;
-    get_chroma_start_location(mbmi, tree_type, &chroma_mi_row_start,
-                              &chroma_mi_col_start);
+    av2_get_chroma_start_location(mbmi, tree_type, &chroma_mi_row_start,
+                                  &chroma_mi_col_start);
     *tu_edge = is_tu_edge_helper(
         tx_size, edge_dir,
         (mi_row - chroma_mi_row_start) >> plane_ptr->subsampling_y,
@@ -329,8 +314,8 @@ static uint32_t get_pu_starting_cooord(const MB_MODE_INFO *const mbmi,
   } else {
     int chroma_mi_row_start;
     int chroma_mi_col_start;
-    get_chroma_start_location(mbmi, tree_type, &chroma_mi_row_start,
-                              &chroma_mi_col_start);
+    av2_get_chroma_start_location(mbmi, tree_type, &chroma_mi_row_start,
+                                  &chroma_mi_col_start);
     pu_starting_mi = vert_edge ? chroma_mi_col_start : chroma_mi_row_start;
   }
   const uint32_t pu_stating_coord_luma = pu_starting_mi * MI_SIZE;
@@ -510,8 +495,8 @@ static int get_remaining_mi_size(const MB_MODE_INFO *mbmi,
   } else {
     int mi_row_start_uv;
     int mi_col_start_uv;
-    get_chroma_start_location(mbmi, tree_type, &mi_row_start_uv,
-                              &mi_col_start_uv);
+    av2_get_chroma_start_location(mbmi, tree_type, &mi_row_start_uv,
+                                  &mi_col_start_uv);
     const int mi_pu_start_y = vert_edge ? mi_row_start_uv : mi_col_start_uv;
     const int scale = vert_edge ? ss_y : ss_x;
     mi_pu_start = mi_pu_start_y >> scale;

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2925,19 +2925,13 @@ static AVM_INLINE bool is_same_block_for_tree(const MB_MODE_INFO *m1,
 static AVM_INLINE void prune_4way_partitions_with_neighbor_boundaries(
     PartitionSearchState *state, const AV2_COMMON *cm, const MACROBLOCKD *xd,
     int mi_row, int mi_col, BLOCK_SIZE bsize) {
-  const int mi_width = mi_size_wide[bsize];
+  // Check left neighbor for horizontal boundaries using mi array
   const int mi_height = mi_size_high[bsize];
-
   const int available_mi_height =
       AVMMIN(mi_height, cm->mi_params.mi_rows - mi_row);
-  const int available_mi_width =
-      AVMMIN(mi_width, cm->mi_params.mi_cols - mi_col);
-
-  bool left_horz_boundaries[MAX_MIB_SIZE] = { false };
-  bool top_vert_boundaries[MAX_MIB_SIZE] = { false };
-
-  // Check left neighbor for horizontal boundaries using mi array
-  if (xd->left_available && mi_height >= 8) {
+  if (xd->left_available && mi_height >= 8 &&
+      available_mi_height == mi_height) {
+    bool left_horz_boundaries[MAX_MIB_SIZE] = { false };
     for (int r = 1; r < available_mi_height; r++) {
       const MB_MODE_INFO *m1 = xd->mi[r * xd->mi_stride - 1];
       const MB_MODE_INFO *m2 = xd->mi[(r - 1) * xd->mi_stride - 1];
@@ -2945,21 +2939,7 @@ static AVM_INLINE void prune_4way_partitions_with_neighbor_boundaries(
         left_horz_boundaries[r] = true;
       }
     }
-  }
-
-  // Check top neighbor for vertical boundaries using mi array
-  if (xd->up_available && mi_width >= 8) {
-    for (int c = 1; c < available_mi_width; c++) {
-      const MB_MODE_INFO *m1 = xd->mi[-xd->mi_stride + c];
-      const MB_MODE_INFO *m2 = xd->mi[-xd->mi_stride + c - 1];
-      if (!is_same_block_for_tree(m1, m2, xd->tree_type)) {
-        top_vert_boundaries[c] = true;
-      }
-    }
-  }
-
-  // Prune 4-way Partitions.
-  if (xd->left_available && mi_height >= 8) {
+    // Prune HORZ 4A/4B partitions.
     if (!left_horz_boundaries[mi_height / 8] &&
         !left_horz_boundaries[3 * mi_height / 8] &&
         !left_horz_boundaries[7 * mi_height / 8]) {
@@ -2972,7 +2952,20 @@ static AVM_INLINE void prune_4way_partitions_with_neighbor_boundaries(
     }
   }
 
-  if (xd->up_available && mi_width >= 8) {
+  // Check top neighbor for vertical boundaries using mi array
+  const int mi_width = mi_size_wide[bsize];
+  const int available_mi_width =
+      AVMMIN(mi_width, cm->mi_params.mi_cols - mi_col);
+  if (xd->up_available && mi_width >= 8 && available_mi_width == mi_width) {
+    bool top_vert_boundaries[MAX_MIB_SIZE] = { false };
+    for (int c = 1; c < available_mi_width; c++) {
+      const MB_MODE_INFO *m1 = xd->mi[-xd->mi_stride + c];
+      const MB_MODE_INFO *m2 = xd->mi[-xd->mi_stride + c - 1];
+      if (!is_same_block_for_tree(m1, m2, xd->tree_type)) {
+        top_vert_boundaries[c] = true;
+      }
+    }
+    // Prune VERT 4A/4B partitions.
     if (!top_vert_boundaries[mi_width / 8] &&
         !top_vert_boundaries[3 * mi_width / 8] &&
         !top_vert_boundaries[7 * mi_width / 8]) {

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2900,6 +2900,83 @@ static AVM_INLINE void init_allowed_partitions(
 #endif  // CONFIG_COLLECT_PARTITION_STATS
 }
 
+static AVM_INLINE bool is_same_block_for_tree(const MB_MODE_INFO *m1,
+                                              const MB_MODE_INFO *m2,
+                                              TREE_TYPE tree_type) {
+  if (!m1 || !m2) return false;
+
+  if (tree_type == CHROMA_PART) {
+    int m1_r;
+    int m1_c;
+    av2_get_chroma_start_location(m1, m1->tree_type, &m1_r, &m1_c);
+    int m2_r;
+    int m2_c;
+    av2_get_chroma_start_location(m2, m2->tree_type, &m2_r, &m2_c);
+    return m1_r == m2_r && m1_c == m2_c;
+  } else {
+    return m1->mi_row_start == m2->mi_row_start &&
+           m1->mi_col_start == m2->mi_col_start;
+  }
+}
+
+static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
+    PartitionSearchState *state, const AV2_COMMON *cm, const MACROBLOCKD *xd,
+    int mi_row, int mi_col, BLOCK_SIZE bsize) {
+  const int mi_width = mi_size_wide[bsize];
+  const int mi_height = mi_size_high[bsize];
+
+  const int available_mi_height =
+      AVMMIN(mi_height, cm->mi_params.mi_rows - mi_row);
+  const int available_mi_width =
+      AVMMIN(mi_width, cm->mi_params.mi_cols - mi_col);
+
+  bool left_horz_boundaries[MAX_MIB_SIZE] = { false };
+  bool top_vert_boundaries[MAX_MIB_SIZE] = { false };
+
+  // Check left neighbor for horizontal boundaries using mi array
+  if (xd->left_available && xd->mi_col > 0) {
+    for (int r = 1; r < available_mi_height; r++) {
+      const MB_MODE_INFO *m1 = xd->mi[r * xd->mi_stride - 1];
+      const MB_MODE_INFO *m2 = xd->mi[(r - 1) * xd->mi_stride - 1];
+      if (!is_same_block_for_tree(m1, m2, xd->tree_type)) {
+        left_horz_boundaries[r] = true;
+      }
+    }
+  }
+
+  // Check top neighbor for vertical boundaries using mi array
+  if (xd->up_available && xd->mi_row > 0) {
+    for (int c = 1; c < available_mi_width; c++) {
+      const MB_MODE_INFO *m1 = xd->mi[-xd->mi_stride + c];
+      const MB_MODE_INFO *m2 = xd->mi[-xd->mi_stride + c - 1];
+      if (!is_same_block_for_tree(m1, m2, xd->tree_type)) {
+        top_vert_boundaries[c] = true;
+      }
+    }
+  }
+
+  // Prune 4-way Partitions.
+  if (xd->left_available && xd->mi_col > 0) {
+    if (mi_height >= 8 && (!left_horz_boundaries[mi_height / 8] &&
+                           !left_horz_boundaries[3 * mi_height / 8] &&
+                           !left_horz_boundaries[5 * mi_height / 8] &&
+                           !left_horz_boundaries[7 * mi_height / 8])) {
+      state->prune_partition[PARTITION_HORZ_4A] = true;
+      state->prune_partition[PARTITION_HORZ_4B] = true;
+    }
+  }
+
+  if (xd->up_available && xd->mi_row > 0) {
+    if (mi_width >= 8 && (!top_vert_boundaries[mi_width / 8] &&
+                          !top_vert_boundaries[3 * mi_width / 8] &&
+                          !top_vert_boundaries[5 * mi_width / 8] &&
+                          !top_vert_boundaries[7 * mi_width / 8])) {
+      state->prune_partition[PARTITION_VERT_4A] = true;
+      state->prune_partition[PARTITION_VERT_4B] = true;
+    }
+  }
+}
+
 // Initialize state variables of partition search used in
 // av2_rd_pick_partition().
 static void init_partition_search_state_params(
@@ -5345,6 +5422,12 @@ bool av2_rd_pick_partition(
   // Set buffers and offsets.
   av2_set_offsets(cpi, tile_info, x, mi_row, mi_col, bsize,
                   &pc_tree->chroma_ref_info);
+
+  if (cpi->sf.part_sf.prune_part_with_neighbor_boundaries &&
+      !x->must_find_valid_partition && !frame_is_intra_only(cm)) {
+    prune_partitions_with_neighbor_boundaries(&part_search_state, cm, xd,
+                                              mi_row, mi_col, bsize);
+  }
 
   // Save rdmult before it might be changed, so it can be restored later.
   const int orig_rdmult = x->rdmult;

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2957,22 +2957,32 @@ static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
 
   // Prune 4-way Partitions.
   if (xd->left_available) {
-    if (mi_height >= 8 && (!left_horz_boundaries[mi_height / 8] &&
-                           !left_horz_boundaries[3 * mi_height / 8] &&
-                           !left_horz_boundaries[5 * mi_height / 8] &&
-                           !left_horz_boundaries[7 * mi_height / 8])) {
-      state->prune_partition[PARTITION_HORZ_4A] = true;
-      state->prune_partition[PARTITION_HORZ_4B] = true;
+    if (mi_height >= 8) {
+      if (!left_horz_boundaries[mi_height / 8] &&
+          !left_horz_boundaries[3 * mi_height / 8] &&
+          !left_horz_boundaries[7 * mi_height / 8]) {
+        state->prune_partition[PARTITION_HORZ_4A] = true;
+      }
+      if (!left_horz_boundaries[mi_height / 8] &&
+          !left_horz_boundaries[5 * mi_height / 8] &&
+          !left_horz_boundaries[7 * mi_height / 8]) {
+        state->prune_partition[PARTITION_HORZ_4B] = true;
+      }
     }
   }
 
   if (xd->up_available) {
-    if (mi_width >= 8 && (!top_vert_boundaries[mi_width / 8] &&
-                          !top_vert_boundaries[3 * mi_width / 8] &&
-                          !top_vert_boundaries[5 * mi_width / 8] &&
-                          !top_vert_boundaries[7 * mi_width / 8])) {
-      state->prune_partition[PARTITION_VERT_4A] = true;
-      state->prune_partition[PARTITION_VERT_4B] = true;
+    if (mi_width >= 8) {
+      if (!top_vert_boundaries[mi_width / 8] &&
+          !top_vert_boundaries[3 * mi_width / 8] &&
+          !top_vert_boundaries[7 * mi_width / 8]) {
+        state->prune_partition[PARTITION_VERT_4A] = true;
+      }
+      if (!top_vert_boundaries[mi_width / 8] &&
+          !top_vert_boundaries[5 * mi_width / 8] &&
+          !top_vert_boundaries[7 * mi_width / 8]) {
+        state->prune_partition[PARTITION_VERT_4B] = true;
+      }
     }
   }
 }

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2919,7 +2919,10 @@ static AVM_INLINE bool is_same_block_for_tree(const MB_MODE_INFO *m1,
   }
 }
 
-static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
+// Prunes uneven 4-way partitions by checking partition boundary alignment with
+// neighboring top/left blocks. Neighbor boundaries are detected by checking if
+// neighboring top/left MI units share the same block ID.
+static AVM_INLINE void prune_4way_partitions_with_neighbor_boundaries(
     PartitionSearchState *state, const AV2_COMMON *cm, const MACROBLOCKD *xd,
     int mi_row, int mi_col, BLOCK_SIZE bsize) {
   const int mi_width = mi_size_wide[bsize];
@@ -2934,7 +2937,7 @@ static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
   bool top_vert_boundaries[MAX_MIB_SIZE] = { false };
 
   // Check left neighbor for horizontal boundaries using mi array
-  if (xd->left_available) {
+  if (xd->left_available && mi_height >= 8) {
     for (int r = 1; r < available_mi_height; r++) {
       const MB_MODE_INFO *m1 = xd->mi[r * xd->mi_stride - 1];
       const MB_MODE_INFO *m2 = xd->mi[(r - 1) * xd->mi_stride - 1];
@@ -2945,7 +2948,7 @@ static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
   }
 
   // Check top neighbor for vertical boundaries using mi array
-  if (xd->up_available) {
+  if (xd->up_available && mi_width >= 8) {
     for (int c = 1; c < available_mi_width; c++) {
       const MB_MODE_INFO *m1 = xd->mi[-xd->mi_stride + c];
       const MB_MODE_INFO *m2 = xd->mi[-xd->mi_stride + c - 1];
@@ -2956,33 +2959,29 @@ static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
   }
 
   // Prune 4-way Partitions.
-  if (xd->left_available) {
-    if (mi_height >= 8) {
-      if (!left_horz_boundaries[mi_height / 8] &&
-          !left_horz_boundaries[3 * mi_height / 8] &&
-          !left_horz_boundaries[7 * mi_height / 8]) {
-        state->prune_partition[PARTITION_HORZ_4A] = true;
-      }
-      if (!left_horz_boundaries[mi_height / 8] &&
-          !left_horz_boundaries[5 * mi_height / 8] &&
-          !left_horz_boundaries[7 * mi_height / 8]) {
-        state->prune_partition[PARTITION_HORZ_4B] = true;
-      }
+  if (xd->left_available && mi_height >= 8) {
+    if (!left_horz_boundaries[mi_height / 8] &&
+        !left_horz_boundaries[3 * mi_height / 8] &&
+        !left_horz_boundaries[7 * mi_height / 8]) {
+      state->prune_partition[PARTITION_HORZ_4A] = true;
+    }
+    if (!left_horz_boundaries[mi_height / 8] &&
+        !left_horz_boundaries[5 * mi_height / 8] &&
+        !left_horz_boundaries[7 * mi_height / 8]) {
+      state->prune_partition[PARTITION_HORZ_4B] = true;
     }
   }
 
-  if (xd->up_available) {
-    if (mi_width >= 8) {
-      if (!top_vert_boundaries[mi_width / 8] &&
-          !top_vert_boundaries[3 * mi_width / 8] &&
-          !top_vert_boundaries[7 * mi_width / 8]) {
-        state->prune_partition[PARTITION_VERT_4A] = true;
-      }
-      if (!top_vert_boundaries[mi_width / 8] &&
-          !top_vert_boundaries[5 * mi_width / 8] &&
-          !top_vert_boundaries[7 * mi_width / 8]) {
-        state->prune_partition[PARTITION_VERT_4B] = true;
-      }
+  if (xd->up_available && mi_width >= 8) {
+    if (!top_vert_boundaries[mi_width / 8] &&
+        !top_vert_boundaries[3 * mi_width / 8] &&
+        !top_vert_boundaries[7 * mi_width / 8]) {
+      state->prune_partition[PARTITION_VERT_4A] = true;
+    }
+    if (!top_vert_boundaries[mi_width / 8] &&
+        !top_vert_boundaries[5 * mi_width / 8] &&
+        !top_vert_boundaries[7 * mi_width / 8]) {
+      state->prune_partition[PARTITION_VERT_4B] = true;
     }
   }
 }
@@ -5435,8 +5434,8 @@ bool av2_rd_pick_partition(
 
   if (cpi->sf.part_sf.prune_part_with_neighbor_boundaries &&
       !x->must_find_valid_partition && !frame_is_intra_only(cm)) {
-    prune_partitions_with_neighbor_boundaries(&part_search_state, cm, xd,
-                                              mi_row, mi_col, bsize);
+    prune_4way_partitions_with_neighbor_boundaries(&part_search_state, cm, xd,
+                                                   mi_row, mi_col, bsize);
   }
 
   // Save rdmult before it might be changed, so it can be restored later.

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2908,10 +2908,14 @@ static AVM_INLINE bool is_same_block_for_tree(const MB_MODE_INFO *m1,
   if (tree_type == CHROMA_PART) {
     int m1_r;
     int m1_c;
-    av2_get_chroma_start_location(m1, m1->tree_type, &m1_r, &m1_c);
+    av2_get_chroma_start_location(
+        m1, m1->tree_type == SHARED_PART ? SHARED_PART : CHROMA_PART, &m1_r,
+        &m1_c);
     int m2_r;
     int m2_c;
-    av2_get_chroma_start_location(m2, m2->tree_type, &m2_r, &m2_c);
+    av2_get_chroma_start_location(
+        m2, m2->tree_type == SHARED_PART ? SHARED_PART : CHROMA_PART, &m2_r,
+        &m2_c);
     return m1_r == m2_r && m1_c == m2_c;
   } else {
     return m1->mi_row_start == m2->mi_row_start &&

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2942,12 +2942,9 @@ static AVM_INLINE void prune_4way_partitions_with_neighbor_boundaries(
     // Prune HORZ 4A/4B partitions.
     if (!left_horz_boundaries[mi_height / 8] &&
         !left_horz_boundaries[3 * mi_height / 8] &&
-        !left_horz_boundaries[7 * mi_height / 8]) {
-      state->prune_partition[PARTITION_HORZ_4A] = true;
-    }
-    if (!left_horz_boundaries[mi_height / 8] &&
         !left_horz_boundaries[5 * mi_height / 8] &&
         !left_horz_boundaries[7 * mi_height / 8]) {
+      state->prune_partition[PARTITION_HORZ_4A] = true;
       state->prune_partition[PARTITION_HORZ_4B] = true;
     }
   }
@@ -2968,12 +2965,9 @@ static AVM_INLINE void prune_4way_partitions_with_neighbor_boundaries(
     // Prune VERT 4A/4B partitions.
     if (!top_vert_boundaries[mi_width / 8] &&
         !top_vert_boundaries[3 * mi_width / 8] &&
-        !top_vert_boundaries[7 * mi_width / 8]) {
-      state->prune_partition[PARTITION_VERT_4A] = true;
-    }
-    if (!top_vert_boundaries[mi_width / 8] &&
         !top_vert_boundaries[5 * mi_width / 8] &&
         !top_vert_boundaries[7 * mi_width / 8]) {
+      state->prune_partition[PARTITION_VERT_4A] = true;
       state->prune_partition[PARTITION_VERT_4B] = true;
     }
   }

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2934,7 +2934,7 @@ static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
   bool top_vert_boundaries[MAX_MIB_SIZE] = { false };
 
   // Check left neighbor for horizontal boundaries using mi array
-  if (xd->left_available && xd->mi_col > 0) {
+  if (xd->left_available) {
     for (int r = 1; r < available_mi_height; r++) {
       const MB_MODE_INFO *m1 = xd->mi[r * xd->mi_stride - 1];
       const MB_MODE_INFO *m2 = xd->mi[(r - 1) * xd->mi_stride - 1];
@@ -2945,7 +2945,7 @@ static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
   }
 
   // Check top neighbor for vertical boundaries using mi array
-  if (xd->up_available && xd->mi_row > 0) {
+  if (xd->up_available) {
     for (int c = 1; c < available_mi_width; c++) {
       const MB_MODE_INFO *m1 = xd->mi[-xd->mi_stride + c];
       const MB_MODE_INFO *m2 = xd->mi[-xd->mi_stride + c - 1];
@@ -2956,7 +2956,7 @@ static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
   }
 
   // Prune 4-way Partitions.
-  if (xd->left_available && xd->mi_col > 0) {
+  if (xd->left_available) {
     if (mi_height >= 8 && (!left_horz_boundaries[mi_height / 8] &&
                            !left_horz_boundaries[3 * mi_height / 8] &&
                            !left_horz_boundaries[5 * mi_height / 8] &&
@@ -2966,7 +2966,7 @@ static AVM_INLINE void prune_partitions_with_neighbor_boundaries(
     }
   }
 
-  if (xd->up_available && xd->mi_row > 0) {
+  if (xd->up_available) {
     if (mi_width >= 8 && (!top_vert_boundaries[mi_width / 8] &&
                           !top_vert_boundaries[3 * mi_width / 8] &&
                           !top_vert_boundaries[5 * mi_width / 8] &&

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -752,6 +752,7 @@ static AVM_INLINE void init_part_sf(PARTITION_SPEED_FEATURES *part_sf) {
   part_sf->prune_rect_with_split_depth = 0;
   part_sf->prune_part_h_with_partition_boundary = 0;
   part_sf->inter_sdp_fast_method_level = 0;
+  part_sf->prune_part_with_neighbor_boundaries = 0;
 #if CONFIG_ML_PART_SPLIT
   part_sf->prune_split_with_ml = 0;
   part_sf->prune_none_with_ml = 0;
@@ -1085,6 +1086,7 @@ static AVM_INLINE void set_erp_speed_features(AV2_COMP *cpi) {
       sf->part_sf.ext_recur_depth_level = 2;
       sf->part_sf.simple_motion_search_split = 1;
       sf->part_sf.simple_motion_search_early_term_none = 1;
+      sf->part_sf.prune_part_with_neighbor_boundaries = true;
       AVM_FALLTHROUGH_INTENDED;
     case 5:
       sf->part_sf.prune_part_h_with_partition_boundary = true;
@@ -1124,6 +1126,7 @@ static AVM_INLINE void set_erp_speed_features(AV2_COMP *cpi) {
     // Emulate erp_pruning_level = 6.
     sf->part_sf.ext_recur_depth_level = 1;
     sf->part_sf.ml_early_term_after_part_split_level = 2;
+    sf->part_sf.prune_part_with_neighbor_boundaries = true;
   }
 
   if (cpi->speed >= 2) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -986,6 +986,7 @@ static AVM_INLINE void set_erp_speed_features_framesize_dependent(
   const int is_1080p_or_larger = AVMMIN(cm->width, cm->height) >= 1080;
   const unsigned int erp_pruning_level = cpi->oxcf.part_cfg.erp_pruning_level;
   const int is_720p_or_lesser = AVMMIN(cm->width, cm->height) <= 720;
+  const int is_270p_or_lesser = AVMMIN(cm->width, cm->height) <= 270;
 
   switch (erp_pruning_level) {
     case 6: AVM_FALLTHROUGH_INTENDED;
@@ -1034,6 +1035,10 @@ static AVM_INLINE void set_erp_speed_features_framesize_dependent(
       sf->part_sf.remove_qp_restriction_with_ml = 1;
     }
 #endif  // CONFIG_ML_PART_SPLIT
+    if (is_270p_or_lesser) {
+      // For small resolutions, this speed feature has a large coding loss.
+      sf->part_sf.prune_part_with_neighbor_boundaries = 0;
+    }
   }
 
   if (cpi->speed >= 2) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -1086,7 +1086,7 @@ static AVM_INLINE void set_erp_speed_features(AV2_COMP *cpi) {
       sf->part_sf.ext_recur_depth_level = 2;
       sf->part_sf.simple_motion_search_split = 1;
       sf->part_sf.simple_motion_search_early_term_none = 1;
-      sf->part_sf.prune_part_with_neighbor_boundaries = true;
+      sf->part_sf.prune_part_with_neighbor_boundaries = 1;
       AVM_FALLTHROUGH_INTENDED;
     case 5:
       sf->part_sf.prune_part_h_with_partition_boundary = true;
@@ -1126,7 +1126,7 @@ static AVM_INLINE void set_erp_speed_features(AV2_COMP *cpi) {
     // Emulate erp_pruning_level = 6.
     sf->part_sf.ext_recur_depth_level = 1;
     sf->part_sf.ml_early_term_after_part_split_level = 2;
-    sf->part_sf.prune_part_with_neighbor_boundaries = true;
+    sf->part_sf.prune_part_with_neighbor_boundaries = 1;
   }
 
   if (cpi->speed >= 2) {

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -441,6 +441,8 @@ typedef struct PARTITION_SPEED_FEATURES {
   //    intra coded block, prunes when inter ratio exceeds 50%, and early skips
   //    when current best partitioning is PARTITION_NONE.
   int inter_sdp_fast_method_level;
+  // Prune partition types if they don't align with neighbor block boundaries.
+  bool prune_part_with_neighbor_boundaries;
 #if CONFIG_ML_PART_SPLIT
   int prune_split_with_ml;
   int prune_split_ml_level;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -442,7 +442,7 @@ typedef struct PARTITION_SPEED_FEATURES {
   //    when current best partitioning is PARTITION_NONE.
   int inter_sdp_fast_method_level;
   // Prune partition types if they don't align with neighbor block boundaries.
-  bool prune_part_with_neighbor_boundaries;
+  int prune_part_with_neighbor_boundaries;
 #if CONFIG_ML_PART_SPLIT
   int prune_split_with_ml;
   int prune_split_ml_level;


### PR DESCRIPTION
Use the best partitioning boundaries of left / above coding blocks to prune uneven 4way partitions -- by checking boundary alignment.

Only prune for inter frames.

- Enabled for speed >= 1.
- But disabled for resolution <= 270p.

Results for RA CTC 33 frames, speed 1:
(Anchor: 8d9588497)

```
+---------+--------+--------+--------+--------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time |
+---------+--------+--------+--------+--------+----------+
| A1      |  0.08% |  0.04% |  0.11% |  0.08% | 97.10%   |
| A2      |  0.07% | -0.07% |  0.16% |  0.07% | 96.50%   |
|avg wo b2|  0.07% |  0.09% |  0.06% |  0.07% | 96.75%   |
+---------+--------+--------+--------+--------+----------+
```

Note: no changes at speed 4, because uneven 4way partitions are disabled at this speed.

Related: refactor a common av2_get_chroma_start_location() function.

STATS_CHANGED for speed >= 1.