### PR TITLE
Revert the unintended change under COLLECT_TX_SIZE_DATA

### DIFF
--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -2692,8 +2692,8 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
 #endif  // CONFIG_COLLECT_RD_STATS == 1
 
 #if COLLECT_TX_SIZE_DATA
-        record_tx_type_info(cpi, x, plane, block, plane_bsize, blk_row, blk_col,
-                            tx_size, packed_tx_type, rd);
+        collect_tx_size_data(x, plane, blk_row, blk_col, plane_bsize, tx_size,
+                             packed_tx_type, rd);
 #endif  // COLLECT_TX_SIZE_DATA
 
         assert(tx_sf->adaptive_tx_type_search_idx < 6);

--- a/av2/encoder/tx_search.h
+++ b/av2/encoder/tx_search.h
@@ -34,11 +34,11 @@ extern "C" {
 
 static const char av2_tx_size_data_output_file[] = "tx_size_data.txt";
 
-static AVM_INLINE void collect_tx_size_data(const AV2_COMP *cpi,
-                                            const MACROBLOCK *x, int plane,
+static AVM_INLINE void collect_tx_size_data(const MACROBLOCK *x, int plane,
                                             int blk_row, int blk_col,
                                             BLOCK_SIZE plane_bsize,
-                                            TX_SIZE tx_size, TX_TYPE tx_type,
+                                            TX_SIZE tx_size,
+                                            TX_TYPE packed_tx_type,
                                             int64_t rd) {
   // Generate small sample to restrict output size.
   static unsigned int seed = 21743;
@@ -76,7 +76,7 @@ static AVM_INLINE void collect_tx_size_data(const AV2_COMP *cpi,
         src_diff += diff_stride;
       }
 
-      fprintf(fp, "%d,%d,%d,%" PRId64, txb_w, txb_h, tx_type, rd);
+      fprintf(fp, "%d,%d,%d,%" PRId64, txb_w, txb_h, packed_tx_type, rd);
       fprintf(fp, "\n");
       fclose(fp);
     }


### PR DESCRIPTION
This change reverts the unintended function renaming and parameter changes of collect_tx_size_data().

No stats changed.