### PR TITLE
Revert "Optimize AV2 encoder by removing redundant memset calls (#5194)"

### DIFF
--- a/av2/encoder/av2_quantize.c
+++ b/av2/encoder/av2_quantize.c
@@ -28,7 +28,12 @@
 #include "av2/encoder/encoder.h"
 #include "av2/encoder/rd.h"
 
-void av2_quantize_skip(uint16_t *eob_ptr) { *eob_ptr = 0; }
+void av2_quantize_skip(intptr_t n_coeffs, tran_low_t *qcoeff_ptr,
+                       tran_low_t *dqcoeff_ptr, uint16_t *eob_ptr) {
+  memset(qcoeff_ptr, 0, n_coeffs * sizeof(*qcoeff_ptr));
+  memset(dqcoeff_ptr, 0, n_coeffs * sizeof(*dqcoeff_ptr));
+  *eob_ptr = 0;
+}
 
 static void highbd_quantize_fp_helper_c(
     const int use_tcq_deadzone_boost, const tran_low_t *coeff_ptr,
@@ -205,11 +210,14 @@ void av2_highbd_quantize_b_facade(const int use_tcq_deadzone_boost,
 }
 
 static INLINE void highbd_quantize_dc(
-    const tran_low_t *coeff_ptr, int skip_block, const int32_t *round_ptr,
-    const int32_t quant, tran_low_t *qcoeff_ptr, tran_low_t *dqcoeff_ptr,
-    const int32_t dequant_ptr, uint16_t *eob_ptr, const qm_val_t *qm_ptr,
-    const qm_val_t *iqm_ptr, const int log_scale) {
+    const tran_low_t *coeff_ptr, int n_coeffs, int skip_block,
+    const int32_t *round_ptr, const int32_t quant, tran_low_t *qcoeff_ptr,
+    tran_low_t *dqcoeff_ptr, const int32_t dequant_ptr, uint16_t *eob_ptr,
+    const qm_val_t *qm_ptr, const qm_val_t *iqm_ptr, const int log_scale) {
   int eob = -1;
+
+  memset(qcoeff_ptr, 0, n_coeffs * sizeof(*qcoeff_ptr));
+  memset(dqcoeff_ptr, 0, n_coeffs * sizeof(*dqcoeff_ptr));
 
   if (!skip_block) {
     const qm_val_t wt = qm_ptr != NULL ? qm_ptr[0] : (1 << AVM_QM_BITS);
@@ -251,11 +259,11 @@ void av2_highbd_quantize_dc_facade(const int use_tcq_deadzone_boost,
   const qm_val_t *iqm_ptr = qparam->iqmatrix;
   (void)sc;
   (void)use_tcq_deadzone_boost;
-  (void)n_coeffs;
 
-  highbd_quantize_dc(coeff_ptr, skip_block, p->round_QTX, p->quant_fp_QTX[0],
-                     qcoeff_ptr, dqcoeff_ptr, p->dequant_QTX[0], eob_ptr,
-                     qm_ptr, iqm_ptr, qparam->log_scale);
+  highbd_quantize_dc(coeff_ptr, (int)n_coeffs, skip_block, p->round_QTX,
+                     p->quant_fp_QTX[0], qcoeff_ptr, dqcoeff_ptr,
+                     p->dequant_QTX[0], eob_ptr, qm_ptr, iqm_ptr,
+                     qparam->log_scale);
 }
 void av2_highbd_quantize_fp_c(const int use_tcq_deadzone_boost,
                               const tran_low_t *coeff_ptr, intptr_t count,

--- a/av2/encoder/av2_quantize.h
+++ b/av2/encoder/av2_quantize.h
@@ -127,7 +127,8 @@ int av2_quantizer_to_qindex(int quantizer, avm_bit_depth_t bit_depth);
 
 int av2_qindex_to_quantizer(int qindex, avm_bit_depth_t bit_depth);
 
-void av2_quantize_skip(uint16_t *eob_ptr);
+void av2_quantize_skip(intptr_t n_coeffs, tran_low_t *qcoeff_ptr,
+                       tran_low_t *dqcoeff_ptr, uint16_t *eob_ptr);
 
 void av2_highbd_quantize_fp_facade(const int use_tcq_deadzone_boost,
                                    const tran_low_t *coeff_ptr,

--- a/av2/encoder/encodemb.c
+++ b/av2/encoder/encodemb.c
@@ -588,6 +588,8 @@ void av2_xform_dc_only(MACROBLOCK *x, int plane, int block,
   const struct macroblock_plane *const p = &x->plane[plane];
   const int block_offset = BLOCK_OFFSET(block);
   tran_low_t *const coeff = p->coeff + block_offset;
+  const int n_coeffs = av2_get_max_eob(txfm_param->tx_size);
+  memset(coeff, 0, sizeof(*coeff) * n_coeffs);
   coeff[0] =
       (tran_low_t)((per_px_mean * dc_coeff_scale[txfm_param->tx_size]) >> 12);
 }
@@ -728,7 +730,7 @@ void av2_quant(const int use_tcq_deadzone_boost, MACROBLOCK *x, int plane,
                                                n_coeffs, p, qcoeff, dqcoeff,
                                                eob, scan_order, qparam);
     } else {
-      av2_quantize_skip(eob);
+      av2_quantize_skip(n_coeffs, qcoeff, dqcoeff, eob);
     }
   }
 

--- a/av2/encoder/hybrid_fwd_txfm.c
+++ b/av2/encoder/hybrid_fwd_txfm.c
@@ -10,17 +10,15 @@
  * aomedia.org/license/patent-license/.
  */
 
-#include <assert.h>
-
-#include "config/av2_rtcd.h"
 #include "config/avm_config.h"
+#include "config/av2_rtcd.h"
 #include "config/avm_dsp_rtcd.h"
 
 #include "av2/common/idct.h"
+#include "av2/encoder/hybrid_fwd_txfm.h"
 #include "av2/common/scan.h"
 #include "av2/common/secondary_tx.h"
 #include "av2/common/txb_common.h"
-#include "av2/encoder/hybrid_fwd_txfm.h"
 
 void av2_lossless_fwd_idtx_c(const int16_t *src_diff, tran_low_t *coeff,
                              int diff_stride, TxfmParam *txfm_param) {
@@ -986,8 +984,7 @@ void fwd_txfm_c(const int16_t *resi, tran_low_t *coeff, int diff_stride,
   int skipWidth = width > 32 ? width - 32 : 0;
   int skipHeight = height > 32 ? height - 32 : 0;
 
-  int buf[MAX_TX_SQUARE];
-  assert(width >= 4 && height >= 4);
+  int buf[MAX_TX_SQUARE] = { 0 };
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {

--- a/av2/encoder/x86/highbd_fwd_txfm_avx2.c
+++ b/av2/encoder/x86/highbd_fwd_txfm_avx2.c
@@ -12,15 +12,13 @@
 #include <assert.h>
 #include <immintrin.h> /*AVX2*/
 
-#include "config/av2_rtcd.h"
 #include "config/avm_config.h"
-#include "config/avm_dsp_rtcd.h"
-
+#include "config/av2_rtcd.h"
 #include "av2/common/av2_txfm.h"
-#include "av2/common/txb_common.h"
 #include "avm_dsp/txfm_common.h"
-#include "avm_dsp/x86/txfm_common_sse2.h"
 #include "avm_ports/mem.h"
+#include "avm_dsp/x86/txfm_common_sse2.h"
+#include "av2/common/txb_common.h"
 
 static INLINE __m256i round_power_of_two_signed_avx2(__m256i v_val_d,
                                                      int bits) {
@@ -5231,8 +5229,7 @@ void fwd_txfm_avx2(const int16_t *resi, tran_low_t *coeff, int diff_stride,
   int skipWidth = width > 32 ? width - 32 : 0;
   int skipHeight = height > 32 ? height - 32 : 0;
 
-  int buf[MAX_TX_SQUARE];
-  assert(width >= 4 && height >= 4);
+  int buf[MAX_TX_SQUARE] = { 0 };
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {


### PR DESCRIPTION
This reverts commit 587f50e26fe339a58175a74f32f2e84fd98e622c.

Reason for revert:
https://github.com/AOMediaCodec/avm/issues/5231