### PR TITLE
Reduce NEWMV DRL search limit at speed >= 4

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -595,6 +595,7 @@ static void set_good_speed_features_framesize_independent(
     sf->mv_sf.reduce_search_range = 1;
 
     sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
+    sf->mv_sf.newmv_drl_search_limit = 1;
   }
 
   if (speed >= 5) {


### PR DESCRIPTION
Lower newmv_drl_search_limit from 2 to 1 for speed >= 4.

Anchor: 7837c409f
Test condition: CTC, RA, 33 frames, speed 4

RA:
```
+------------+-------+-------+-------+-------+------+
| Class      |     Y |    Cb |    Cr |  wAvg | Enc% |
+------------+-------+-------+-------+-------+------+
| A1         |  0.07 |  0.18 | -0.04 |  0.06 | 98.2 |
| A2         |  0.04 | -0.02 |  0.10 |  0.04 | 98.3 |
+------------+-------+-------+-------+-------+------+
| Avg w/o B2 |  0.00 |  0.20 |  0.13 |  0.02 | 98.3 |
+------------+-------+-------+-------+-------+------+
```
STATS_CHANGED