### PR TITLE
Add tools-off options for low complexity decoding

### DIFF
--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -1159,25 +1159,6 @@ static void set_max_bvp_drl_bits(struct AV2_COMP *cpi) {
          cm->features.max_bvp_drl_bits <= MAX_MAX_IBC_DRL_BITS);
 }
 
-static void set_seq_lr_tools_mask(SequenceHeader *const seq_params,
-                                  const AV2EncoderConfig *oxcf) {
-  const ToolCfg *const tool_cfg = &oxcf->tool_cfg;
-  seq_params->lr_tools_disable_mask[0] = 0;  // default - no tools disabled
-  seq_params->lr_tools_disable_mask[1] = 0;  // default - no tools disabled
-
-  // Parse oxcf here to disable tools as requested through cmd lines
-  if (!tool_cfg->enable_pc_wiener) {
-    seq_params->lr_tools_disable_mask[0] |= (1 << RESTORE_PC_WIENER);
-    seq_params->lr_tools_disable_mask[1] |= (1 << RESTORE_PC_WIENER);
-  }
-  if (!tool_cfg->enable_wiener_nonsep) {
-    seq_params->lr_tools_disable_mask[0] |= (1 << RESTORE_WIENER_NONSEP);
-    seq_params->lr_tools_disable_mask[1] |= (1 << RESTORE_WIENER_NONSEP);
-  }
-
-  seq_params->lr_tools_disable_mask[1] |= DEF_UV_LR_TOOLS_DISABLE_MASK;
-}
-
 void av2_change_config(struct AV2_COMP *cpi, const AV2EncoderConfig *oxcf) {
   AV2_COMMON *const cm = &cpi->common;
   SequenceHeader *const seq_params = &cm->seq_params;
@@ -1453,7 +1434,6 @@ void av2_change_config(struct AV2_COMP *cpi, const AV2EncoderConfig *oxcf) {
   // This should not be called after the first key frame.
   if (!cpi->seq_params_locked) {
     av2_init_seq_coding_tools(cpi, &cm->seq_params, cm, oxcf);
-    if (seq_params->enable_restoration) set_seq_lr_tools_mask(seq_params, oxcf);
   }
 
   // restore the value of lag_in_frame for LAP stage.

--- a/av2/encoder/encoder.h
+++ b/av2/encoder/encoder.h
@@ -3616,6 +3616,25 @@ static INLINE bool av2_is_shown_keyframe(const AV2_COMP *cpi,
   return (frame_type == KEY_FRAME) && !cpi->no_show_fwd_kf;
 }
 
+static INLINE void av2_set_seq_lr_tools_mask(SequenceHeader *const seq_params,
+                                             const AV2EncoderConfig *oxcf) {
+  const ToolCfg *const tool_cfg = &oxcf->tool_cfg;
+  seq_params->lr_tools_disable_mask[0] = 0;  // default - no tools disabled
+  seq_params->lr_tools_disable_mask[1] = 0;  // default - no tools disabled
+
+  // Parse oxcf here to disable tools as requested through cmd lines
+  if (!tool_cfg->enable_pc_wiener) {
+    seq_params->lr_tools_disable_mask[0] |= (1 << RESTORE_PC_WIENER);
+    seq_params->lr_tools_disable_mask[1] |= (1 << RESTORE_PC_WIENER);
+  }
+  if (!tool_cfg->enable_wiener_nonsep) {
+    seq_params->lr_tools_disable_mask[0] |= (1 << RESTORE_WIENER_NONSEP);
+    seq_params->lr_tools_disable_mask[1] |= (1 << RESTORE_WIENER_NONSEP);
+  }
+
+  seq_params->lr_tools_disable_mask[1] |= DEF_UV_LR_TOOLS_DISABLE_MASK;
+}
+
 /*!\endcond */
 
 #ifdef __cplusplus

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -648,6 +648,17 @@ static void set_good_speed_features_framesize_independent(
   }
 }
 
+// Define frame size independent speed features for low complexity decoding
+// mode.
+static void set_good_speed_features_lc_dec_framesize_independent(
+    AV2_COMP *cpi) {
+  cpi->oxcf.tool_cfg.enable_mv_traj = 0;
+  cpi->oxcf.tool_cfg.enable_gdf = 0;
+  cpi->oxcf.tool_cfg.enable_pc_wiener = 0;
+  cpi->oxcf.tool_cfg.enable_tip_refinemv = 0;
+  cpi->oxcf.tool_cfg.reduced_ref_frame_mvs_mode = 1;
+}
+
 static void set_rt_speed_features_framesize_independent(
     const AV2_COMP *const cpi, SPEED_FEATURES *const sf, int speed) {
   // Set this good features as default for now.
@@ -1160,6 +1171,21 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
     set_rt_speed_features_framesize_independent(cpi, sf, speed);
   }
 
+  if (oxcf->mode == GOOD && cpi->oxcf.enable_low_complexity_decode) {
+    // TODO (yunqingwang): LC speed features are added below.
+    set_good_speed_features_lc_dec_framesize_independent(cpi);
+
+    // Adjust sequence flags for LC decode mode.
+    if (!cpi->seq_params_locked) {
+      cpi->common.seq_params.enable_mv_traj = cpi->oxcf.tool_cfg.enable_mv_traj;
+      cpi->common.seq_params.enable_gdf = cpi->oxcf.tool_cfg.enable_gdf;
+      cpi->common.seq_params.enable_tip_refinemv =
+          cpi->oxcf.tool_cfg.enable_tip_refinemv;
+      cpi->common.seq_params.order_hint_info.reduced_ref_frame_mvs_mode =
+          cpi->oxcf.tool_cfg.reduced_ref_frame_mvs_mode;
+    }
+  }
+
   if (!cpi->seq_params_locked) {
     cpi->common.seq_params.enable_restoration &= !sf->lpf_sf.disable_lr_filter;
 
@@ -1179,6 +1205,9 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
       cpi->common.seq_params.enable_tcq = TCQ_DISABLE;
       cpi->common.features.tcq_mode = TCQ_DISABLE;
     }
+
+    if (cpi->common.seq_params.enable_restoration)
+      av2_set_seq_lr_tools_mask(&cpi->common.seq_params, oxcf);
   }
 
   // sf->part_sf.partition_search_breakout_dist_thr is set assuming max 64x64


### PR DESCRIPTION
Several tools are disabled that give good coding efficiency vs decoder time tradeoff, and the corresponding
sequence flags are reset.

Baseline: 82dbc4b3668f0c5b42c755c8b1f1a10ca82ed067
Test condition: CTC, RA, 65 frames, speed 1

```
   | PSNR-YUV | Enc-time (%) | Dec-time (%)
-- | -------- | ------------ | ----------
A1 | 2.00%    | 97%          | 57%
A2 | 1.62%    | 98%          | 61%
A3 | 2.01%    | 100%         | 60%
```

With "enable_low_complexity_decode = 1", SW decoder complexity (vs AV1 decoder) reduces from 4x
to 2.3x.

STATS_CHANGED for enable_low_complexity_decode = 1