### PR TITLE
Enable DC-block prediction at speed 4 and 5

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -596,6 +596,7 @@ static void set_good_speed_features_framesize_independent(
     sf->mv_sf.reduce_search_range = 1;
 
     sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
+    sf->winner_mode_sf.dc_blk_pred_level = 2;
   }
 
   if (speed >= 5) {
@@ -631,7 +632,6 @@ static void set_good_speed_features_framesize_independent(
 
     sf->rd_sf.perform_coeff_opt = is_boosted_arf2_bwd_type ? 4 : 6;
 
-    sf->winner_mode_sf.dc_blk_pred_level = 2;
     sf->winner_mode_sf.multi_winner_mode_type = MULTI_WINNER_MODE_OFF;
   }
 


### PR DESCRIPTION
Enable the DC-only transform-block prediction at speed 4 and 5 to skip transform evaluation on flat blocks.

Anchor: 7837c409f
Test condition: CTC, RA, 33 frames, speed 4

RA:
```
+------------+-------+-------+-------+-------+------+
| Class      |     Y |    Cb |    Cr |  wAvg | Enc% |
+------------+-------+-------+-------+-------+------+
| A1         |  0.04 |  0.23 |  0.48 |  0.06 | 95.9 |
| A2         | -0.05 | -0.27 | -0.27 | -0.06 | 97.1 |
+------------+-------+-------+-------+-------+------+
| Avg w/o B2 | -0.01 | -0.11 |  0.44 |  0.01 | 96.5 |
+------------+-------+-------+-------+-------+------+
```
STATS_CHANGED