### PR TITLE
Add encoder options for aggressive low-complexity level

### DIFF
--- a/av2/arg_defs.c
+++ b/av2/arg_defs.c
@@ -888,8 +888,9 @@ const av2_codec_arg_definitions_t g_av2_codec_arg_defs = {
                                 "(0: GROUP format [default], 1: SHORT format)"),
   .enable_low_complexity_decode =
       ARG_DEF(NULL, "enable-low-complexity-decode", 1,
-              "Enable low complexity decode "
-              "(0: false (default), 1: true)"),
+              "Enable low complexity decode. "
+              "(0: false (default), 1: standard low-complexity level, 2: "
+              "aggressive low-complexity level)"),
 #endif  // CONFIG_AV2_ENCODER
   .enable_short_refresh_frame_flags =
       ARG_DEF(NULL, "enable-short-refresh-frame-flags", 1,

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -857,7 +857,7 @@ static avm_codec_err_t validate_config(avm_codec_alg_priv_t *ctx,
 
   RANGE_CHECK(extra_cfg, reduced_tx_type_set, 0, 3);
 
-  RANGE_CHECK_HI(extra_cfg, enable_low_complexity_decode, 1);
+  RANGE_CHECK_HI(extra_cfg, enable_low_complexity_decode, 2);
 
   return AVM_CODEC_OK;
 }
@@ -1753,9 +1753,10 @@ static avm_codec_err_t set_encoder_config(AV2EncoderConfig *oxcf,
   // Now, low complexity decode mode is only supported for good-quality
   // encoding. This can be further modified if needed.
   oxcf->enable_low_complexity_decode =
-      extra_cfg->enable_low_complexity_decode &&
-      cfg->g_usage == AVM_USAGE_GOOD_QUALITY;
-  if (extra_cfg->enable_low_complexity_decode &&
+      (cfg->g_usage == AVM_USAGE_GOOD_QUALITY)
+          ? extra_cfg->enable_low_complexity_decode
+          : 0;
+  if (extra_cfg->enable_low_complexity_decode > 0 &&
       cfg->g_usage != AVM_USAGE_GOOD_QUALITY) {
     fprintf(stderr,
             "Warning: setting enable_low_complexity_decode to 0 since it "

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -653,11 +653,19 @@ static void set_good_speed_features_framesize_independent(
 // mode.
 static void set_good_speed_features_lc_dec_framesize_independent(
     AV2_COMP *cpi) {
+  // Standard low-complexity level
   cpi->oxcf.tool_cfg.enable_mv_traj = 0;
   cpi->oxcf.tool_cfg.enable_gdf = 0;
   cpi->oxcf.tool_cfg.enable_pc_wiener = 0;
   cpi->oxcf.tool_cfg.enable_tip_refinemv = 0;
   cpi->oxcf.tool_cfg.reduced_ref_frame_mvs_mode = 1;
+
+  // Aggressive low-complexity level
+  if (cpi->oxcf.enable_low_complexity_decode > 1) {
+    cpi->oxcf.tool_cfg.enable_opfl_refine = 0;
+    cpi->oxcf.intra_mode_cfg.enable_mhccp = 0;
+    cpi->oxcf.tool_cfg.enable_lf_sub_pu = 0;
+  }
 }
 
 static void set_rt_speed_features_framesize_independent(
@@ -1195,6 +1203,13 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
           cpi->oxcf.tool_cfg.enable_tip_refinemv;
       cpi->common.seq_params.order_hint_info.reduced_ref_frame_mvs_mode =
           cpi->oxcf.tool_cfg.reduced_ref_frame_mvs_mode;
+
+      cpi->common.seq_params.enable_opfl_refine =
+          cpi->oxcf.tool_cfg.enable_opfl_refine;
+      cpi->common.seq_params.enable_mhccp =
+          cpi->oxcf.intra_mode_cfg.enable_mhccp;
+      cpi->common.seq_params.enable_lf_sub_pu =
+          cpi->oxcf.tool_cfg.enable_lf_sub_pu;
     }
   }
 

--- a/avm/avm_encoder.h
+++ b/avm/avm_encoder.h
@@ -682,9 +682,10 @@ typedef struct cfg_options {
   int operating_points_count;
 
   /*!\brief enable the low complexity decode mode
-   * If 0, disables the low complexity decode mode (default).
-   * If 1 and the usage is good-quality, enables the low complexity decode
-   * mode.
+   * If value = 0, disables the low complexity decode mode (default).
+   * If value > 0 and the usage is good-quality, enables the low complexity
+   * decode mode (value 1: standard low-complexity level, value 2: aggressive
+   * low-complexity level).
    */
   unsigned int enable_low_complexity_decode;
 } cfg_options_t;


### PR DESCRIPTION
   Added encoder options for the aggressive low-complexity (LC) level
    (i.e. LC level = 2).
    
    Baseline: 5b32726
    Test condition: CTC, RA, 65 frames, speed 1
    
    ```
       | PSNR-YUV | Enc-time (%) | Dec-time (%)
    -- | -------- | ------------ | ----------
    A1 | 3.97%    | 93%          | 44%
    A2 | 3.42%    | 94%          | 49%
    A3 | 3.69%    | 94%          | 46%
    ```
    
    With "enable_low_complexity_decode = 2", SW decoder complexity (vs AV1
    decoder) reduces from 4x to 1.87x.
    
    STATS_CHANGED for enable_low_complexity_decode = 2