### PR TITLE
Increase exhaustive search threshold for speed >=2

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -430,8 +430,7 @@ static void set_good_speed_features_framesize_independent(
     sf->part_sf.disable_uneven_4way_partitions = true;
     sf->part_sf.disable_ext_partitions = true;
 
-    if (cpi->twopass.fr_content_type == FC_HIGHMOTION ||
-        cpi->is_screen_content_type) {
+    if (cpi->is_screen_content_type) {
       sf->mv_sf.exhaustive_searches_thresh = (1 << 21);
     } else {
       sf->mv_sf.exhaustive_searches_thresh = (1 << 26);


### PR DESCRIPTION
Increase the threshold used to force mesh search when the residue variance is high, thereby reducing the number of exhaustive searches. The threshold is unchanged for screen contents.

Results for RA CTC, A1 17 frames, A2 33 frames, speed 2,3: (Anchor: 587f50e)
```
+-------+------------+-------+-------+-------+-------+---------------+
| Speed | Class      |     Y |    Cb |    Cr |  wAvg |EncInstCount(%)|
+-------+------------+-------+-------+-------+-------+---------------+
|     2 | A2         |  0.05 |  0.20 |  0.21 |  0.07 |         88.68 |
|     2 | A1         |  0.12 |  0.32 |  0.19 |  0.13 |         91.29 |
+--------------------------------------------------------------------+
|     3 | A2         |  0.08 |  0.07 |  0.32 |  0.09 |         95.20 |
|     3 | A1         |  0.02 |  0.10 |  0.18 |  0.03 |         96.65 |
+-------+------------+-------+-------+-------+-------+---------------+
```

STATS_CHANGED for speed>=2