### PR TITLE
Extend prune_inter_tx_part_rd_eval qindex threshold

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -1404,7 +1404,12 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
       }
     }
 
-    if (cm->quant_params.base_qindex <= qindex_thresh &&
+    // For speed >= 1, raise the threshold for non-4K content so more frames
+    // use this pruning; 4K (A1-like, where extended TX partitions matter) and
+    // speed 0 keep the baseline threshold.
+    const int qindex_thresh_tx =
+        (speed >= 1 && !is_2160p_or_larger ? 170 : 135) + qindex_offset;
+    if (cm->quant_params.base_qindex <= qindex_thresh_tx &&
         !cm->features.allow_screen_content_tools) {
       sf->flexmv_sf.prune_mv_prec_using_best_mv_prec_so_far = boosted ? 0 : 1;
       if (!boosted) {


### PR DESCRIPTION
Broaden the transform-partition RD-evaluation pruning to cover more frames, keeping 4K content conservative where extended transform partitions matter most.

Anchor: aa78cfb0
Test condition: CTC, RA, 33 frames, speed 1

RA:
```
+------------+-------+-------+-------+-------+------+
| Class      |     Y |    Cb |    Cr |  wAvg | Enc% |
+------------+-------+-------+-------+-------+------+
| A1         |  0.00 |  0.00 |  0.00 |  0.00 |  100 |
| A2         |  0.02 |  0.10 |  0.24 |  0.03 | 98.4 |
+------------+-------+-------+-------+-------+------+
| Avg w/o B2 |  0.02 |  0.10 |  0.11 |  0.02 | 99.1 |
+------------+-------+-------+-------+-------+------+
```
STATS_CHANGED