### PR TITLE
CCSO early terminate by cost threshold

### DIFF
--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -3144,7 +3144,8 @@ static void cdef_restoration_frame(AV2_COMP *cpi, AV2_COMMON *cm,
                 ,
                 &cpi->td
 #endif
-    );
+                ,
+                cpi->sf.lpf_sf.early_terminate_ccso_search_by_cost);
     ccso_frame(&cm->cur_frame->buf, cm, xd, ext_rec_y);
 #if CONFIG_MISMATCH_DEBUG
     mismatch_record_frame(&cm->cur_frame->buf, num_planes, 2);

--- a/av2/encoder/pickccso.c
+++ b/av2/encoder/pickccso.c
@@ -1105,7 +1105,8 @@ static void derive_ccso_filter(CcsoCtx *ctx, AV2_COMMON *cm, const int plane,
                                ,
                                ThreadData *td
 #endif
-) {
+                               ,
+                               int early_terminate_ccso_search) {
   const CommonModeInfoParams *const mi_params = &cm->mi_params;
   const int ccso_blk_size = get_ccso_unit_size_log2_adaptive_tile(
       cm, cm->mib_size_log2 + MI_SIZE_LOG2, CCSO_BLK_SIZE);
@@ -1268,6 +1269,7 @@ static void derive_ccso_filter(CcsoCtx *ctx, AV2_COMMON *cm, const int plane,
         for (int quant_idx = 0; quant_idx < num_quant_iter; quant_idx++) {
           for (int edge_clf = 0; edge_clf < num_edge_clf_iter; edge_clf++) {
             const int max_edge_interval = edge_clf_to_edge_interval[edge_clf];
+            uint64_t last_best_cost = final_filtered_cost;
 
             if (quant_sz[scale_idx][quant_idx] == 0 && edge_clf == 1) {
               continue;
@@ -1605,13 +1607,17 @@ static void derive_ccso_filter(CcsoCtx *ctx, AV2_COMMON *cm, const int plane,
                 memcpy(ctx->final_filter_control, ctx->best_filter_control,
                        sizeof(*ctx->best_filter_control) * sb_count);
               }
+              if (early_terminate_ccso_search &&
+                  final_filtered_cost != UINT64_MAX &&
+                  1.001 * final_filtered_cost > last_best_cost)
+                goto exit_loops;
             }
           }
         }
       }
     }
   }
-
+exit_loops:
   if (best_unfiltered_cost < final_filtered_cost) {
     memset(ctx->final_filter_control, 0,
            sizeof(*ctx->final_filter_control) * sb_count);
@@ -1840,7 +1846,8 @@ void ccso_search(AV2_COMMON *cm, MACROBLOCKD *xd, int rdmult,
                  ,
                  ThreadData *td
 #endif
-) {
+                 ,
+                 int early_terminate_ccso_search) {
   int rdmult_weight = clamp(cm->quant_params.base_qindex >> 3, 1, 37);
   int64_t rdmult_temp = (int64_t)rdmult * (int64_t)rdmult_weight;
   if (rdmult_temp >= INT_MAX) {
@@ -1867,7 +1874,8 @@ void ccso_search(AV2_COMMON *cm, MACROBLOCKD *xd, int rdmult,
                      ,
                      td
 #endif
-  );
+                     ,
+                     early_terminate_ccso_search);
 
   cm->ccso_info.ccso_frame_flag = cm->ccso_info.ccso_enable[0];
   if (num_planes > 1) {
@@ -1878,14 +1886,16 @@ void ccso_search(AV2_COMMON *cm, MACROBLOCKD *xd, int rdmult,
                        ,
                        td
 #endif
-    );
+                       ,
+                       early_terminate_ccso_search);
     derive_ccso_filter(ctx, cm, AVM_PLANE_V, xd, org_uv[AVM_PLANE_V], ext_rec_y,
                        rec_uv[AVM_PLANE_V], rdmult, error_resilient_frame_seen
 #if CONFIG_ENTROPY_STATS
                        ,
                        td
 #endif
-    );
+                       ,
+                       early_terminate_ccso_search);
     cm->ccso_info.ccso_frame_flag |= cm->ccso_info.ccso_enable[1];
     cm->ccso_info.ccso_frame_flag |= cm->ccso_info.ccso_enable[2];
   }

--- a/av2/encoder/pickccso.h
+++ b/av2/encoder/pickccso.h
@@ -29,7 +29,8 @@ void ccso_search(AV2_COMMON *cm, MACROBLOCKD *xd, int rdmult,
                  ,
                  ThreadData *td
 #endif
-);
+                 ,
+                 int early_terminate_ccso_search);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -414,6 +414,7 @@ static void set_good_speed_features_framesize_independent(
   }
 
   if (speed >= 2) {
+    sf->lpf_sf.early_terminate_ccso_search_by_cost = 1;
     sf->part_sf.partition_pruning_with_mlp_none_thresh = 2.5f;
     sf->part_sf.intra_cnn_split = 0;
     sf->part_sf.simple_motion_search_early_term_none = 1;
@@ -956,6 +957,7 @@ static AVM_INLINE void init_lpf_sf(LOOP_FILTER_SPEED_FEATURES *lpf_sf) {
   lpf_sf->disable_lr_filter = 0;
   lpf_sf->wienerns_refine_iters = 2;
   lpf_sf->enable_deblock_for_partition_search = 0;
+  lpf_sf->early_terminate_ccso_search_by_cost = 0;
 }
 
 static void av2_disable_ml_based_transform_sf(TX_SPEED_FEATURES *const tx_sf) {

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -996,6 +996,9 @@ typedef struct LOOP_FILTER_SPEED_FEATURES {
 
   // enable deblock for block partition search
   int enable_deblock_for_partition_search;
+
+  // early terminate ccso search by cost threshold
+  int early_terminate_ccso_search_by_cost;
 } LOOP_FILTER_SPEED_FEATURES;
 
 typedef struct REALTIME_SPEED_FEATURES {


### PR DESCRIPTION
Early terminate ccs search by cost comparison.

Enable for speed levels greater than one.

Results:

Anchor: 587f50e26fe339a58175a74f32f2e84fd98e622c

speed 2:

```

+-------+------+------+------+------+------+-------+
| Class |  Y%  |  U%  |  V%  | YUV% | ENC% | DEC%  |
+-------+------+------+------+------+------+-------+
| A1    | 0.19 | 1.03 | 1.10 | 0.29 | 83.2 |  98.2 |
| A2    | 0.14 | 1.96 | 2.11 | 0.31 | 82.8 | 100.4 |
+-------+------+------+------+------+------+-------+

```

Speed 3

```
+-------+------+------+------+------+------+------+
| Class |  Y%  |  U%  |  V%  | YUV% | ENC% | DEC% |
+-------+------+------+------+------+------+------+
| A1    | 0.16 | 1.35 | 1.46 | 0.28 | 78.4 | 98.1 |
| A2    | 0.18 | 2.37 | 4.82 | 0.42 | 78.9 | 98.9 |
+-------+------+------+------+------+------+------+
```


Speed 4

```

+-------+------+------+------+------+------+------+
| Class |  Y%  |  U%  |  V%  | YUV% | ENC% | DEC% |
+-------+------+------+------+------+------+------+
| A1    | 0.21 | 1.62 | 0.99 | 0.33 | 72.0 | 99.3 |
| A2    | 0.17 | 2.40 | 4.25 | 0.38 | 71.9 | 98.6 |
+-------+------+------+------+------+------+------+

```