### PR TITLE
Extend ref_mv_idx search pruning to speed 1-5

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -231,6 +231,10 @@ static void set_good_speed_feature_framesize_dependent(
     }
   }
 
+  if (speed >= 1) {
+    sf->inter_sf.prune_ref_mv_idx_search = 1;
+  }
+
   if (speed >= 6) {
     if (is_720p_or_larger) {
       sf->part_sf.auto_max_partition_based_on_simple_motion = NOT_IN_USE;


### PR DESCRIPTION
Enable the DRL ref_mv_idx search pruning for speeds 1-5.

Anchor: 7837c409f
Test condition: CTC, RA, 33 frames

RA, speed 4:
```
+------------+-------+-------+-------+-------+------+
| Class      |     Y |    Cb |    Cr |  wAvg | Enc% |
+------------+-------+-------+-------+-------+------+
| A1         |  0.08 |  0.06 |  0.15 |  0.09 | 97.8 |
| A2         |  0.10 |  0.15 |  0.06 |  0.09 | 97.3 |
+------------+-------+-------+-------+-------+------+
| Avg w/o B2 |  0.09 |  0.15 |  0.26 |  0.10 | 97.3 |
+------------+-------+-------+-------+-------+------+
```

RA, speed 1:
```
+------------+-------+-------+-------+-------+------+
| Class      |     Y |    Cb |    Cr |  wAvg | Enc% |
+------------+-------+-------+-------+-------+------+
| A1         |  0.06 |  0.22 | -0.01 |  0.07 | 97.3 |
| A2         |  0.07 |  0.26 |  0.08 |  0.08 | 96.7 |
+------------+-------+-------+-------+-------+------+
| Avg w/o B2 |  0.05 |  0.19 |  0.10 |  0.06 | 96.6 |
+------------+-------+-------+-------+-------+------+
```
STATS_CHANGED