### PR TITLE
Prune evaluation of compound modes using estimated RD-Cost

### DIFF
--- a/av2/common/enums.h
+++ b/av2/common/enums.h
@@ -913,6 +913,7 @@ enum {
 #define TOP_INTRA_MODEL_COUNT 6
 #define TOP_TX_PART_COUNT 4
 #define TOP_INTER_TX_PART_COUNT 8
+#define TOP_COMP_EST_RD_COUNT 2
 // Total number of luma intra prediction modes (include both directional and
 // non-directional modes)
 #define LUMA_MODE_COUNT 61

--- a/av2/encoder/block.h
+++ b/av2/encoder/block.h
@@ -1669,6 +1669,10 @@ typedef struct macroblock {
    * evaluation. */
   int64_t top_tx_part_rd_inter[MAX_TX_BLOCKS_IN_MAX_SB]
                               [TOP_INTER_TX_PART_COUNT];
+  /*! \brief Keep records of top estimated rdcosts of compound type search,
+   * which are used for pruning compound modes in inter mode
+   * evaluation. */
+  int64_t top_comp_est_rd[TOP_COMP_EST_RD_COUNT];
 } MACROBLOCK;
 #undef SINGLE_REF_MODES
 

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -4361,6 +4361,46 @@ static int skip_repeated_newmv(
   return 0;
 }
 
+// Store the estimated RD cost for compound mode pruning.
+static INLINE void push_comp_est_rd(MACROBLOCK *x, const MB_MODE_INFO *mbmi,
+                                    int64_t tmp_rd,
+                                    bool prune_comp_mode_eval_using_est_rd) {
+  if (!prune_comp_mode_eval_using_est_rd) return;
+
+  // Do not store for skip modes.
+  if (mbmi->skip_mode != 0) return;
+  if (tmp_rd == INT64_MAX) return;
+
+  // Insert the RD Cost in sorted order.
+  for (int i = 0; i < TOP_COMP_EST_RD_COUNT; i++) {
+    if (tmp_rd < x->top_comp_est_rd[i]) {
+      for (int j = TOP_COMP_EST_RD_COUNT - 1; j > i; j--) {
+        x->top_comp_est_rd[j] = x->top_comp_est_rd[j - 1];
+      }
+      x->top_comp_est_rd[i] = tmp_rd;
+      break;
+    }
+  }
+}
+
+// Prune compound mode evaluation based on top estimated RD costs.
+static INLINE bool prune_comp_eval_using_est_rd(
+    MACROBLOCK *const x, MB_MODE_INFO *const mbmi, int64_t tmp_rd,
+    bool prune_comp_mode_eval_using_est_rd) {
+  if (!prune_comp_mode_eval_using_est_rd) return false;
+
+  // Do not prune for skip mode.
+  if (mbmi->skip_mode != 0) return false;
+  if (tmp_rd == INT64_MAX) return false;
+
+  // Do not prune if there is no valid top RD Cost for comparison.
+  if (x->top_comp_est_rd[TOP_COMP_EST_RD_COUNT - 1] == INT64_MAX) return false;
+
+  if (tmp_rd > x->top_comp_est_rd[TOP_COMP_EST_RD_COUNT - 1]) return true;
+
+  return false;
+}
+
 /*!\brief High level function to select parameters for compound mode.
  *
  * \ingroup inter_mode_search
@@ -4472,6 +4512,13 @@ static int process_compound_inter_mode(
     restore_dst_buf(xd, *orig_dst, num_planes);
     return 1;
   }
+
+  push_comp_est_rd(x, mbmi, best_rd_compound,
+                   cpi->sf.inter_sf.prune_comp_mode_eval_using_est_rd);
+  if (prune_comp_eval_using_est_rd(
+          x, mbmi, best_rd_compound,
+          cpi->sf.inter_sf.prune_comp_mode_eval_using_est_rd))
+    return 1;
 
   // Build only uv predictor for COMPOUND_AVERAGE.
   // Note there is no need to call av2_enc_build_inter_predictor
@@ -8511,6 +8558,16 @@ static INLINE void init_top_tx_part_rd_for_inter_modes(
   }
 }
 
+// Initialize the table that stores top estimated RD Costs of compound mode.
+static INLINE void init_top_comp_est_rd(
+    MACROBLOCK *const x, bool prune_comp_mode_eval_using_est_rd) {
+  if (!prune_comp_mode_eval_using_est_rd) return;
+
+  for (int j = 0; j < TOP_COMP_EST_RD_COUNT; j++) {
+    x->top_comp_est_rd[j] = INT64_MAX;
+  }
+}
+
 // Evaluate intra prediction modes in an inter frame at the block level
 static void av2_evaluate_intra_modes_in_inter_frame(
     const struct AV2_COMP *cpi, MACROBLOCK *x, BLOCK_SIZE bsize,
@@ -9117,6 +9174,8 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
   }
 
   init_top_tx_part_rd_for_inter_modes(x, sf->tx_sf.prune_inter_tx_part_rd_eval);
+
+  init_top_comp_est_rd(x, sf->inter_sf.prune_comp_mode_eval_using_est_rd);
 
   // Initialize arguments for mode loop speed features
   InterModeSFArgs sf_args = { &args.skip_motion_mode,

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -350,6 +350,7 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.prune_interintra_by_ref_idx = 1;
     sf->inter_sf.prune_warp_delta_by_ref_idx = 1;
     sf->intra_sf.intra_pruning_with_mlp = 1;
+    sf->inter_sf.prune_comp_mode_eval_using_est_rd = true;
 
     sf->intra_sf.include_dip_for_top_n_model_rd_pruning = true;
 
@@ -835,6 +836,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->prune_warpmv_prob_thresh = 32;
   inter_sf->prune_amvd_newmv = 0;
   inter_sf->enable_enhanced_inter_mode_cache_reuse = 0;
+  inter_sf->prune_comp_mode_eval_using_est_rd = false;
 }
 
 static AVM_INLINE void init_interp_sf(INTERP_FILTER_SPEED_FEATURES *interp_sf) {

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -783,6 +783,10 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // current best mode is not the same mode as the one being evaluated, because
   // AMVD on top of these modes is unlikely to win over the non-AMVD best mode.
   int prune_amvd_newmv;
+
+  // Prune further evaluation of compound mode using estimated RD Cost of best
+  // compound type chosen.
+  bool prune_comp_mode_eval_using_est_rd;
 } INTER_MODE_SPEED_FEATURES;
 
 typedef struct INTERP_FILTER_SPEED_FEATURES {


### PR DESCRIPTION
In av2_compound_type_rd(), the best compound type is chosen using RD-Cost with NONE transform partition type and DCT_DCT transform type. This estimated RD-Cost is used to keep track of best N, N=2, compound modes, on-the-fly. A speed feature is introduced to prune the further evaluation of other compound modes that have estimated RD Cost worse than these best N modes.

The speed feature is disabled for speed=0 and enabled for speed >= 1.

STATS_CHANGED for speed >= 1

Test results (RA) for Speed 1
Anchor: commit 69bd08f
A1 - 17 frames
A2 - 33 frames

EncInstRed% and DecInstRed% are average percentage instruction
count reduction seen for encoder and decoder with this change.

```
+------------+-------+-------+-------+-------+-----------+-----------+
| Class      |     Y |    Cb |    Cr |  wAvg |EncInstRed%|DecInstRed%|
+------------+-------+-------+-------+-------+-----------+-----------+
| A1         |  0.02 | -0.14 |  0.00 |  0.01 |   2.911   |   0.385   |
| A2         |  0.02 | -0.09 |  0.34 |  0.03 |   3.063   |   0.562   |
+------------+-------+-------+-------+-------+-----------+-----------+
```