### PR TITLE
Optimize speed features to disable H / 4-way Partitions

### DIFF
--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2993,8 +2993,7 @@ static INLINE void accumulate_partition_timing_stats(
 
 static AVM_INLINE void init_allowed_partitions(
     PartitionSearchState *part_search_state, const PartitionCfg *part_cfg,
-    const SPEED_FEATURES *const sf, const int bru_skip,
-    const bool *partition_allowed) {
+    const int bru_skip, const bool *partition_allowed) {
   if (bru_skip) {
     part_search_state->is_block_splittable = false;
     part_search_state->do_rectangular_split = false;
@@ -3030,40 +3029,30 @@ static AVM_INLINE void init_allowed_partitions(
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT),
                    min_partition_size);
   part_search_state->partition_allowed[PARTITION_HORZ_3] =
-      !sf->part_sf.disable_ext_partitions &&
       partition_allowed[PARTITION_HORZ_3] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_3),
                    blk_params->min_partition_size) &&
       is_bsize_geq(get_h_partition_subsize(bsize, 1, PARTITION_HORZ_3),
                    blk_params->min_partition_size);
   part_search_state->partition_allowed[PARTITION_VERT_3] =
-      !sf->part_sf.disable_ext_partitions &&
       partition_allowed[PARTITION_VERT_3] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_3),
                    blk_params->min_partition_size) &&
       is_bsize_geq(get_h_partition_subsize(bsize, 1, PARTITION_VERT_3),
                    blk_params->min_partition_size);
   part_search_state->partition_allowed[PARTITION_HORZ_4A] =
-      !sf->part_sf.disable_ext_partitions &&
-      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_HORZ_4A] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_4A),
                    blk_params->min_partition_size);
   part_search_state->partition_allowed[PARTITION_HORZ_4B] =
-      !sf->part_sf.disable_ext_partitions &&
-      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_HORZ_4B] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_HORZ_4B),
                    blk_params->min_partition_size);
   part_search_state->partition_allowed[PARTITION_VERT_4A] =
-      !sf->part_sf.disable_ext_partitions &&
-      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_VERT_4A] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_4A),
                    blk_params->min_partition_size);
   part_search_state->partition_allowed[PARTITION_VERT_4B] =
-      !sf->part_sf.disable_ext_partitions &&
-      !sf->part_sf.disable_uneven_4way_partitions &&
       partition_allowed[PARTITION_VERT_4B] &&
       is_bsize_geq(get_partition_subsize(bsize, PARTITION_VERT_4B),
                    blk_params->min_partition_size);
@@ -3262,7 +3251,7 @@ static void init_partition_search_state_params(
       cm, x, mi_row, mi_col, bsize, ptree_luma, template_tree,
       pc_tree->region_type, partition_allowed);
   init_allowed_partitions(
-      part_search_state, &cpi->oxcf.part_cfg, &cpi->sf,
+      part_search_state, &cpi->oxcf.part_cfg,
       is_bru_not_active_and_not_on_partial_border(cm, mi_col, mi_row, bsize),
       partition_allowed);
 }
@@ -5616,7 +5605,7 @@ BEGIN_PARTITION_SEARCH:
         (pc_tree->parent ? pc_tree->parent->region_type : INTRA_REGION), mi_row,
         mi_col, ss_x, ss_y, bsize, &pc_tree->chroma_ref_info);
     init_allowed_partitions(
-        &part_search_state, &cpi->oxcf.part_cfg, &cpi->sf,
+        &part_search_state, &cpi->oxcf.part_cfg,
         is_bru_not_active_and_not_on_partial_border(cm, mi_col, mi_row, bsize),
         partition_allowed);
 #if CONFIG_ML_PART_SPLIT

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -1226,6 +1226,12 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
     cpi->common.seq_params.enable_masked_compound &=
         !sf->inter_sf.disable_masked_comp;
 
+    cpi->common.seq_params.enable_ext_partitions &=
+        !sf->part_sf.disable_ext_partitions;
+
+    cpi->common.seq_params.enable_uneven_4way_partitions &=
+        !sf->part_sf.disable_uneven_4way_partitions;
+
     if (sf->inter_sf.reduce_comp_refs) {
       cpi->common.seq_params.num_same_ref_compound =
           AVMMIN(cpi->common.seq_params.num_same_ref_compound, 1);


### PR DESCRIPTION
Use the sequence flag to normatively disable these instead of using encoder-only method.

Anchor: 8d9588497

### Speed 4,  AI CTC 5 frames:

```
+---------+--------+----------+
| Summary |  YUV   | Enc-time |
+---------+--------+----------+
| A1      | -0.04% |   100%   |
| A2      | -0.02% |   100%   |
| A3      | -0.04% |   100%   |
| A4      | -0.29% |   100%   |
| A5      | -0.09% |   100%   |
| B1      | -0.14% |   100%   |
| Avg     | -0.08% |   100%   |
+---------+--------+----------+
```

### Speed 4, RA CTC 33 frames:

```
+---------+--------+----------+
| Summary |  YUV   | Enc-time |
+---------+--------+----------+
| A1      | -0.06% |   100%   |
| A2      | -0.05% |   100%   |
| A3      | -0.15% |   100%   |
| A4      | -0.04% |   100%   |
| A5      | -0.14% |   100%   |
| B1      | -0.10% |   100%   |
| Avg     | -0.08% |   100%   |
+---------+--------+----------+
```
