### PR TITLE
Two-pass superblock partition search

### DIFF
--- a/av2/common/blockd.h
+++ b/av2/common/blockd.h
@@ -562,6 +562,10 @@ typedef struct MB_MODE_INFO {
   uint8_t joint_y_mode_delta_angle;
   /*! \brief re-ordered mode list for y mode and y delta angle. */
   uint8_t y_intra_mode_list[LUMA_MODE_COUNT];
+  /*! \brief How many entries at the start of y_intra_mode_list are the most
+   * probable modes, i.e. the ones taken from neighbouring blocks. The rest of
+   * the list is filled with a fixed default order. */
+  uint8_t num_y_intra_mpm;
   /*! \brief re-ordered mode list for uv mode. */
   uint8_t uv_intra_mode_list[UV_INTRA_MODES];
   /**@}*/

--- a/av2/common/reconintra.c
+++ b/av2/common/reconintra.c
@@ -462,6 +462,10 @@ void get_y_intra_mode_set(MB_MODE_INFO *mi, MACROBLOCKD *const xd) {
     }
   }
 
+  // Everything added so far came from neighbouring blocks, so record how many
+  // entries that is. What the default fill adds below does not count.
+  mi->num_y_intra_mpm = mode_idx;
+
   // fill the remaining list with default modes
   for (i = 0; i < LUMA_MODE_COUNT - NON_DIRECTIONAL_MODES_COUNT &&
               mode_idx < LUMA_MODE_COUNT;

--- a/av2/encoder/block.h
+++ b/av2/encoder/block.h
@@ -1647,6 +1647,16 @@ typedef struct macroblock {
   MB_MODE_INFO *inter_mode_cache[NUMBER_OF_CACHED_MODES];
   /*! \brief Whether the whole superblock is inside the frame boudnary */
   bool is_whole_sb;
+
+  /*! \brief True during the dry pass of the SB-level two-pass partition
+   * search; gates the block-level dry-pass shortcuts. */
+  bool apply_dry_pass_shortcuts;
+
+  /*! \brief Cap on top intra Y candidates for full RD. */
+  int intra_mode_prune_top;
+
+  /*! \brief Cap on top inter motion-mode candidates for full RD. */
+  int inter_mode_prune_top;
   /**@}*/
 
   /*! \brief Quantization state of a transform coefficient.

--- a/av2/encoder/enc_enums.h
+++ b/av2/encoder/enc_enums.h
@@ -28,6 +28,12 @@ enum {
   USE_LARGESTALL,
 } UENUM1BYTE(TX_SIZE_SEARCH_METHOD);
 
+enum {
+  SB_SINGLE_PASS,  // Single pass encoding: all ctxs get updated normally
+  SB_DRY_PASS,     // First pass of multi-pass: does not update the ctxs
+  SB_WET_PASS      // Second pass of multi-pass: finalize and update the ctx
+} UENUM1BYTE(SB_MULTI_PASS_MODE);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -594,12 +594,18 @@ static AVM_INLINE void perform_two_partition_passes(
                              SB_WET_PASS, NULL);
 }
 
-/*!\brief Set all tree nodes <= min_bsize to PARTITION_INVALID.
+/*!\brief Mark the small nodes of the dry-pass tree as "search again".
  *
  * \ingroup partition_search
+ *
+ * The wet pass trusts the dry-pass shape for large blocks and searches the
+ * small ones again. This walks the dry-pass tree and clears the shape of every
+ * node smaller than min_bsize so the wet pass is free to choose its own.
  */
 static AVM_INLINE void set_min_none_to_invalid(PARTITION_TREE *part_tree,
-                                               BLOCK_SIZE min_bsize) {
+                                               BLOCK_SIZE min_bsize,
+                                               bool allow_none_resplit) {
+  if (!part_tree) return;
   const BLOCK_SIZE bsize = part_tree->bsize;
   const PARTITION_TYPE part_type = part_tree->partition;
   if (!is_bsize_geq(bsize, min_bsize)) {
@@ -608,7 +614,19 @@ static AVM_INLINE void set_min_none_to_invalid(PARTITION_TREE *part_tree,
       av2_free_ptree_recursive(part_tree->sub_tree[idx]);
       part_tree->sub_tree[idx] = NULL;
     }
+    return;
+  }
 
+  // Large blocks the dry pass left unsplit: re-split them in the wet pass
+  // (only on the fast level, guarded by allow_none_resplit). The conservative
+  // level keeps its pre-PR semantics.
+  if (allow_none_resplit && part_type == PARTITION_NONE) {
+    // Only do this for blocks up to 128 px. Bigger unsplit blocks are usually
+    // genuinely flat, so searching them again costs a lot of time for little
+    // gain.
+    if (AVMMAX(block_size_wide[bsize], block_size_high[bsize]) <= 128) {
+      part_tree->partition = PARTITION_INVALID;
+    }
     return;
   }
 
@@ -630,7 +648,8 @@ static AVM_INLINE void set_min_none_to_invalid(PARTITION_TREE *part_tree,
   }
 
   for (int idx = 0; idx < num_subtrees; idx++) {
-    set_min_none_to_invalid(part_tree->sub_tree[idx], min_bsize);
+    set_min_none_to_invalid(part_tree->sub_tree[idx], min_bsize,
+                            allow_none_resplit);
   }
 }
 
@@ -644,7 +663,8 @@ static AVM_INLINE void set_min_none_to_invalid(PARTITION_TREE *part_tree,
  */
 static AVM_INLINE void perform_two_pass_partition_search(
     AV2_COMP *cpi, ThreadData *td, TileDataEnc *tile_data, TokenExtra **tp,
-    TokenExtra **tp_chroma, const int mi_row, const int mi_col) {
+    TokenExtra **tp_chroma, const int mi_row, const int mi_col,
+    bool fast_two_pass) {
   SIMPLE_MOTION_DATA_TREE *const sms_root = td->sms_root;
   AV2_COMMON *const cm = &cpi->common;
   MACROBLOCK *const x = &td->mb;
@@ -653,17 +673,20 @@ static AVM_INLINE void perform_two_pass_partition_search(
   const BLOCK_SIZE sb_size = cm->sb_size;
   assert(!frame_is_intra_only(cm));
 
-  // First pass to estimate  partition structures
+  // First pass to estimate partition structures
   SB_FIRST_PASS_STATS sb_fp_stats;
   av2_backup_sb_state(&sb_fp_stats, cpi, td, tile_data, mi_row, mi_col);
-  const BLOCK_SIZE fp_min_bsize = BLOCK_16X16;
-  x->sb_enc.min_partition_size = fp_min_bsize;
+  // The dry pass does not go below 16x16: it only needs a rough shape, and it
+  // scores blocks with a reduced set of tools.
+  x->sb_enc.min_partition_size = BLOCK_16X16;
   perform_one_partition_pass(cpi, td, tile_data, tp, tp_chroma, mi_row, mi_col,
                              SB_DRY_PASS, NULL);
   PARTITION_TREE *part_ref = xd->sbi->ptree_root[0];
   // Set this to NULL otherwise part_ref will get freed in the second pass.
   xd->sbi->ptree_root[0] = NULL;
-  set_min_none_to_invalid(part_ref, get_larger_sqr_bsize(fp_min_bsize));
+  // Trust the dry-pass shape for >=32x32 blocks; re-search smaller ones.
+  set_min_none_to_invalid(part_ref, get_larger_sqr_bsize(BLOCK_16X16),
+                          fast_two_pass);
 
   // Second pass
   RD_STATS dummy_rdc;
@@ -850,9 +873,13 @@ static AVM_INLINE void encode_rd_sb(AV2_COMP *cpi, ThreadData *td,
                                    mi_col);
     } else if (!frame_is_intra_only(cm) &&
                bru_is_sb_active(cm, mi_col, mi_row) &&
-               sf->part_sf.two_pass_partition_search) {
-      perform_two_pass_partition_search(cpi, td, tile_data, tp, tp_chroma,
-                                        mi_row, mi_col);
+               av2_two_pass_part_enabled(&sf->part_sf)) {
+      // TODO(Yeqing): Add an SB-level heuristic to skip the second pass on
+      // SBs where a single pass is good enough, to reduce encoding time.
+      // Only the fast level opts into the extra re-split of unsplit blocks.
+      perform_two_pass_partition_search(
+          cpi, td, tile_data, tp, tp_chroma, mi_row, mi_col,
+          av2_two_pass_part_is_fast(&sf->part_sf));
     } else {
       perform_one_partition_pass(cpi, td, tile_data, tp, tp_chroma, mi_row,
                                  mi_col, SB_SINGLE_PASS, NULL);

--- a/av2/encoder/encodeframe_utils.h
+++ b/av2/encoder/encodeframe_utils.h
@@ -26,12 +26,6 @@
 extern "C" {
 #endif
 
-enum {
-  SB_SINGLE_PASS,  // Single pass encoding: all ctxs get updated normally
-  SB_DRY_PASS,     // First pass of multi-pass: does not update the ctxs
-  SB_WET_PASS      // Second pass of multi-pass: finalize and update the ctx
-} UENUM1BYTE(SB_MULTI_PASS_MODE);
-
 typedef struct {
   ENTROPY_CONTEXT a[MAX_MIB_SIZE * MAX_MB_PLANE];
   ENTROPY_CONTEXT l[MAX_MIB_SIZE * MAX_MB_PLANE];
@@ -181,6 +175,34 @@ typedef struct PartitionSearchState {
   PartitionTimingStats part_timing_stats;
 #endif  // CONFIG_COLLECT_PARTITION_STATS
 } PartitionSearchState;
+
+// Set the per-block two-pass flags from the SB pass mode. Called before every
+// pick_sb_modes so the flags stay in one place. The block-level dry-pass
+// shortcuts fire only on the fast two-pass level, not the conservative one.
+static AVM_INLINE void av2_set_two_pass_flags(
+    const AV2_COMP *cpi, MACROBLOCK *x, SB_MULTI_PASS_MODE multi_pass_mode,
+    const PartitionSearchState *part_search_state) {
+  const bool fast_two_pass = av2_two_pass_part_is_fast(&cpi->sf.part_sf);
+  x->apply_dry_pass_shortcuts =
+      fast_two_pass && (multi_pass_mode == SB_DRY_PASS);
+  const bool is_wet_pass_reuse =
+      (fast_two_pass && multi_pass_mode == SB_WET_PASS && part_search_state &&
+       part_search_state->forced_partition != PARTITION_INVALID);
+  if (x->apply_dry_pass_shortcuts) {
+    // Dry pass: rough shape ranking only.
+    x->intra_mode_prune_top = 1;
+    x->inter_mode_prune_top = 2;
+  } else if (is_wet_pass_reuse) {
+    // Wet pass reusing the dry-pass shape.
+    x->intra_mode_prune_top = 2;
+    x->inter_mode_prune_top = 4;
+  } else {
+    // Full pool.
+    x->intra_mode_prune_top =
+        cpi->sf.intra_sf.intra_pruning_with_mlp ? 4 : TOP_INTRA_MODEL_COUNT;
+    x->inter_mode_prune_top = TOP_MOTION_MODE_MODEL_COUNT;
+  }
+}
 
 static AVM_INLINE void update_wedge_mode_cdf(FRAME_CONTEXT *fc,
                                              const BLOCK_SIZE bsize,

--- a/av2/encoder/encoder_utils.c
+++ b/av2/encoder/encoder_utils.c
@@ -533,7 +533,6 @@ void av2_scale_references(AV2_COMP *cpi, const InterpFilter filter,
 }
 
 BLOCK_SIZE av2_select_sb_size(const AV2_COMP *const cpi) {
-  const AV2_COMMON *const cm = &cpi->common;
   const AV2EncoderConfig *const oxcf = &cpi->oxcf;
 
   if (oxcf->tool_cfg.superblock_size == AVM_SUPERBLOCK_SIZE_64X64)
@@ -545,28 +544,40 @@ BLOCK_SIZE av2_select_sb_size(const AV2_COMP *const cpi) {
 
   assert(oxcf->tool_cfg.superblock_size == AVM_SUPERBLOCK_SIZE_DYNAMIC);
 
+  BLOCK_SIZE chosen;
   if (oxcf->resize_cfg.resize_mode != RESIZE_NONE) {
     // Use the configured size (top resolution) for spatial layers or
     // on resize.
-    return AVMMIN(oxcf->frm_dim_cfg.width, oxcf->frm_dim_cfg.height) >= 720
-               ? BLOCK_256X256
-           : AVMMIN(oxcf->frm_dim_cfg.width, oxcf->frm_dim_cfg.height) > 480
-               ? BLOCK_128X128
-               : BLOCK_64X64;
+    chosen = AVMMIN(oxcf->frm_dim_cfg.width, oxcf->frm_dim_cfg.height) >= 720
+                 ? BLOCK_256X256
+             : AVMMIN(oxcf->frm_dim_cfg.width, oxcf->frm_dim_cfg.height) > 480
+                 ? BLOCK_128X128
+                 : BLOCK_64X64;
+  } else if (oxcf->speed > 1 && !av2_wants_two_pass_partition(oxcf)) {
+    // TODO(any): Possibly could improve this with a heuristic.
+    // When resize is on, 'cm->width / height' can change between calls, so we
+    // don't apply this heuristic there. Things break if superblock size
+    // changes between the first pass and second pass encoding, which is why
+    // this heuristic is not configured as a speed-feature. Two-pass partition
+    // search requires a large superblock, so the small-SB heuristic is
+    // guarded on the same predicate.
+    const AV2_COMMON *const cm = &cpi->common;
+    chosen = AVMMIN(cm->width, cm->height) > 480 ? BLOCK_128X128 : BLOCK_64X64;
+  } else {
+    chosen = AVMMIN(oxcf->frm_dim_cfg.width, oxcf->frm_dim_cfg.height) >= 720
+                 ? BLOCK_256X256
+                 : BLOCK_128X128;
   }
 
-  // TODO(any): Possibly could improve this with a heuristic.
-  // When resize is on, 'cm->width / height' can change between
-  // calls, so we don't apply this heuristic there.
-  // Things break if superblock size changes between the first pass and second
-  // pass encoding, which is why this heuristic is not configured as a
-  // speed-feature.
-  if (oxcf->resize_cfg.resize_mode == RESIZE_NONE && oxcf->speed > 1) {
-    return AVMMIN(cm->width, cm->height) > 480 ? BLOCK_128X128 : BLOCK_64X64;
+  // Never choose an SB larger than the shortest side of the frame. This
+  // avoids a known issue where two-pass partition on multi-layer content
+  // produces a malformed OBU when the SB spans a small frame.
+  const int short_side =
+      AVMMIN(oxcf->frm_dim_cfg.width, oxcf->frm_dim_cfg.height);
+  while (chosen != BLOCK_64X64 && block_size_wide[chosen] > short_side) {
+    chosen = (chosen == BLOCK_256X256) ? BLOCK_128X128 : BLOCK_64X64;
   }
-  return AVMMIN(oxcf->frm_dim_cfg.width, oxcf->frm_dim_cfg.height) >= 720
-             ? BLOCK_256X256
-             : BLOCK_128X128;
+  return chosen;
 }
 
 void reallocate_sb_size_dependent_buffers(AV2_COMP *cpi) {

--- a/av2/encoder/encoder_utils.h
+++ b/av2/encoder/encoder_utils.h
@@ -959,6 +959,17 @@ void av2_scale_references(AV2_COMP *cpi, const InterpFilter filter,
 
 void av2_setup_frame(AV2_COMP *cpi);
 
+// Config-time part of the TWO_PASS_PART_FAST predicate: GOOD mode at speed >= 3
+// on configs that produce inter frames. Kept config-only (no cm state) because
+// av2_select_sb_size() also keys off it, and the superblock size must not
+// change between the two passes.
+// TODO(Yeqing): Extend to intra/key frames and drop the all_intra guard.
+static INLINE bool av2_wants_two_pass_partition(const AV2EncoderConfig *oxcf) {
+  const int all_intra =
+      oxcf->kf_cfg.key_freq_max == 0 && oxcf->kf_cfg.key_freq_min == 0;
+  return oxcf->mode == GOOD && oxcf->speed >= 3 && !all_intra;
+}
+
 BLOCK_SIZE av2_select_sb_size(const AV2_COMP *const cpi);
 void set_ard_active_map(AV2_COMP *cpi);
 

--- a/av2/encoder/interp_search.c
+++ b/av2/encoder/interp_search.c
@@ -449,6 +449,12 @@ int64_t av2_interpolation_filter_search(
   *rd = RDCOST(x->rdmult, *switchable_rate + rd_stats.rate, rd_stats.dist);
   x->pred_sse[ref_frame] = (unsigned int)(rd_stats_luma.sse >> 4);
 
+  // Dry pass: keep the default interpolation filter instead of searching for
+  // one. The prediction above was already built with it.
+  if (x->apply_dry_pass_shortcuts) {
+    return 0;
+  }
+
   if (assign_filter != SWITCHABLE || match_found_idx != -1) {
     return 0;
   }

--- a/av2/encoder/interp_search.h
+++ b/av2/encoder/interp_search.h
@@ -46,6 +46,51 @@ typedef struct InterModeRdPair {
 #define NUM_USE_AMVD_OPTIONS 2
 /*!\endcond */
 
+/*! \brief Dry-pass caps for the two-pass partition search. */
+typedef struct {
+  /*! \brief Highest rank of inter reference searched (0-based). */
+  int ref_rank_cap;
+  /*! \brief Highest rank kept for same-ref compound on single-sided frames
+   * (both-sides frames drop same-ref compound entirely). */
+  int same_ref_compound_rank_cap;
+  /*! \brief Max ref MV candidates per reference. */
+  int ref_mv_set_cap;
+  /*! \brief Max WARP_DELTA reference candidates. */
+  int warp_ref_idx_cap;
+  /*! \brief Max WARP_DELTA precisions. */
+  int warp_precision_cap;
+  /*! \brief Max WARPMV-with-MVD choices. */
+  int warpmv_with_mvd_cap;
+  /*! \brief Max WARP inter-intra choices. */
+  int warp_inter_intra_cap;
+  /*! \brief Max CWP indices (1 => CWP_EQUAL only). */
+  int cwp_loop_cap;
+  /*! \brief Max jmvd scale index (0 => scale_mode 0 only). */
+  int jmvd_scale_cap;
+  /*! \brief Max BAWP flag (0 => BAWP off). */
+  int bawp_cap;
+  /*! \brief Max refinemv loop index (0 => refinemv_flag 0 only). */
+  int refinemv_cap;
+  /*! \brief Max dpcm index (0 => DPCM off). */
+  int intra_dpcm_cap;
+  /*! \brief Max fsc mode index (0 => FSC off). */
+  int intra_fsc_cap;
+  /*! \brief Max intra MRL index (0 => nearest reference line only). */
+  int intra_mrl_cap;
+  /*! \brief Bitmask of allowed MOTION_MODE values (default:
+   * SIMPLE_TRANSLATION). */
+  uint32_t motion_mode_mask;
+  /*! \brief Bitmask of allowed COMPOUND_TYPE values (default: AVERAGE|WEDGE).
+   */
+  uint32_t compound_type_mask;
+  /*! \brief Bitmask of allowed PREDICTION_MODE values in the dry pass. */
+  uint32_t inter_mode_mask;
+  /*! \brief Number of top MV precisions searched, from the highest. */
+  int precisions_from_top;
+  /*! \brief Cap on most-probable intra Y modes. */
+  int intra_mpm_cap;
+} DryPassCfg;
+
 /*!\brief Miscellaneous arguments for inter mode search.
  */
 typedef struct {
@@ -157,6 +202,9 @@ typedef struct {
 
   NEAR_NEWMV_AMVD_STATS near_newmv_amvd_stats[MAX_COMP_MV_STATS];
   int near_newmv_amvd_stats_idx;
+
+  /*! \brief Dry-pass caps, or NULL outside a dry pass. */
+  const DryPassCfg *dry_pass_cfg;
 } HandleInterModeArgs;
 
 /*!\cond */

--- a/av2/encoder/intra_mode_search.c
+++ b/av2/encoder/intra_mode_search.c
@@ -326,25 +326,29 @@ void av2_count_colors_highbd(const uint16_t *src, int stride, int rows,
 }
 
 bool prune_intra_y_mode(int64_t this_model_rd, int64_t *best_model_rd,
-                        int64_t top_intra_model_rd[], int k, int lossless,
-                        uint8_t use_dpcm_y) {
+                        int64_t top_intra_model_rd[], int prune_top,
+                        int lossless, uint8_t use_dpcm_y) {
   (void)lossless;
   assert(IMPLIES(use_dpcm_y != 0, lossless != 0));
+  assert(prune_top > 0);
   if (this_model_rd < *best_model_rd) *best_model_rd = this_model_rd;
   if (use_dpcm_y != 0) return false;
 
-  const double thresh_top = 1.00;
-  for (int i = 0; i < k; i++) {
+  // Only the top prune_top candidates get full RD; the rest are pruned.
+  const int threshold_slot = prune_top - 1;
+  // top_intra_model_rd[] holds the smallest model RDs seen so far, in
+  // ascending order, kept sorted up to threshold_slot.
+  for (int i = 0; i <= threshold_slot; i++) {
     if (this_model_rd < top_intra_model_rd[i]) {
-      for (int j = k - 1; j > i; j--) {
+      for (int j = threshold_slot; j > i; j--) {
         top_intra_model_rd[j] = top_intra_model_rd[j - 1];
       }
       top_intra_model_rd[i] = this_model_rd;
       break;
     }
   }
-  if (top_intra_model_rd[k - 1] != INT64_MAX &&
-      this_model_rd > thresh_top * top_intra_model_rd[k - 1])
+  if (top_intra_model_rd[threshold_slot] != INT64_MAX &&
+      this_model_rd > top_intra_model_rd[threshold_slot])
     return true;
 
   return false;
@@ -1032,8 +1036,8 @@ static INLINE int prune_intra_dip_mode(const AV2_COMP *cpi, MACROBLOCK *x,
   const MB_MODE_INFO *const mbmi = xd->mi[0];
   const int64_t this_model_rd = intra_model_yrd(cpi, x, bsize, mode_cost);
   if (prune_intra_y_mode(this_model_rd, best_model_rd, top_intra_model_rd,
-                         TOP_INTRA_MODEL_COUNT, xd->lossless[mbmi->segment_id],
-                         mbmi->use_dpcm_y))
+                         x->intra_mode_prune_top,
+                         xd->lossless[mbmi->segment_id], mbmi->use_dpcm_y))
     return 1;
   return 0;
 }
@@ -1242,9 +1246,8 @@ int64_t av2_handle_intra_mode(IntraModeSearchState *intra_search_state,
   }
 
   int64_t this_model_rd = intra_model_yrd(cpi, x, bsize, mode_cost);
-  const int k =
-      cpi->sf.intra_sf.intra_pruning_with_mlp ? 4 : TOP_INTRA_MODEL_COUNT;
-  if (prune_intra_y_mode(this_model_rd, best_model_rd, top_intra_model_rd, k,
+  if (prune_intra_y_mode(this_model_rd, best_model_rd, top_intra_model_rd,
+                         x->intra_mode_prune_top,
                          xd->lossless[mbmi->segment_id], mbmi->use_dpcm_y))
     return INT64_MAX;
   if (cpi->sf.intra_sf.intra_pruning_with_mlp && mbmi->mrl_index == 0 &&
@@ -1533,7 +1536,7 @@ void search_fsc_mode(const AV2_COMP *const cpi, MACROBLOCK *x, int *rate,
           this_model_rd = intra_model_yrd(cpi, x, bsize, mode_costs);
 
           if (prune_intra_y_mode(this_model_rd, best_model_rd,
-                                 top_intra_model_rd, TOP_INTRA_MODEL_COUNT,
+                                 top_intra_model_rd, x->intra_mode_prune_top,
                                  xd->lossless[mbmi->segment_id],
                                  mbmi->use_dpcm_y)) {
             continue;
@@ -1738,8 +1741,6 @@ int64_t av2_rd_pick_intra_sby_mode(const AV2_COMP *const cpi, ThreadData *td,
   mbmi->dpcm_mode_y = 0;
   // mbmi->dpcm_angle_delta = 0;
   //  Searches the intra-modes except for intrabc, palette, and filter_intra.
-  const int model_rd_k =
-      cpi->sf.intra_sf.intra_pruning_with_mlp ? 4 : TOP_INTRA_MODEL_COUNT;
   int64_t top_intra_model_rd[TOP_INTRA_MODEL_COUNT];
   for (int i = 0; i < TOP_INTRA_MODEL_COUNT; i++) {
     top_intra_model_rd[i] = INT64_MAX;
@@ -1854,9 +1855,10 @@ int64_t av2_rd_pick_intra_sby_mode(const AV2_COMP *const cpi, ThreadData *td,
           if (dpcm_index == 0) mode_costs += mrl_idx_cost;
           int64_t this_model_rd;
           this_model_rd = intra_model_yrd(cpi, x, bsize, mode_costs);
-          if (prune_intra_y_mode(
-                  this_model_rd, &best_model_rd, top_intra_model_rd, model_rd_k,
-                  xd->lossless[mbmi->segment_id], mbmi->use_dpcm_y))
+          if (prune_intra_y_mode(this_model_rd, &best_model_rd,
+                                 top_intra_model_rd, x->intra_mode_prune_top,
+                                 xd->lossless[mbmi->segment_id],
+                                 mbmi->use_dpcm_y))
             continue;
 
           if (cpi->sf.intra_sf.intra_pruning_with_mlp && mrl_idx == 0 &&

--- a/av2/encoder/intra_mode_search.h
+++ b/av2/encoder/intra_mode_search.h
@@ -387,14 +387,14 @@ void av2_count_colors_highbd(const uint16_t *src, int stride, int rows,
  *                                  far.
  * \param[in]    top_intra_model_rd Top intra model RD seen for this
  *                                  block so far.
- * \param[in]    k                  Number of top model RD candidates to
- *                                  keep in top_intra_model_rd.
+ * \param[in]    prune_top          Cap on the number of top candidates that
+ *                                  get full RD.
  * \param[in]    lossless           True if current block is lossless.
  * \param[in]    use_dpcm_y         True if block is lossless with DPCM mode.
  */
 bool prune_intra_y_mode(int64_t this_model_rd, int64_t *best_model_rd,
-                        int64_t top_intra_model_rd[], int k, int lossless,
-                        uint8_t use_dpcm_y);
+                        int64_t top_intra_model_rd[], int prune_top,
+                        int lossless, uint8_t use_dpcm_y);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -508,6 +508,12 @@ void av2_set_offsets(const AV2_COMP *const cpi, const TileInfo *const tile,
  * Pointer to structure holding coding contexts and chosen modes for the current
  * block \param[in]    best_rd        Upper bound of rd cost of a valid
  * partition
+ * \param[in]    multi_pass_mode     Multi-pass mode for the current superblock
+ *                                   (identifies which pass of the two-pass
+ *                                   partition search is active)
+ * \param[in]    part_search_state   Pointer to the current partition search
+ *                                   state; used to derive per-block two-pass
+ *                                   flags. May be NULL when not applicable.
  *
  * Nothing is returned. Instead, the chosen modes and contexts necessary
  * for reconstruction are stored in ctx, the rate-distortion stats are stored in
@@ -519,13 +525,18 @@ static void pick_sb_modes(AV2_COMP *const cpi, ThreadData *td,
                           int mi_row, int mi_col, RD_STATS *rd_cost,
                           REGION_TYPE cur_region_type,
                           int sb_root_partition_info, BLOCK_SIZE bsize,
-                          PICK_MODE_CONTEXT *ctx, RD_STATS best_rd) {
+                          PICK_MODE_CONTEXT *ctx, RD_STATS best_rd,
+                          SB_MULTI_PASS_MODE multi_pass_mode,
+                          const PartitionSearchState *part_search_state) {
   if (best_rd.rdcost < 0) {
     ctx->rd_stats.rdcost = INT64_MAX;
     ctx->rd_stats.skip_txfm = 0;
     av2_invalid_rd_stats(rd_cost);
     return;
   }
+
+  // Own the per-block two-pass flags here so every caller is covered.
+  av2_set_two_pass_flags(cpi, x, multi_pass_mode, part_search_state);
 
   AV2_COMMON *const cm = &cpi->common;
   const int num_planes = av2_num_planes(cm);
@@ -650,6 +661,7 @@ static void pick_sb_modes(AV2_COMP *const cpi, ThreadData *td,
     start_timing(cpi, av2_rd_pick_inter_mode_sb_time);
 #endif
     if (segfeature_active(&cm->seg, mbmi->segment_id, SEG_LVL_SKIP)) {
+      // SEG_LVL_SKIP blocks bypass the dry-pass shortcuts by design.
       av2_rd_pick_inter_mode_sb_seg_skip(cpi, tile_data, x, mi_row, mi_col,
                                          rd_cost, bsize, ctx, best_rd.rdcost);
     } else {
@@ -1892,9 +1904,9 @@ static void encode_sb(const AV2_COMP *const cpi, ThreadData *td,
           pc_tree->is_cfl_allowed_for_this_chroma |
           is_cfl_allowed_for_sdp(cm, xd, ptree_luma, partition, bsize);
   }
-  // If two pass partition tree is enable, then store the partition types in
-  // ptree even if it's dry run.
-  if (!dry_run || (cpi->sf.part_sf.two_pass_partition_search && ptree)) {
+  // On two-pass, store partition types in ptree even during a dry run so the
+  // second pass has a shape to start from.
+  if (!dry_run || (av2_two_pass_part_enabled(&cpi->sf.part_sf) && ptree)) {
     assert(ptree);
 
     ptree->partition = partition;
@@ -2470,7 +2482,7 @@ void av2_nonrd_use_partition(AV2_COMP *cpi, ThreadData *td,
     case PARTITION_NONE:
       pick_sb_modes(cpi, td, tile_data, x, mi_row, mi_col, &this_rdc,
                     pc_tree->region_type, pc_tree->sb_root_partition_info,
-                    bsize, ctx_none, best_rdc);
+                    bsize, ctx_none, best_rdc, SB_SINGLE_PASS, NULL);
       encode_b(cpi, tile_data, td, tp, mi_row, mi_col, OUTPUT_ENABLED, subsize,
                partition, ctx_none, &rate);
       break;
@@ -2684,7 +2696,7 @@ void av2_rd_use_partition(AV2_COMP *cpi, ThreadData *td, TileDataEnc *tile_data,
     case PARTITION_NONE:
       pick_sb_modes(cpi, td, tile_data, x, mi_row, mi_col, &last_part_rdc,
                     pc_tree->region_type, pc_tree->sb_root_partition_info,
-                    bsize, ctx_none, invalid_rdc);
+                    bsize, ctx_none, invalid_rdc, SB_SINGLE_PASS, NULL);
       break;
     case PARTITION_HORZ:
       pc_tree->horizontal[cur_region_type][0] = av2_alloc_pc_tree_node(
@@ -3917,7 +3929,8 @@ static void none_partition_search(
     RD_SEARCH_MACROBLOCK_CONTEXT *x_ctx,
     PartitionSearchState *part_search_state, RD_STATS *best_rdc,
     unsigned int *pb_source_variance, int64_t *none_rd, int64_t *part_none_rd,
-    LevelBanksRDO *level_banks, const PARTITION_TREE *ptree_luma) {
+    LevelBanksRDO *level_banks, const PARTITION_TREE *ptree_luma,
+    SB_MULTI_PASS_MODE multi_pass_mode) {
   const AV2_COMMON *const cm = &cpi->common;
   MACROBLOCK *const x = &td->mb;
   const int num_planes = av2_num_planes(cm);
@@ -4024,7 +4037,7 @@ static void none_partition_search(
   RD_STATS *this_rdc = &part_search_state->this_rdc;
   pick_sb_modes(cpi, td, tile_data, x, mi_row, mi_col, this_rdc, region_type,
                 pc_tree->sb_root_partition_info, bsize, *ctx_none,
-                best_remain_rdcost);
+                best_remain_rdcost, multi_pass_mode, part_search_state);
 
   for (int k = 0; k < NUMBER_OF_CACHED_MODES; k++) {
     x->inter_mode_cache[k] = NULL;
@@ -5434,10 +5447,29 @@ bool av2_rd_pick_partition(
   if (bsize == cm->sb_size)
     pc_tree->is_cfl_allowed_for_this_chroma = CFL_DISALLOWED_FOR_CHROMA;
 
+  int eff_max_recursion_depth = max_recursion_depth;
+  // Cap the wet-pass re-split at ~8x8 (short-side driven). Without a cap it
+  // recovers a bit of quality but gives back most of the speedup. This only
+  // triggers on TWO_PASS_PART_FAST: set_min_none_to_invalid() marks a node
+  // invalid either because it is below the 32x32 trust threshold (short side
+  // < 32, so the test below fails) or because the fast level re-opened an
+  // unsplit block.
+  if (template_tree && template_tree->partition == PARTITION_INVALID &&
+      AVMMIN(block_size_wide[bsize], block_size_high[bsize]) >= 32) {
+    const int floor_px = 8;
+    int mind = AVMMIN(block_size_wide[bsize], block_size_high[bsize]);
+    int levels = 0;
+    while (mind > floor_px) {
+      mind >>= 1;
+      levels++;
+    }
+    eff_max_recursion_depth = AVMMIN(eff_max_recursion_depth, levels);
+  }
+
   // Initialization of state variables used in partition search.
   init_partition_search_state_params(
       x, cpi, &part_search_state, pc_tree, ptree_luma, template_tree,
-      max_recursion_depth, mi_row, mi_col, bsize);
+      eff_max_recursion_depth, mi_row, mi_col, bsize);
 
   set_sms_tree_partitioning(sms_tree, PARTITION_NONE);
 
@@ -5641,7 +5673,8 @@ BEGIN_PARTITION_SEARCH:
       partition_none_allowed) {
     none_partition_search(cpi, td, tile_data, tp, pc_tree, sms_tree, &x_ctx,
                           &part_search_state, &best_rdc, &pb_source_variance,
-                          none_rd, &part_none_rd, &level_banks, ptree_luma);
+                          none_rd, &part_none_rd, &level_banks, ptree_luma,
+                          multi_pass_mode);
   }
   if (is_intra_child_of_mixed_region(pc_tree) && xd->tree_type == CHROMA_PART) {
     *rd_cost = best_rdc;
@@ -5654,7 +5687,7 @@ BEGIN_PARTITION_SEARCH:
   split_partition_search(cpi, td, tile_data, tp, pc_tree, sms_tree, &x_ctx,
                          &part_search_state, &best_rdc, multi_pass_mode,
                          &part_split_rd, &level_banks, ptree_luma,
-                         template_tree, max_recursion_depth - 1);
+                         template_tree, eff_max_recursion_depth - 1);
   prune_partitions_after_split(cpi, pc_tree, &part_search_state);
   if (!search_none_after_rect && !search_none_after_split &&
       partition_none_allowed) {
@@ -5680,7 +5713,8 @@ BEGIN_PARTITION_SEARCH:
       partition_none_allowed && search_none_after_split) {
     none_partition_search(cpi, td, tile_data, tp, pc_tree, sms_tree, &x_ctx,
                           &part_search_state, &best_rdc, &pb_source_variance,
-                          none_rd, &part_none_rd, &level_banks, ptree_luma);
+                          none_rd, &part_none_rd, &level_banks, ptree_luma,
+                          multi_pass_mode);
   }
 
   prune_rect_partitions(cpi, td, tile_data, pc_tree, &part_search_state,
@@ -5688,7 +5722,7 @@ BEGIN_PARTITION_SEARCH:
   // Search partitions horz and vert.
   rectangular_partition_search(
       cpi, td, tile_data, tp, pc_tree, &x_ctx, &part_search_state, &best_rdc,
-      multi_pass_mode, ptree_luma, template_tree, max_recursion_depth - 1,
+      multi_pass_mode, ptree_luma, template_tree, eff_max_recursion_depth - 1,
       rect_part_win_info, &level_banks, parent_partition
 #if CONFIG_ML_PART_SPLIT
       ,
@@ -5701,12 +5735,13 @@ BEGIN_PARTITION_SEARCH:
     prune_none_after_rect(&part_search_state, pc_tree);
     none_partition_search(cpi, td, tile_data, tp, pc_tree, sms_tree, &x_ctx,
                           &part_search_state, &best_rdc, &pb_source_variance,
-                          none_rd, &part_none_rd, &level_banks, ptree_luma);
+                          none_rd, &part_none_rd, &level_banks, ptree_luma,
+                          multi_pass_mode);
   }
 
   // Search extended partitions.
   const int ext_recur_depth = get_ext_partitions_recur_depth(
-      &cpi->sf.part_sf, bsize, max_recursion_depth, false);
+      &cpi->sf.part_sf, bsize, eff_max_recursion_depth, false);
   bool partition_boundaries[MAX_MIB_SQUARE] = { 0 };
 
   prune_ext_partitions_3way(cpi, pc_tree, &part_search_state,
@@ -5721,7 +5756,7 @@ BEGIN_PARTITION_SEARCH:
 
   if ((pc_tree->region_type != INTRA_REGION || frame_is_intra_only(cm))) {
     const int uneven_4way_recur_depth = get_ext_partitions_recur_depth(
-        &cpi->sf.part_sf, bsize, max_recursion_depth, true);
+        &cpi->sf.part_sf, bsize, eff_max_recursion_depth, true);
 
     prune_ext_partitions_4way(cpi, pc_tree, &part_search_state,
                               partition_boundaries);
@@ -5756,12 +5791,25 @@ BEGIN_PARTITION_SEARCH:
   }
 
 #if !defined(NDEBUG)
-  if (template_tree && template_tree->partition != PARTITION_INVALID &&
+  // Verify that the wet pass honoured the dry-pass template. This only holds
+  // when a valid partition was actually found: if the search failed, either
+  // because every partition was pruned or because none met the rd limit passed
+  // down from the parent, pc_tree->partitioning is still the PARTITION_NONE
+  // default from av2_alloc_pc_tree_node() and carries no meaning. That is a
+  // legitimate outcome -- the caller invalidates the rd stats and backs off
+  // (see rd_try_subblock_partition) -- so it must not trip the check. A real
+  // forcing violation still has found_best_partition set and is still caught.
+  if (part_search_state.found_best_partition && template_tree &&
+      template_tree->partition != PARTITION_INVALID &&
       pc_tree->partitioning != template_tree->partition) {
+    printf(
+        "Mismatch with template at fr: %d, mi: (%d, %d), BLOCK_%dX%d: "
+        "template %d, chose %d\n",
+        cm->current_frame.display_order_hint, mi_row, mi_col,
+        block_size_wide[bsize], block_size_high[bsize],
+        (int)template_tree->partition, (int)pc_tree->partitioning);
+    fflush(stdout);
     assert(0);
-    printf("Mismatch with template at fr: %d, mi: (%d, %d), BLOCK_%dX%d\n",
-           cm->current_frame.display_order_hint, mi_row, mi_col,
-           block_size_wide[bsize], block_size_high[bsize]);
   }
 #endif  // !defined(NDEBUG)
 

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -49,6 +49,7 @@
 #include "av2/encoder/av2_quantize.h"
 #include "av2/common/cost.h"
 #include "av2/encoder/compound_type.h"
+#include "av2/encoder/encodeframe_utils.h"
 #include "av2/encoder/encodemb.h"
 #include "av2/encoder/encodemv.h"
 #include "av2/encoder/encoder.h"
@@ -2212,13 +2213,16 @@ static int motion_mode_is_prune_exempt(const AV2_COMMON *const cm,
 static int prune_motion_mode(int64_t this_model_rd,
                              int64_t top_motion_mode_model_rd[],
                              const AV2_COMMON *const cm,
-                             const MACROBLOCKD *const xd, BLOCK_SIZE bsize) {
-  // top_motion_mode_model_rd[] holds the smallest model RDs seen so far in
-  // ascending order, padded with the INT64_MAX sentinel. Insert this_model_rd
-  // if it ranks among them.
-  for (int i = 0; i < TOP_MOTION_MODE_MODEL_COUNT; i++) {
+                             const MACROBLOCKD *const xd, BLOCK_SIZE bsize,
+                             int prune_top) {
+  assert(prune_top > 0);
+  // Only the top prune_top candidates get full RD; the rest are pruned.
+  const int threshold_slot = AVMMIN(prune_top, TOP_MOTION_MODE_MODEL_COUNT) - 1;
+  // top_motion_mode_model_rd[] holds the smallest model RDs seen so far,
+  // in ascending order, kept sorted up to threshold_slot.
+  for (int i = 0; i <= threshold_slot; i++) {
     if (this_model_rd < top_motion_mode_model_rd[i]) {
-      for (int j = TOP_MOTION_MODE_MODEL_COUNT - 1; j > i; j--) {
+      for (int j = threshold_slot; j > i; j--) {
         top_motion_mode_model_rd[j] = top_motion_mode_model_rd[j - 1];
       }
       top_motion_mode_model_rd[i] = this_model_rd;
@@ -2227,11 +2231,9 @@ static int prune_motion_mode(int64_t this_model_rd,
   }
   // Never prune the prune-exempt setting, even when its model RD does not rank.
   if (motion_mode_is_prune_exempt(cm, xd, bsize)) return 0;
-  // Did not rank: this_model_rd is >= every kept value. Prune only when it
-  // strictly exceeds the largest kept RD. An unfilled pool keeps the INT64_MAX
-  // sentinel in the last slot, which can never be exceeded, so it returns 0.
-  return this_model_rd >
-         top_motion_mode_model_rd[TOP_MOTION_MODE_MODEL_COUNT - 1];
+  // Did not rank: prune only if worse than every kept value. Caller must
+  // initialize top_motion_mode_model_rd[] to INT64_MAX so the pool fills first.
+  return this_model_rd > top_motion_mode_model_rd[threshold_slot];
 }
 
 // Records the best fast/full RD for a given (mode, refs) into the
@@ -3118,7 +3120,8 @@ static AVM_INLINE int evaluate_motion_mode_trial(
       int64_t est_rd =
           RDCOST(x->rdmult, rd_stats->rate + est_residue_cost, est_dist);
       update_inter_mode_rd(args, mbmi, est_rd, 1);
-      if (prune_motion_mode(est_rd, top_motion_mode_model_rd, cm, xd, bsize))
+      if (prune_motion_mode(est_rd, top_motion_mode_model_rd, cm, xd, bsize,
+                            x->inter_mode_prune_top))
         return -1;
     }
 
@@ -3265,6 +3268,7 @@ static int64_t motion_mode_rd(
   MACROBLOCKD *xd = &x->e_mbd;
   MB_MODE_INFO *mbmi = xd->mi[0];
   MB_MODE_INFO_EXT *mbmi_ext = x->mbmi_ext;
+  const DryPassCfg *const cfg = args->dry_pass_cfg;
   const int rate2_nocoeff = rd_stats->rate;
   const int rate_mv0 = mbmi->mode == WARPMV ? 0 : *rate_mv;
   assert(IMPLIES(mbmi->mode == WARPMV, (rate_mv0 == 0)));
@@ -3279,11 +3283,17 @@ static int64_t motion_mode_rd(
 
   int allowed_motion_modes = motion_mode_allowed(
       cm, xd, mbmi_ext->ref_mv_stack[mbmi->ref_frame[0]], mbmi);
-  const int modes_to_search =
-      (base_mbmi.mode == WARPMV || base_mbmi.mode == WARP_NEWMV)
-          ? allowed_motion_modes
-          : select_modes_to_search(cpi, allowed_motion_modes, eval_motion_mode,
-                                   args->skip_motion_mode);
+  // The dry pass uses simple translation only, except for the warp modes,
+  // which would produce an invalid prediction without a warp motion mode.
+  int modes_to_search;
+  if (base_mbmi.mode == WARPMV || base_mbmi.mode == WARP_NEWMV) {
+    modes_to_search = allowed_motion_modes;
+  } else if (x->apply_dry_pass_shortcuts) {
+    modes_to_search = cfg->motion_mode_mask;
+  } else {
+    modes_to_search = select_modes_to_search(
+        cpi, allowed_motion_modes, eval_motion_mode, args->skip_motion_mode);
+  }
 
   // Initialize shared trial context (constant across all trials)
   MotionModeTrialCtx ctx;
@@ -3320,8 +3330,12 @@ static int64_t motion_mode_rd(
         eval_motion_mode &&
         (mode_index == WARP_CAUSAL || mode_index == WARP_EXTEND))
       continue;
-    const int warp_ref_idx_limit =
+    int warp_ref_idx_limit =
         get_warp_ref_idx_limit(xd, &base_mbmi, mbmi_ext, mode_index);
+    // Dry pass: try only one warp reference candidate.
+    if (x->apply_dry_pass_shortcuts) {
+      warp_ref_idx_limit = AVMMIN(warp_ref_idx_limit, cfg->warp_ref_idx_cap);
+    }
 
     if (mode_index != WARP_DELTA) {
       // SIMPLE_TRANSLATION, WARP_CAUSAL, INTERINTRA, WARP_EXTEND:
@@ -3342,8 +3356,14 @@ static int64_t motion_mode_rd(
         previous_mvs[i].as_int = INVALID_MV;
       ctx.previous_mvs = previous_mvs;
       const int is_low_delay_enc = (cpi->oxcf.gf_cfg.lag_in_frames == 0);
-      const int warp_inter_intra_limit =
+      int warp_inter_intra_limit =
           1 + (allow_warp_inter_intra(&base_mbmi) && !is_low_delay_enc);
+      int warpmv_with_mvd_limit = 2;
+      // Dry pass: try only the first option of each extra warp choice.
+      if (x->apply_dry_pass_shortcuts) {
+        warp_inter_intra_limit = cfg->warp_inter_intra_cap;
+        warpmv_with_mvd_limit = cfg->warpmv_with_mvd_cap;
+      }
       for (int warp_inter_intra = 0; warp_inter_intra < warp_inter_intra_limit;
            warp_inter_intra++) {
         for (int warp_ref_idx = 0; warp_ref_idx < warp_ref_idx_limit;
@@ -3356,7 +3376,8 @@ static int64_t motion_mode_rd(
           assert(IMPLIES(cpi->sf.inter_sf.enable_warp_inter_intra_in_winner &&
                              !eval_motion_mode,
                          (!warp_inter_intra || warp_ref_idx >= 2)));
-          for (int warpmv_with_mvd_flag = 0; warpmv_with_mvd_flag < 2;
+          for (int warpmv_with_mvd_flag = 0;
+               warpmv_with_mvd_flag < warpmv_with_mvd_limit;
                warpmv_with_mvd_flag++) {
             const MotionModeTrialParams trial = {
               mode_index,           warp_ref_idx,     warp_ref_idx_limit,
@@ -3378,11 +3399,14 @@ static int64_t motion_mode_rd(
       warp_mode_info_array prev_best_models;
       reset_warp_stats_buffer(&prev_best_models);
       ctx.prev_best_models = &prev_best_models;
+      int warp_precision_limit = NUM_WARP_PRECISION_MODES;
+      // Dry pass: try only the first warp precision.
+      if (x->apply_dry_pass_shortcuts)
+        warp_precision_limit = cfg->warp_precision_cap;
       for (int warp_ref_idx = 0; warp_ref_idx < warp_ref_idx_limit;
            warp_ref_idx++) {
         for (int warp_precision_idx = 0;
-             warp_precision_idx < NUM_WARP_PRECISION_MODES;
-             warp_precision_idx++) {
+             warp_precision_idx < warp_precision_limit; warp_precision_idx++) {
           const MotionModeTrialParams trial = {
             mode_index, warp_ref_idx,      warp_ref_idx_limit, 0,
             0,          warp_precision_idx
@@ -4481,6 +4505,7 @@ static int process_compound_inter_mode(
   MACROBLOCKD *xd = &x->e_mbd;
   MB_MODE_INFO *mbmi = xd->mi[0];
   const AV2_COMMON *cm = &cpi->common;
+  const DryPassCfg *const cfg = args->dry_pass_cfg;
   const int masked_compound_used =
       is_any_masked_compound_used(bsize) &&
       cm->seq_params.enable_masked_compound &&
@@ -4491,6 +4516,11 @@ static int process_compound_inter_mode(
 
   if (get_cwp_idx(mbmi) != CWP_EQUAL) {
     mode_search_mask = (1 << COMPOUND_AVERAGE);
+  }
+  // Dry pass: restrict compound types. Only applied when CWP is CWP_EQUAL,
+  // since WEDGE is invalid otherwise.
+  if (x->apply_dry_pass_shortcuts && get_cwp_idx(mbmi) == CWP_EQUAL) {
+    mode_search_mask = cfg->compound_type_mask;
   }
   const int num_planes = av2_num_planes(cm);
   const int mi_row = xd->mi_row;
@@ -5246,6 +5276,7 @@ static int64_t handle_inter_mode(
   MB_MODE_INFO *mbmi = xd->mi[0];
   MB_MODE_INFO_EXT *const mbmi_ext = x->mbmi_ext;
   TxfmSearchInfo *txfm_info = &x->txfm_search_info;
+  const DryPassCfg *const cfg = args->dry_pass_cfg;
   const int is_comp_pred = has_second_ref(mbmi);
   const PREDICTION_MODE this_mode = mbmi->mode;
 
@@ -5297,6 +5328,11 @@ static int64_t handle_inter_mode(
   if (has_two_drls) {
     ref_set[1] = get_drl_refmv_count(cm->features.max_drl_bits, x,
                                      mbmi->ref_frame, this_mode, 1);
+  }
+  // Dry pass: look at no more than 2 reference MV candidates per reference.
+  if (x->apply_dry_pass_shortcuts) {
+    ref_set[0] = AVMMIN(ref_set[0], cfg->ref_mv_set_cap);
+    ref_set[1] = AVMMIN(ref_set[1], cfg->ref_mv_set_cap);
   }
 
   inter_mode_info mode_info[BAWP_OPTION_CNT][NUM_MV_PRECISIONS]
@@ -5465,6 +5501,9 @@ static int64_t handle_inter_mode(
 
   for (int scale_index = 0; scale_index < jmvd_scaling_factor_num;
        ++scale_index) {
+    // Dry pass: cap jmvd scale index.
+    if (x->apply_dry_pass_shortcuts && scale_index > cfg->jmvd_scale_cap)
+      continue;
     mbmi->jmvd_scale_mode = scale_index;
     if (is_joint_amvd_coding_mode(mbmi->mode, mbmi->use_amvd)) {
       if (scale_index > JOINT_AMVD_SCALE_FACTOR_CNT - 1) continue;
@@ -5500,6 +5539,8 @@ static int64_t handle_inter_mode(
         if (best_cwp_idxs[scale_index] == CWP_EQUAL &&
             (ref_mv_idx[0] > 0 || ref_mv_idx[1] > 0))
           cwp_loop_num = 1;
+        // Dry pass: use only cwp_idx == CWP_EQUAL (no CWP search).
+        if (x->apply_dry_pass_shortcuts) cwp_loop_num = cfg->cwp_loop_cap;
 
         int cwp_search_mask[MAX_CWP_NUM] = { 0 };
         av2_zero(cwp_search_mask);
@@ -5567,6 +5608,11 @@ static int64_t handle_inter_mode(
               continue;
             }
             assert(pb_mv_precision <= mbmi->max_mv_precision);
+            // Dry pass: try only the top N MV precisions.
+            if (x->apply_dry_pass_shortcuts &&
+                precision_dx <
+                    precision_def->num_precisions - cfg->precisions_from_top)
+              break;
 
             const int jmvd_scale_mode_cost =
                 get_jmvd_scale_mode_cost(mbmi, mode_costs);
@@ -5650,6 +5696,9 @@ static int64_t handle_inter_mode(
                                av2_allow_bawp(cm, mbmi, xd->mi_row, xd->mi_col);
             if (bawp_eanbled && av2_allow_explicit_bawp(mbmi))
               bawp_eanbled += EXPLICIT_BAWP_SCALE_CNT;
+            // Dry pass: cap BAWP flag (0 => BAWP off).
+            if (x->apply_dry_pass_shortcuts)
+              bawp_eanbled = AVMMIN(bawp_eanbled, cfg->bawp_cap);
             for (int bawp_flag = 0; bawp_flag <= bawp_eanbled; bawp_flag++) {
               if (mbmi->ref_mv_idx[0] > 0 && bawp_flag > 1 &&
                   best_mbmi.bawp_flag[0] == 0)
@@ -5780,6 +5829,10 @@ static int64_t handle_inter_mode(
 
                 for (int refinemv_loop = 0; refinemv_loop < REFINEMV_NUM_MODES;
                      refinemv_loop++) {
+                  // Dry pass: cap refinemv loop index.
+                  if (x->apply_dry_pass_shortcuts &&
+                      refinemv_loop > cfg->refinemv_cap)
+                    break;
                   if (refinemv_loop == 1 &&
                       (!switchable_refinemv_flag(cm, mbmi) ||
                        cpi->sf.inter_sf.disable_switchable_refinemv))
@@ -8577,7 +8630,9 @@ static void av2_evaluate_intra_modes_in_inter_frame(
     const struct AV2_COMP *cpi, MACROBLOCK *x, BLOCK_SIZE bsize,
     PICK_MODE_CONTEXT *ctx, int64_t inter_cost, int64_t intra_cost,
     InterModeSearchState *search_state, RD_STATS *rd_cost,
-    unsigned int intra_ref_frame_cost, int is_intra_mode_allowed) {
+    unsigned int intra_ref_frame_cost, int is_intra_mode_allowed,
+    const DryPassCfg *dry_pass_cfg) {
+  const bool apply_dry_pass_shortcuts = x->apply_dry_pass_shortcuts;
   const AV2_COMMON *const cm = &cpi->common;
   const SPEED_FEATURES *const sf = &cpi->sf;
   MACROBLOCKD *const xd = &x->e_mbd;
@@ -8648,12 +8703,18 @@ static void av2_evaluate_intra_modes_in_inter_frame(
     }
   }
   for (int dpcm_idx = 0; dpcm_idx < dpcm_loop_num; dpcm_idx++) {
+    // Dry pass: cap DPCM index.
+    if (apply_dry_pass_shortcuts && dpcm_idx > dry_pass_cfg->intra_dpcm_cap)
+      break;
     mbmi->use_dpcm_y = dpcm_idx;
     memset(search_state->intra_search_state.mrl0_dir_mode_survived, 0,
            sizeof(search_state->intra_search_state.mrl0_dir_mode_survived));
     for (int fsc_mode = 0;
          fsc_mode < (allow_fsc_intra(cm, bsize, mbmi) ? FSC_MODES : 1);
          fsc_mode++) {
+      // Dry pass: cap FSC mode index.
+      if (apply_dry_pass_shortcuts && fsc_mode > dry_pass_cfg->intra_fsc_cap)
+        break;
       uint8_t enable_mrls_flag = cm->seq_params.enable_mrls && !fsc_mode;
       const int num_mrl_indices = enable_mrls_flag ? MRL_LINE_NUMBER : 1;
       ModeRDInfoUV mode_rd_info_uv = { { false }, { 0 }, { 0 } };
@@ -8664,6 +8725,9 @@ static void av2_evaluate_intra_modes_in_inter_frame(
         av2_zero(mode_rd_info_uv.mode_evaluated);
       }
       for (int mrl_index = 0; mrl_index < num_mrl_indices; mrl_index++) {
+        // Dry pass: cap MRL index (0 => nearest reference line only).
+        if (apply_dry_pass_shortcuts && mrl_index > dry_pass_cfg->intra_mrl_cap)
+          break;
         if (mrl_index > 0 &&
             (xd->tree_type == CHROMA_PART ? mbmi->fsc_mode[PLANE_TYPE_Y]
                                           : fsc_mode)) {
@@ -8677,6 +8741,11 @@ static void av2_evaluate_intra_modes_in_inter_frame(
           if (!is_intra_mode_allowed) break;
           for (int mode_idx = INTRA_MODE_START; mode_idx < LUMA_MODE_COUNT;
                ++mode_idx) {
+            // Dry pass: only the top MPM intra modes, capped.
+            if (apply_dry_pass_shortcuts &&
+                mode_idx >= AVMMIN((int)mbmi->num_y_intra_mpm,
+                                   dry_pass_cfg->intra_mpm_cap))
+              break;
             if (sf->rt_sf.use_only_dc_intra_interframe && mode_idx != DC_PRED)
               continue;
             if (sf->intra_sf.skip_intra_in_interframe &&
@@ -8908,6 +8977,43 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
                                struct macroblock *x, struct RD_STATS *rd_cost,
                                BLOCK_SIZE bsize, PICK_MODE_CONTEXT *ctx,
                                int64_t best_rd_so_far) {
+  // WARNING: on the dry pass, all exits must go through dry_pass_cleanup —
+  // use `goto dry_pass_cleanup;` instead of `return`.
+  const bool apply_dry_pass_shortcuts = x->apply_dry_pass_shortcuts;
+
+  // Save rd_model for restore on exit; the dry pass forces FULL_TXFM_RD.
+  TXFM_RD_MODEL saved_rd_model = FULL_TXFM_RD;
+  // Dry-pass policy caps consulted by every gate below.
+  DryPassCfg dry_pass_cfg = { 0 };
+  if (apply_dry_pass_shortcuts) {
+    saved_rd_model = x->rd_model;
+    dry_pass_cfg = (DryPassCfg){
+      .ref_rank_cap = 1,
+      .same_ref_compound_rank_cap = 0,
+      .ref_mv_set_cap = 2,
+      .warp_ref_idx_cap = 1,
+      .warp_precision_cap = 1,
+      .warpmv_with_mvd_cap = 1,
+      .warp_inter_intra_cap = 1,
+      .cwp_loop_cap = 1,
+      .jmvd_scale_cap = 0,
+      .bawp_cap = 0,
+      .refinemv_cap = 0,
+      .intra_dpcm_cap = 0,
+      .intra_fsc_cap = 0,
+      .intra_mrl_cap = 0,
+      .motion_mode_mask = (1u << SIMPLE_TRANSLATION),
+      .compound_type_mask = (1u << COMPOUND_AVERAGE) | (1u << COMPOUND_WEDGE),
+      .inter_mode_mask = (1u << NEWMV) | (1u << NEW_NEWMV) | (1u << NEARMV) |
+                         (1u << NEAR_NEARMV) | (1u << WARPMV) |
+                         (1u << WARP_NEWMV),
+      .precisions_from_top = 3,
+      .intra_mpm_cap = 13,
+    };
+    // Keep the normal distortion measure; a cheaper one made the partition
+    // choices worse.
+    x->rd_model = FULL_TXFM_RD;
+  }
   AV2_COMMON *const cm = &cpi->common;
   const FeatureFlags *const features = &cm->features;
   const int num_planes = av2_num_planes(cm);
@@ -8960,6 +9066,7 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
     0,
     { { 0 } },
     0,
+    apply_dry_pass_shortcuts ? &dry_pass_cfg : NULL,
   };
 
   // Indicates the appropriate number of simple translation winner modes for
@@ -9080,10 +9187,14 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
   const InterModeRdModel *md = &tile_data->inter_mode_rd_models[bsize];
   // If do_tx_search is 0, only estimated RD should be computed.
   // If do_tx_search is 1, all modes have TX search performed.
+  // Dry pass: transform search stays on, but the settings above keep it cheap.
   const int do_tx_search =
-      !((cpi->sf.inter_sf.inter_mode_rd_model_estimation == 1 && md->ready) ||
-        (cpi->sf.inter_sf.inter_mode_rd_model_estimation == 2 &&
-         num_pels_log2_lookup[bsize] > 8));
+      apply_dry_pass_shortcuts
+          ? 1
+          : !((cpi->sf.inter_sf.inter_mode_rd_model_estimation == 1 &&
+               md->ready) ||
+              (cpi->sf.inter_sf.inter_mode_rd_model_estimation == 2 &&
+               num_pels_log2_lookup[bsize] > 8));
   InterModesInfo *inter_modes_info = x->inter_modes_info;
   inter_modes_info->num = 0;
 
@@ -9273,6 +9384,35 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
         continue;
     }
 
+    // Dry pass: search a small set of inter modes that still covers the range
+    // of MV costs, so the partition ranking matches a full search. Modes with
+    // an explicit MV difference, modes with a near-zero MV, and the warp modes
+    // are all represented. Searching only the explicit-MV modes made the dry
+    // pass split too much at high QP, and the more expensive optical-flow
+    // modes are not worth their cost here.
+    if (apply_dry_pass_shortcuts &&
+        !(dry_pass_cfg.inter_mode_mask & (1u << this_mode)))
+      continue;
+    // Dry pass: use the top ranks only. The eval order iterates rank indices
+    // 0..N-1 where rank 0 is the closest reference. TIP is always allowed
+    // because it is a different kind of prediction and can win on smooth
+    // content.
+    if (apply_dry_pass_shortcuts && is_inter_ref_frame(ref_frame) &&
+        ref_frame > dry_pass_cfg.ref_rank_cap && !is_tip_ref_frame(ref_frame))
+      continue;
+    // Dry pass: same limit for the second reference of a compound mode.
+    if (apply_dry_pass_shortcuts && is_inter_ref_frame(second_ref_frame) &&
+        second_ref_frame > dry_pass_cfg.ref_rank_cap)
+      continue;
+    // Dry pass: mostly skip compound modes that use the same reference twice.
+    // They pay for two MVs but rarely win the partition choice. When the frame
+    // has references on both sides they are dropped completely; otherwise the
+    // top same_ref_compound_rank_cap ranks are kept.
+    if (apply_dry_pass_shortcuts && is_comp_mode &&
+        ref_frame == second_ref_frame &&
+        (cm->has_both_sides_refs ||
+         ref_frame > dry_pass_cfg.same_ref_compound_rank_cap))
+      continue;
     if (this_mode == WARPMV && !warpmv_allowed) continue;
     if (this_mode == WARP_NEWMV && (!warpmv_allowed || !warp_newmv_allowed))
       continue;
@@ -9486,7 +9626,8 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
   }
   av2_evaluate_intra_modes_in_inter_frame(
       cpi, x, bsize, ctx, inter_cost, intra_cost, &search_state, rd_cost,
-      intra_ref_frame_cost, is_intra_mode_allowed);
+      intra_ref_frame_cost, is_intra_mode_allowed,
+      apply_dry_pass_shortcuts ? &dry_pass_cfg : NULL);
 
 #if CONFIG_COLLECT_COMPONENT_TIMING
   end_timing(cpi, handle_intra_mode_time);
@@ -9597,7 +9738,7 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
       search_state.best_rd >= best_rd_so_far) {
     rd_cost->rate = INT_MAX;
     rd_cost->rdcost = INT64_MAX;
-    return;
+    goto dry_pass_cleanup;
   }
 
   const InterpFilter interp_filter = features->interp_filter;
@@ -9661,6 +9802,10 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
   // TODO(urvang): Remove index from `palette_size` array, as palette is no
   // longer allowed for chroma.
   assert(mbmi->palette_mode_info.palette_size[1] == 0);
+dry_pass_cleanup:
+  if (apply_dry_pass_shortcuts) {
+    x->rd_model = saved_rd_model;
+  }
 }
 
 void av2_rd_pick_inter_mode_sb_seg_skip(const AV2_COMP *cpi,

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -15,6 +15,7 @@
 #include "av2/common/reconintra.h"
 
 #include "av2/encoder/encoder.h"
+#include "av2/encoder/encoder_utils.h"
 #include "av2/encoder/speed_features.h"
 #include "av2/encoder/rdopt.h"
 
@@ -768,7 +769,7 @@ static AVM_INLINE void init_part_sf(PARTITION_SPEED_FEATURES *part_sf) {
   part_sf->prune_part_4_horz_or_vert = 0;
   part_sf->prune_part_4_with_part_3 = 0;
   part_sf->prune_part_4b_with_part_4a = 0;
-  part_sf->two_pass_partition_search = 0;
+  part_sf->two_pass_partition_search = TWO_PASS_PART_OFF;
   part_sf->prune_rect_with_ml = 0;
   part_sf->partition_pruning_with_mlp = 0;
   part_sf->partition_pruning_with_mlp_none_thresh = 0.0f;
@@ -1400,30 +1401,10 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
 static AVM_INLINE void set_erp_speed_features_qindex_dependent(AV2_COMP *cpi) {
   SPEED_FEATURES *const sf = &cpi->sf;
   const AV2_COMMON *const cm = &cpi->common;
-  const int is_1080p_or_larger = AVMMIN(cm->width, cm->height) >= 1080;
-  const unsigned int erp_pruning_level = cpi->oxcf.part_cfg.erp_pruning_level;
   const int boosted = frame_is_boosted(cpi);
 
   const int qindex_offset = MAXQ_OFFSET * (cm->seq_params.bit_depth - 8);
-  const int qindex_thresh2 = 113 + qindex_offset;
   const int qindex_thresh3 = 135 + qindex_offset;
-
-  switch (erp_pruning_level) {
-    case 6: AVM_FALLTHROUGH_INTENDED;
-    case 5:
-      if (is_1080p_or_larger &&
-          cm->quant_params.base_qindex <= qindex_thresh2 &&
-          !frame_is_intra_only(cm)) {
-        sf->part_sf.two_pass_partition_search = 1;
-      }
-      AVM_FALLTHROUGH_INTENDED;
-    case 4: AVM_FALLTHROUGH_INTENDED;
-    case 3: AVM_FALLTHROUGH_INTENDED;
-    case 2: AVM_FALLTHROUGH_INTENDED;
-    case 1: AVM_FALLTHROUGH_INTENDED;
-    case 0: break;
-    default: assert(0 && "Invalid ERP pruning level.");
-  }
 
   if (cpi->speed == 1) {
     if (!boosted && cm->quant_params.base_qindex < qindex_thresh3) {
@@ -1433,6 +1414,42 @@ static AVM_INLINE void set_erp_speed_features_qindex_dependent(AV2_COMP *cpi) {
     if (frame_is_intra_only(cm) &&
         cm->quant_params.base_qindex >= qindex_thresh3)
       sf->part_sf.uneven_4way_recur_depth_level = 0;
+  }
+}
+
+// Pick the two-pass superblock partition search level for this frame. This is
+// the single decision point for the feature: it runs at the end of
+// av2_set_speed_features_qindex_dependent(), which is the last speed-feature
+// pass before av2_encode_frame(), so it sees the final frame type and qindex.
+static AVM_INLINE void set_two_pass_partition_level(AV2_COMP *cpi) {
+  const AV2_COMMON *const cm = &cpi->common;
+  int *const level = &cpi->sf.part_sf.two_pass_partition_search;
+
+  *level = TWO_PASS_PART_OFF;
+  // Both regimes only ever run on inter frames.
+  // TODO(Yeqing): Extend to intra/key frames.
+  if (frame_is_intra_only(cm)) return;
+
+  // The fast level takes precedence: it is the speed >= 3 regime, and
+  // av2_select_sb_size() keys the superblock size off the same config-time
+  // predicate, so the size and the level have to agree. Note that this
+  // predicate is GOOD-only, which is what keeps the fast level out of REALTIME
+  // mode even though set_rt_speed_features_framesize_independent() runs the
+  // GOOD setters.
+  if (av2_wants_two_pass_partition(&cpi->oxcf)) {
+    *level = TWO_PASS_PART_FAST;
+    return;
+  }
+
+  // The conservative level is deliberately not restricted to GOOD mode: it is
+  // reachable in REALTIME mode too, where it still affects the dry-run
+  // partition tree store even when the partition search itself is variance
+  // based.
+  const int qindex_thresh = 113 + MAXQ_OFFSET * (cm->seq_params.bit_depth - 8);
+  if (cpi->oxcf.part_cfg.erp_pruning_level >= 5 &&
+      AVMMIN(cm->width, cm->height) >= 1080 &&
+      cm->quant_params.base_qindex <= qindex_thresh) {
+    *level = TWO_PASS_PART_CONSERVATIVE;
   }
 }
 
@@ -1539,4 +1556,6 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
   set_erp_speed_features(cpi);
   set_erp_speed_features_framesize_dependent(cpi);
   set_erp_speed_features_qindex_dependent(cpi);
+
+  set_two_pass_partition_level(cpi);
 }

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -304,6 +304,21 @@ typedef struct GLOBAL_MOTION_SPEED_FEATURES {
   int disable_gm_search_based_on_stats;
 } GLOBAL_MOTION_SPEED_FEATURES;
 
+// Levels for the two-pass superblock partition search. In both enabled levels
+// the first ("dry") pass works out a rough partition shape down to 16x16, and
+// the second ("wet") pass codes the superblock for real while trusting the
+// dry-pass shape for blocks of 32x32 and larger.
+enum {
+  TWO_PASS_PART_OFF = 0,
+  // The dry pass runs the full tool set, and the wet pass trusts every shape
+  // of 32x32 and larger, including blocks the dry pass left unsplit.
+  TWO_PASS_PART_CONSERVATIVE = 1,
+  // The dry pass runs a reduced tool set (see DryPassCfg), and the wet pass
+  // re-searches unsplit blocks up to 128 px and narrows the mode pool on the
+  // shapes it reuses.
+  TWO_PASS_PART_FAST = 2,
+};
+
 typedef struct PARTITION_SPEED_FEATURES {
   PARTITION_SEARCH_TYPE partition_search_type;
 
@@ -399,6 +414,10 @@ typedef struct PARTITION_SPEED_FEATURES {
   // Prunes PARTITION_HORZ/VERT_4B based on PARTITION_HORZ/VERT_4A result.
   int prune_part_4b_with_part_4a;
 
+  // Two-pass superblock partition search level: one of TWO_PASS_PART_OFF,
+  // TWO_PASS_PART_CONSERVATIVE or TWO_PASS_PART_FAST. Decided once per frame in
+  // set_two_pass_partition_level(); read through av2_two_pass_part_enabled()
+  // and av2_two_pass_part_is_fast().
   int two_pass_partition_search;
 
   // Prunes rect partition with ml model
@@ -466,6 +485,20 @@ typedef struct PARTITION_SPEED_FEATURES {
   // Force the max partition-block aspect ratio
   unsigned int force_max_pb_aspect_ratio;
 } PARTITION_SPEED_FEATURES;
+
+// True when the two-pass superblock partition search runs at all.
+static INLINE bool av2_two_pass_part_enabled(
+    const PARTITION_SPEED_FEATURES *part_sf) {
+  return part_sf->two_pass_partition_search != TWO_PASS_PART_OFF;
+}
+
+// True when the two-pass search runs in its faster regime: a reduced-tool dry
+// pass, a wet pass that re-searches unsplit blocks, and a narrowed mode pool on
+// reused shapes.
+static INLINE bool av2_two_pass_part_is_fast(
+    const PARTITION_SPEED_FEATURES *part_sf) {
+  return part_sf->two_pass_partition_search >= TWO_PASS_PART_FAST;
+}
 
 typedef struct MV_SPEED_FEATURES {
   // Motion search method (Diamond, NSTEP, Hex, Big Diamond, Square, etc).

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -3406,7 +3406,8 @@ static AVM_INLINE void choose_largest_tx_size(const AV2_COMP *const cpi,
   const int64_t no_skip_txfm_rd = is_inter_block(mbmi, xd->tree_type)
                                       ? RDCOST(x->rdmult, no_skip_txfm_rate, 0)
                                       : 0;
-  const int skip_trellis = 0;
+  // Dry pass: skip trellis (no RDOQ) — light quant only.
+  const int skip_trellis = x->apply_dry_pass_shortcuts ? 1 : 0;
   av2_txfm_rd_in_plane(x, cpi, rd_stats, ref_best_rd,
                        AVMMIN(no_skip_txfm_rd, skip_txfm_rd), AVM_PLANE_Y, bs,
                        FTXS_NONE, skip_trellis);


### PR DESCRIPTION
Speed up the partition search by splitting it into two passes over each superblock.

The first pass (the "dry" pass) works out a rough partition shape. It runs mode search with a reduced set of tools, because it only has to rank shapes against each other, not produce the final coding decision. It stops at 16x16.

The second pass (the "wet" pass) codes the superblock for real, with the full set of tools. It keeps the first pass's shape for blocks of 32x32 and larger and searches the smaller blocks again, since that is where the first pass is least reliable. Large blocks the first pass left unsplit are also searched again, because a reduced tool set tends to under-split them, and trusting that would leave the block over-merged with no way to recover. That re-search is limited to blocks up to 128 and stops at 8x8, which keeps most of the time saved.

STATS_CHANGED

Anchor: commit 5b32726
Speed 4 (cpu-used=4): FG16 CTC (33 frames, class A1 and A2, RA)
Speed 3 (cpu-used=3): FG16 CTC (33 frames, class A1 and A2, RA)
Speed 2 (cpu-used=2): FG16 CTC (33 frames, class A1 and A2, RA)

```
    1) Speed 4 (cpu-used=4)
      +------------+-------+-------+-------+-------+------+------+
      | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
      +------------+-------+-------+-------+-------+------+------+
      | A1         | -0.09 | -2.32 | -2.75 | -0.35 |   86 |   86 |
      | A2         |  0.78 |  0.86 |  1.13 |  0.80 |   73 |   95 |
      | Avg w/o B2 |  0.52 | -0.08 | -0.02 |  0.46 |   77 |   93 |
      +------------+-------+-------+-------+-------+------+------+
    
    2) Speed 3 (cpu-used=3)
      +------------+-------+-------+-------+-------+------+------+
      | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
      +------------+-------+-------+-------+-------+------+------+
      | A1         | -0.03 | -2.27 | -2.79 | -0.29 |   93 |   88 |
      | A2         |  0.81 |  0.98 |  1.82 |  0.87 |   73 |   96 |
      | Avg w/o B2 |  0.56 |  0.02 |  0.45 |  0.53 |   79 |   94 |
      +------------+-------+-------+-------+-------+------+------+
    
    3) Speed 2 (cpu-used=2): Not satisfied: Score = 24.7
      +------------+-------+-------+-------+-------+------+------+
      | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
      +------------+-------+-------+-------+-------+------+------+
      | A1         |  0.39 | -1.90 | -2.76 |  0.11 |   94 |   89 |
      | A2         |  0.94 |  2.07 |  2.25 |  1.05 |   76 |   96 |
      | Avg w/o B2 |  0.77 |  0.89 |  0.77 |  0.77 |   81 |   94 |
      +------------+-------+-------+-------+-------+------+------+
```

Thus, it is only enabled for speed >= 3 in the current stage.