### PR TITLE
Extend perform_coeff_opt qindex threshold

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -1356,11 +1356,15 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
   }
 
   if (is_720p_or_larger && cpi->oxcf.mode == GOOD && speed <= 1) {
-    const int qindex_thresh = 124 + qindex_offset;
+    // At speed 1, extend the qindex band and use a boost-aware coeff-opt level
+    // (keeps full optimization on KF/ARF/GF references while pruning more on
+    // the non-reference leaves). Speed 0 keeps its original behavior.
+    const int qindex_thresh = (speed == 1 ? 200 : 124) + qindex_offset;
     const int qindex_thresh2 = 113 + qindex_offset;
 
     if (cm->quant_params.base_qindex <= qindex_thresh) {
-      sf->rd_sf.perform_coeff_opt = 2 + is_1080p_or_larger;
+      sf->rd_sf.perform_coeff_opt =
+          (speed == 1) ? (boosted ? 2 : 3) : (2 + is_1080p_or_larger);
       memcpy(winner_mode_params->coeff_opt_dist_threshold,
              coeff_opt_dist_thresholds[sf->rd_sf.perform_coeff_opt],
              sizeof(winner_mode_params->coeff_opt_dist_threshold));


### PR DESCRIPTION
Broaden the coefficient-optimization speed feature to cover more frames, using a reference-aware optimization level that stays conservative on reference frames.

Anchor: aa78cfb0
Test condition: CTC, RA, 33 frames, speed 1

RA:
```
+------------+-------+-------+-------+-------+------+
| Class      |     Y |    Cb |    Cr |  wAvg | Enc% |
+------------+-------+-------+-------+-------+------+
| A1         |  0.02 | -0.05 |  0.23 |  0.03 | 98.7 |
| A2         | -0.04 |  0.26 |  0.30 | -0.02 | 98.9 |
+------------+-------+-------+-------+-------+------+
| Avg w/o B2 |  0.02 |  0.09 |  0.11 |  0.02 | 98.9 |
+------------+-------+-------+-------+-------+------+
```
STATS_CHANGED