### PR TITLE
Implement non-RD partition evaluation for real-time mode

### DIFF
--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -805,12 +805,22 @@ static AVM_INLINE void encode_rd_sb(AV2_COMP *cpi, ThreadData *td,
       for (int plane = plane_start; plane < plane_end; plane++) {
         x->cb_offset[plane] = 0;
       }
-      av2_rd_use_partition(
-          cpi, td, tile_data, mi,
-          (intra_sdp_enabled && xd->tree_type == CHROMA_PART) ? tp_chroma : tp,
-          mi_row, mi_col, sb_size, &dummy_rate, &dummy_dist, 1,
-          xd->sbi->ptree_root[av2_get_sdp_idx(xd->tree_type)], pc_root,
-          (xd->tree_type == CHROMA_PART) ? xd->sbi->ptree_root[0] : NULL);
+      TokenExtra **const tp_start =
+          (intra_sdp_enabled && xd->tree_type == CHROMA_PART) ? tp_chroma : tp;
+      PARTITION_TREE *const ptree_luma =
+          (xd->tree_type == CHROMA_PART) ? xd->sbi->ptree_root[0] : NULL;
+      if (cpi->sf.rt_sf.use_nonrd_partition) {
+        av2_nonrd_use_partition(
+            cpi, td, tile_data, mi, tp_start, mi_row, mi_col, sb_size,
+            xd->sbi->ptree_root[av2_get_sdp_idx(xd->tree_type)], pc_root,
+            ptree_luma);
+      } else {
+        av2_rd_use_partition(
+            cpi, td, tile_data, mi, tp_start, mi_row, mi_col, sb_size,
+            &dummy_rate, &dummy_dist, 1,
+            xd->sbi->ptree_root[av2_get_sdp_idx(xd->tree_type)], pc_root,
+            ptree_luma);
+      }
       av2_free_pc_tree_recursive(pc_root, num_planes, 0, 0);
       x->sb_enc.min_partition_size = min_partition_size;
     }

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2356,6 +2356,193 @@ static void init_partition_costs(const AV2_COMMON *const cm,
   }
 }
 
+/*!\brief Fast non-RD block partition encoding.
+ *
+ * \ingroup partition_search
+ * Encodes a block using pre-calculated partition patterns (e.g. from
+ * variance-based partitioning) without executing full Rate-Distortion (RD)
+ * searches across all candidate partition types. Recursively traverses basic
+ * partition types: PARTITION_NONE, PARTITION_HORZ, PARTITION_VERT, and
+ * PARTITION_SPLIT.
+ *
+ * \param[in]    cpi         Top-level encoder structure
+ * \param[in]    td          Pointer to thread data
+ * \param[in]    tile_data   Pointer to tile-level encoder data structure
+ * \param[in]    mib         Array of MB_MODE_INFO pointers starting from the
+ * current block
+ * \param[in]    tp          Pointer to the starting token
+ * \param[in]    mi_row      Row coordinate of the block (in MI units)
+ * \param[in]    mi_col      Column coordinate of the block (in MI units)
+ * \param[in]    bsize       Current block size
+ * \param[in]    ptree       Pointer to PARTITION_TREE node holding
+ * pre-calculated partitions
+ * \param[in]    pc_tree     Pointer to PC_TREE node holding picked partition
+ * information
+ * \param[in]    ptree_luma  Pointer to luma partition tree (used for chroma
+ * partition estimation)
+ */
+void av2_nonrd_use_partition(AV2_COMP *cpi, ThreadData *td,
+                             TileDataEnc *tile_data, MB_MODE_INFO **mib,
+                             TokenExtra **tp, int mi_row, int mi_col,
+                             BLOCK_SIZE bsize, PARTITION_TREE *ptree,
+                             PC_TREE *pc_tree, PARTITION_TREE *ptree_luma) {
+  AV2_COMMON *const cm = &cpi->common;
+  const CommonModeInfoParams *const mi_params = &cm->mi_params;
+  if (mi_row >= mi_params->mi_rows || mi_col >= mi_params->mi_cols) return;
+
+  TileInfo *const tile_info = &tile_data->tile_info;
+  MACROBLOCK *const x = &td->mb;
+  MACROBLOCKD *const xd = &x->e_mbd;
+  const int ss_x = xd->plane[1].subsampling_x;
+  const int ss_y = xd->plane[1].subsampling_y;
+  assert(bsize < BLOCK_SIZES_ALL);
+  const int hbh = mi_size_high[bsize] / 2;
+  const int hbw = mi_size_wide[bsize] / 2;
+  const PARTITION_TYPE partition =
+      get_preset_partition(cm, xd->tree_type, mi_row, mi_col, bsize, ptree);
+  const BLOCK_SIZE subsize = get_partition_subsize(bsize, partition);
+  RD_STATS this_rdc, best_rdc;
+  int rate;
+  av2_invalid_rd_stats(&this_rdc);
+  av2_invalid_rd_stats(&best_rdc);
+
+  if (!frame_is_intra_only(cm))
+    pc_tree->region_type = MIXED_INTER_INTRA_REGION;
+  else
+    pc_tree->region_type = INTRA_REGION;
+  REGION_TYPE cur_region_type = pc_tree->region_type;
+  if (is_inter_sdp_chroma(cm, cur_region_type, x->e_mbd.tree_type)) {
+    if (pc_tree->none_chroma == NULL) {
+      pc_tree->none_chroma =
+          av2_alloc_pmc(cm, xd->tree_type, mi_row, mi_col, bsize, pc_tree,
+                        PARTITION_NONE, 0, ss_x, ss_y, &td->shared_coeff_buf);
+    }
+  } else {
+    if (pc_tree->none[cur_region_type] == NULL) {
+      pc_tree->none[cur_region_type] =
+          av2_alloc_pmc(cm, xd->tree_type, mi_row, mi_col, bsize, pc_tree,
+                        PARTITION_NONE, 0, ss_x, ss_y, &td->shared_coeff_buf);
+    }
+  }
+
+  PICK_MODE_CONTEXT *ctx_none =
+      is_inter_sdp_chroma(cm, cur_region_type, x->e_mbd.tree_type)
+          ? pc_tree->none_chroma
+          : pc_tree->none[pc_tree->region_type];
+
+  pc_tree->partitioning = partition;
+
+  if (bsize == BLOCK_16X16 && cpi->vaq_refresh) {
+    av2_set_offsets(cpi, tile_info, x, mi_row, mi_col, bsize,
+                    &pc_tree->chroma_ref_info);
+    x->mb_energy = av2_log_block_var(cpi, x, bsize
+#if CONFIG_MIXED_LOSSLESS_ENCODE
+                                     ,
+                                     mi_row, mi_col
+#endif  // CONFIG_MIXED_LOSSLESS_ENCODE
+    );
+  }
+
+  if (bsize == cm->sb_size) {
+    if (pc_tree)
+      pc_tree->is_cfl_allowed_for_this_chroma = CFL_DISALLOWED_FOR_CHROMA;
+
+    xd->is_cfl_allowed_in_sdp =
+        is_cfl_allowed_for_sdp(cm, xd, ptree_luma, PARTITION_NONE, bsize);
+    ptree->is_cfl_allowed_for_this_chroma_partition = CFL_DISALLOWED_FOR_CHROMA;
+  }
+
+  if (partition == PARTITION_NONE) {
+    xd->is_cfl_allowed_in_sdp =
+        pc_tree->is_cfl_allowed_for_this_chroma |
+        ptree->is_cfl_allowed_for_this_chroma_partition |
+        is_cfl_allowed_for_sdp(cm, xd, ptree_luma, partition, bsize);
+
+  } else {
+    pc_tree->is_cfl_allowed_for_this_chroma =
+        ((pc_tree->parent) ? pc_tree->parent->is_cfl_allowed_for_this_chroma
+                           : 0) |
+        is_cfl_allowed_for_sdp(cm, xd, ptree_luma, partition, bsize);
+    ptree->is_cfl_allowed_for_this_chroma_partition = CFL_DISALLOWED_FOR_CHROMA;
+  }
+
+  switch (partition) {
+    case PARTITION_NONE:
+      pick_sb_modes(cpi, td, tile_data, x, mi_row, mi_col, &this_rdc,
+                    pc_tree->region_type, pc_tree->sb_root_partition_info,
+                    bsize, ctx_none, best_rdc);
+      encode_b(cpi, tile_data, td, tp, mi_row, mi_col, OUTPUT_ENABLED, subsize,
+               partition, ctx_none, &rate);
+      break;
+    case PARTITION_HORZ:
+      pc_tree->horizontal[cur_region_type][0] = av2_alloc_pc_tree_node(
+          xd->tree_type, mi_row, mi_col, cm->sb_size, subsize, pc_tree,
+          PARTITION_HORZ, 0, 0, ss_x, ss_y);
+      pc_tree->horizontal[cur_region_type][1] = av2_alloc_pc_tree_node(
+          xd->tree_type, mi_row + hbh, mi_col, cm->sb_size, subsize, pc_tree,
+          PARTITION_HORZ, 1, 1, ss_x, ss_y);
+
+      av2_nonrd_use_partition(cpi, td, tile_data, mib, tp, mi_row, mi_col,
+                              subsize, ptree ? ptree->sub_tree[0] : NULL,
+                              pc_tree->horizontal[cur_region_type][0],
+                              get_partition_subtree_const(ptree_luma, 0));
+      if (bsize >= BLOCK_8X8 && mi_row + hbh < mi_params->mi_rows) {
+        av2_nonrd_use_partition(
+            cpi, td, tile_data, mib + hbh * mi_params->mi_stride, tp,
+            mi_row + hbh, mi_col, subsize, ptree ? ptree->sub_tree[1] : NULL,
+            pc_tree->horizontal[cur_region_type][1],
+            get_partition_subtree_const(ptree_luma, 1));
+      }
+      break;
+    case PARTITION_VERT:
+      pc_tree->vertical[cur_region_type][0] = av2_alloc_pc_tree_node(
+          xd->tree_type, mi_row, mi_col, cm->sb_size, subsize, pc_tree,
+          PARTITION_VERT, 0, 0, ss_x, ss_y);
+      pc_tree->vertical[cur_region_type][1] = av2_alloc_pc_tree_node(
+          xd->tree_type, mi_row, mi_col + hbw, cm->sb_size, subsize, pc_tree,
+          PARTITION_VERT, 1, 1, ss_x, ss_y);
+      av2_nonrd_use_partition(cpi, td, tile_data, mib, tp, mi_row, mi_col,
+                              subsize, ptree ? ptree->sub_tree[0] : NULL,
+                              pc_tree->vertical[cur_region_type][0],
+                              get_partition_subtree_const(ptree_luma, 0));
+      if (bsize >= BLOCK_8X8 && mi_col + hbw < mi_params->mi_cols) {
+        av2_nonrd_use_partition(cpi, td, tile_data, mib + hbw, tp, mi_row,
+                                mi_col + hbw, subsize,
+                                ptree ? ptree->sub_tree[1] : NULL,
+                                pc_tree->vertical[cur_region_type][1],
+                                get_partition_subtree_const(ptree_luma, 1));
+      }
+      break;
+    case PARTITION_SPLIT:
+      for (int i = 0; i < SUB_PARTITIONS_SPLIT; i++) {
+        int x_idx = (i & 1) * hbw;
+        int y_idx = (i >> 1) * hbh;
+        int jj = i >> 1, ii = i & 0x01;
+        if ((mi_row + y_idx >= mi_params->mi_rows) ||
+            (mi_col + x_idx >= mi_params->mi_cols))
+          continue;
+        pc_tree->split[cur_region_type][i] = av2_alloc_pc_tree_node(
+            xd->tree_type, mi_row + y_idx, mi_col + x_idx, cm->sb_size, subsize,
+            pc_tree, PARTITION_SPLIT, i, i == 3, ss_x, ss_y);
+        av2_nonrd_use_partition(
+            cpi, td, tile_data,
+            mib + jj * hbh * mi_params->mi_stride + ii * hbw, tp,
+            mi_row + y_idx, mi_col + x_idx, subsize,
+            ptree ? ptree->sub_tree[i] : NULL,
+            pc_tree->split[cur_region_type][i],
+            get_partition_subtree_const(ptree_luma, i));
+      }
+      break;
+    case PARTITION_HORZ_4A:
+    case PARTITION_HORZ_4B:
+    case PARTITION_VERT_4A:
+    case PARTITION_VERT_4B:
+    case PARTITION_HORZ_3:
+    case PARTITION_VERT_3:
+    default: assert(0); break;
+  }
+}
+
 /*!\brief AV2 block partition search (partition estimation and partial search).
 *
 * \ingroup partition_search

--- a/av2/encoder/partition_search.h
+++ b/av2/encoder/partition_search.h
@@ -27,6 +27,11 @@ void av2_set_offsets_without_segment_id(const AV2_COMP *const cpi,
 void av2_set_offsets(const AV2_COMP *const cpi, const TileInfo *const tile,
                      MACROBLOCK *const x, int mi_row, int mi_col,
                      BLOCK_SIZE bsize, const CHROMA_REF_INFO *chroma_ref_info);
+void av2_nonrd_use_partition(AV2_COMP *cpi, ThreadData *td,
+                             TileDataEnc *tile_data, MB_MODE_INFO **mib,
+                             TokenExtra **tp, int mi_row, int mi_col,
+                             BLOCK_SIZE bsize, PARTITION_TREE *ptree,
+                             PC_TREE *pc_tree, PARTITION_TREE *ptree_luma);
 void av2_rd_use_partition(AV2_COMP *cpi, ThreadData *td, TileDataEnc *tile_data,
                           MB_MODE_INFO **mib, TokenExtra **tp, int mi_row,
                           int mi_col, BLOCK_SIZE bsize, int *rate,

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -687,6 +687,7 @@ static void set_rt_speed_features_framesize_independent(
     sf->part_sf.partition_pruning_with_mlp = 0;
     sf->part_sf.partition_search_type = VAR_BASED_PARTITION;
     sf->rd_sf.tx_domain_dist_thres_level = 2;
+    sf->rt_sf.use_nonrd_partition = 1;
     sf->rt_sf.use_only_dc_intra_interframe = true;
     sf->winner_mode_sf.tx_size_search_level = USE_LARGESTALL;
   }

--- a/test/rtc_test.cc
+++ b/test/rtc_test.cc
@@ -71,7 +71,7 @@ class RtcTestLarge : public ::libavm_test::CodecTestWithParam<int>,
       encoder->Control(AV2E_SET_QUANT_B_ADAPT, 0);
       encoder->Control(AV2E_SET_ENABLE_TPL_MODEL, 0);
       encoder->Control(AV2E_SET_FRAME_PERIODIC_BOOST, 0);
-      encoder->Control(AV2E_SET_MAX_REFERENCE_FRAMES, 3);
+      encoder->Control(AV2E_SET_MAX_REFERENCE_FRAMES, 1);
       encoder->Control(AV2E_SET_REDUCED_REFERENCE_SET, 1);
       encoder->Control(AV2E_SET_ENABLE_REF_FRAME_MVS, 0);
       encoder->Control(AV2E_SET_ENABLE_QM, 0);
@@ -90,6 +90,37 @@ class RtcTestLarge : public ::libavm_test::CodecTestWithParam<int>,
       encoder->Control(AV2E_SET_COEFF_COST_UPD_FREQ, 2);
       encoder->Control(AV2E_SET_MODE_COST_UPD_FREQ, 2);
       encoder->Control(AV2E_SET_MV_COST_UPD_FREQ, 3);
+      // The following settings don't have codec control assigned yet.
+      encoder->SetOption("enable-sdp", "0");
+      encoder->SetOption("enable-extended-sdp", "0");
+      encoder->SetOption("enable-mhccp", "0");
+      encoder->SetOption("enable-mrls", "0");
+      encoder->SetOption("enable-tip", "0");
+      encoder->SetOption("enable-bawp", "0");
+      encoder->SetOption("enable-cwp", "0");
+      encoder->SetOption("enable-imp-msk-bld", "0");
+      encoder->SetOption("enable-ist", "0");
+      encoder->SetOption("enable-inter-ist", "0");
+      encoder->SetOption("enable-inter-ddt", "0");
+      encoder->SetOption("enable-cctx", "0");
+      encoder->SetOption("enable-ccso", "0");
+      encoder->SetOption("enable-ext-partitions", "0");
+      encoder->SetOption("enable-pc-wiener", "0");
+      encoder->SetOption("enable-wiener-nonsep", "0");
+      encoder->SetOption("enable-ibp", "0");
+      encoder->SetOption("enable-refmvbank", "0");
+      encoder->SetOption("enable-opfl-refine", "0");
+      encoder->SetOption("enable-lf-sub-pu", "0");
+      encoder->SetOption("enable-adaptive-mvd", "0");
+      encoder->SetOption("enable-flex-mvres", "0");
+      encoder->SetOption("enable-joint-mvd", "0");
+      encoder->SetOption("enable-refinemv", "0");
+      encoder->SetOption("enable-mvd-sign-derive", "0");
+      encoder->SetOption("enable-parity-hiding", "0");
+      encoder->SetOption("enable-warp-delta", "0");
+      encoder->SetOption("enable-warp-extend", "0");
+      encoder->SetOption("max-drl-refmvs", "0");
+      encoder->SetOption("max-drl-refbvs", "0");
     }
   }
 


### PR DESCRIPTION
This change is bitexact for RTC mode with speed up:

Without Non-RD partition:

```
         Bitrate(kbps)  |  PSNR(Y)  |  PSNR(U)  |  PSNR(V)  |  PSNR(Avg)  |  PSNR(Overall)  |  Encoding time (FPS)
------------------------------------------------------------------------------------------------------------
Summary:    285.057200  |  46.194842  |  44.555717  |  44.840002  |  45.625135    |  45.587741        |    20.9s (14.3 fps)
```

With Non-RD partition:

```
         Bitrate(kbps)  |  PSNR(Y)  |  PSNR(U)  |  PSNR(V)  |  PSNR(Avg)  |  PSNR(Overall)  |  Encoding time (FPS)
------------------------------------------------------------------------------------------------------------
Summary:    285.057200  |  46.194842  |  44.555717  |  44.840002  |  45.625135    |  45.587741        |    18.4s (16.2 fps)
```

Tested with command line:

```
./avmenc --passes=1 --bit-depth=8 --obu --lag-in-frames=0 --kf-min-dist=1000 --kf-max-dist=1000 screen_inp.1280_720.yuv -w 1280 -h 720 -o out.ivf --fps=15/1 --target-bitrate=400 --auto-alt-ref=0 --enable-tpl-model=0 --enable-keyframe-filtering=0 --enable-deblocking=1 --enable-restoration=0  --enable-intra-edge-filter=0 --enable-flip-idtx=1 --enable-masked-comp=0 --enable-onesided-comp=0 --enable-interintra-comp=0 --enable-smooth-interintra=0 --enable-diff-wtd-comp=0 --enable-interinter-wedge=0 --enable-interintra-wedge=0 --enable-global-motion=0 --enable-warped-motion=0 --enable-smooth-intra=0 --enable-paeth-intra=0 --enable-cfl-intra=0 --force-video-mode=1 --enable-overlay=0 --enable-angle-delta=0 --enable-trellis-quant=0 --enable-qm=0 --use-intra-dct-only=1 --coeff-cost-upd-freq=2 --mode-cost-upd-freq=2 --mv-cost-upd-freq=3 --frame-parallel=0 --aq-mode=0 --deltaq-mode=0 --frame-boost=0 --noise-sensitivity=0 --cdf-update-mode=1 --reduced-reference-set=1 --enable-ref-frame-mvs=0 --erp-pruning-level=0 --use-ml-erp-pruning=0 --enable-ext-partitions=0 --enable-mrls=0 --enable-pc-wiener=0 --enable-wiener-nonsep=0 --enable-tip=0 --enable-bawp=0 --enable-cwp=0 --enable-imp-msk-bld=0 --enable-ist=0 --enable-inter-ist=0 --enable-inter-ddt=0 --enable-cctx=0 --enable-ibp=0 --max-drl-refmvs=0 --max-drl-refbvs=0 --enable-refmvbank=0 --enable-opfl-refine=0 --enable-ccso=0 --enable-lf-sub-pu=0 --enable-adaptive-mvd=0 --enable-flex-mvres=0 --enable-joint-mvd=0 --enable-refinemv=0 --enable-mvd-sign-derive=0 --enable-parity-hiding=0 --enable-warp-delta=0 --enable-warp-extend=0 --tile-columns=0 --gf-min-pyr-height=0 --gf-max-pyr-height=0 --end-usage=q --use-fixed-qp-offsets=0 --psnr --threads=1 --enable-sdp=0 --min-gf-interval=8 --max-gf-interval=8 --explicit-ref-frame-map=1 --enable-bru=0 --enable-ext-seg=0 --enable-six-param-warp-delta=0 --enable-cdef=1 --enable-cdef-on-skip-txfm=0 --limit=1000 --dpb-size=3 --use-inter-dct-only=0 enable-fsc=1 --enable-idtx-intra=1 --enable-palette=1 --enable-intrabc-ext=0 --enable-intrabc=1 --tune-content=1 --rt --cpu-used=6 --min-qp=100 --max-qp=100 --enable-gdf=0 --max-reference-frames=1
```