### PR TITLE
Speed up warped-motion refinement at speed 4

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -593,6 +593,8 @@ static void set_good_speed_features_framesize_independent(
     sf->lpf_sf.cdef_pick_method = CDEF_FAST_SEARCH_LVL3;
 
     sf->mv_sf.reduce_search_range = 1;
+
+    sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
   }
 
   if (speed >= 5) {
@@ -606,7 +608,6 @@ static void set_good_speed_features_framesize_independent(
                                           : MULTI_WINNER_MODE_OFF;
 
     sf->mv_sf.prune_mesh_search = 1;
-    sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
 
     sf->tpl_sf.prune_starting_mv = 3;
     sf->lpf_sf.enable_deblock_for_partition_search = 0;


### PR DESCRIPTION
Use a lighter search pattern for warped-motion refinement at speed 4.

Anchor: 7837c409f
Test condition: CTC, RA, 33 frames, speed 4

RA:
```
+------------+-------+-------+-------+-------+------+
| Class      |     Y |    Cb |    Cr |  wAvg | Enc% |
+------------+-------+-------+-------+-------+------+
| A1         |  0.09 | -0.08 |  0.24 |  0.08 | 96.1 |
| A2         |  0.11 |  0.10 | -0.17 |  0.09 | 96.1 |
+------------+-------+-------+-------+-------+------+
| Avg w/o B2 |  0.07 |  0.17 |  0.17 |  0.08 | 96.5 |
+------------+-------+-------+-------+-------+------+
```
STATS_CHANGED