### PR TITLE
Bugfix for deblocking filter in partition search: fix distortion scaling

### DIFF
--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -3555,6 +3555,16 @@ static int64_t get_dist_offset_by_deblock(
         mi_row * MI_SIZE >> sub_y, bh >> sub_y);
   }
 
+  const int bit_depth = cm->seq_params.bit_depth;
+  int dist_normal;  // dist is normalized to 16 * 8_bit_content_distortion
+  if (bit_depth <= 10) {
+    dist_normal = 1 << ((10 - cm->seq_params.bit_depth) * 2);
+    rec_dist = rec_dist * dist_normal;
+  } else {
+    dist_normal = 1 << ((cm->seq_params.bit_depth - 10) * 2);
+    rec_dist = rec_dist / dist_normal;
+  }
+
   if (llabs(this_rdc->dist - rec_dist) < this_rdc->dist / 50) {
     int h_start = mi_col * MI_SIZE;
     int v_start = mi_row * MI_SIZE;
@@ -3595,13 +3605,9 @@ static int64_t get_dist_offset_by_deblock(
     const int64_t filtered_y_dist = avm_highbd_get_y_sse_part(
         src, filtered, h_start, area_w, v_start, area_h);
 
-    const int bit_depth = cm->seq_params.bit_depth;
-    int dist_normal;  // dist is normalized to 16 * 8_bit_content_distortion
     if (bit_depth <= 10) {
-      dist_normal = 1 << ((10 - cm->seq_params.bit_depth) * 2);
       return dist_normal * (filtered_y_dist - unfiltered_y_dist);
     } else {
-      dist_normal = 1 << ((cm->seq_params.bit_depth - 10) * 2);
       return (filtered_y_dist - unfiltered_y_dist) / dist_normal;
     }
   } else {


### PR DESCRIPTION
Due to this bug, for sequences with coded bitdepth = 8, the scale of `this_rdc->dist`  was 16x compared to that of `rec_dist`.   Hence, the condition `llabs(this_rdc->dist - rec_dist) < this_rdc->dist / 50` could never be true and so deblocking filter was never activated for this case.

Note:
- Coded bitdepth = 10 was already working correctly -- so no change in output for these cases.
- Coded bitdepth = 12 had this issue as well theoretically, but this is unused in CTC currently.

Results for RA CTC 33 frames at speed 1:
(only affects testsets A3 and A5 that are coded with bitdepth = 8)

```
+------------+--------+--------+---------0--------+--------------+
| Testset | YUV | VMAF | VMAF-NEG | Enc-time |
+------------+--------+--------+---------0--------+--------------+
| A3 | -0.11% | -0.32% | -0.12%  | 99.45% |
| A5 | -0.11% | -0.46% | -0.42%  | 99.76% |
|avg| -0.02% | -0.08% | -0.05%  | 99.41% |
+---------+--------+--------+--------+--------+----------+
```

STATS_CHANGED for speed >= 1