### PR TITLE
Increase exhaustive search threshold for speed 1

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -380,6 +380,10 @@ static void set_good_speed_features_framesize_independent(
       sf->rd_sf.perform_coeff_opt = 0;
     }
 
+    if (!cpi->is_screen_content_type &&
+        cpi->twopass.fr_content_type == FC_HIGHMOTION) {
+      sf->mv_sf.exhaustive_searches_thresh <<= 1;
+    }
     // Skip the second-best full-pel candidate's subpel refinement in the
     // single-ref NEWMV search.
     sf->mv_sf.skip_second_best_subpel = 1;


### PR DESCRIPTION
Increase the threshold used to force mesh search when the residue variance is high, thereby reducing the number of exhaustive searches. The threshold is unchanged for screen contents.

Results for RA CTC, A1 17 frames, A2 33 frames, speed 1: (Anchor: 587f50e)
```
+------------+-------+-------+-------+-------+---------------+
| Class      |     Y |    Cb |    Cr |  wAvg |EncInstCount(%)|
+------------+-------+-------+-------+-------+---------------+
| A1         | -0.02 |  0.05 |  0.09 | -0.02 |   95.27       |
| A2         | -0.00 | -0.01 |  0.23 |  0.01 |   96.11       |
+------------+-------+-------+-------+-------+---------------+
```

STATS_CHANGED for speed=1