### PR TITLE
Disable deblocking in partition search for speed >= 3

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -469,6 +469,8 @@ static void set_good_speed_features_framesize_independent(
     sf->rd_sf.disable_tcq = 1;
     // --- End ---
 
+    sf->lpf_sf.enable_deblock_for_partition_search = 0;
+
     sf->hl_sf.high_precision_mv_usage = CURRENT_Q;
     sf->hl_sf.recode_loop = ALLOW_RECODE_KFARFGF;
 
@@ -613,7 +615,6 @@ static void set_good_speed_features_framesize_independent(
     sf->mv_sf.prune_mesh_search = 1;
 
     sf->tpl_sf.prune_starting_mv = 3;
-    sf->lpf_sf.enable_deblock_for_partition_search = 0;
   }
 
   if (speed >= 6) {


### PR DESCRIPTION
The in-partition-search deblock filter improves RD at speed 1-2 but degrades it at speed 3-4, so disable it for speed >= 3 (speed 5-6 were already disabled).

Anchor: 7837c409f
Test condition: CTC, RA, 33 frames

Effect of disabling, by speed (wAvg BD-rate):
```
+-------+-------+-------+-------+------+
| Speed |    A1 |    A2 |  wAvg | Enc% |
+-------+-------+-------+-------+------+
|     1 |  0.54 |  0.38 |  0.28 | 98.9 |
|     2 |  0.36 |  0.35 |  0.23 | 98.9 |
|     3 |  0.00 | -0.07 | -0.08 | 99.6 |
|     4 | -0.05 | -0.19 | -0.21 |100.6 |
+-------+-------+-------+-------+------+
```
STATS_CHANGED