### PR TITLE
Apply fast method to new_newmv and new_newmv_opfl amvd sub-mode

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -9359,7 +9359,9 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
           mbmi->use_amvd && cm->current_frame.pyramid_level > 3)
         continue;
       if (sf->inter_sf.prune_amvd_newmv &&
-          cm->current_frame.pyramid_level >= 4 && (mbmi->mode == NEWMV)) {
+          cm->current_frame.pyramid_level >= 4 &&
+          (mbmi->mode == NEWMV || mbmi->mode == NEW_NEWMV ||
+           mbmi->mode == NEW_NEWMV_OPTFLOW)) {
         if (mbmi->use_amvd && search_state.best_mbmode.mode != mbmi->mode) {
           continue;
         }


### PR DESCRIPTION
Apply the existing amvd fast method to new_newmv and new_newmv_opfl.

Test is launched on top of commit ad328d2ba0186b909.

Resutls for A2 (33f) and A1 (17f) is listed below:

```
+---------+--------+--------+--------+--------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time |
+---------+--------+--------+--------+--------+----------+
| A1      |  0.03% |  0.01% |  0.03% |  0.03% | 98.6%   |
| A2      |  0.06% |  -0.03% |  0.04% |  0.04% | 98.1%   |
+---------+--------+--------+--------+--------+----------+
```
STATS_CHANGED
