### PR TITLE
Call memcpy() in avm_[highbd_]convolve_copy_*()

### DIFF
--- a/avm_dsp/avm_convolve.c
+++ b/avm_dsp/avm_convolve.c
@@ -115,7 +115,7 @@ void avm_highbd_convolve8_c(const uint16_t *src, ptrdiff_t src_stride,
 void avm_convolve_copy_c(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst,
                          ptrdiff_t dst_stride, int w, int h) {
   for (int r = h; r > 0; --r) {
-    memmove(dst, src, w);
+    memcpy(dst, src, w);
     src += src_stride;
     dst += dst_stride;
   }

--- a/avm_dsp/mips/avm_convolve_copy_msa.c
+++ b/avm_dsp/mips/avm_convolve_copy_msa.c
@@ -232,7 +232,7 @@ void avm_convolve_copy_msa(const uint8_t *src, ptrdiff_t src_stride,
     default: {
       uint32_t cnt;
       for (cnt = h; cnt--;) {
-        memmove(dst, src, w);
+        memcpy(dst, src, w);
         src += src_stride;
         dst += dst_stride;
       }

--- a/avm_dsp/x86/avm_convolve_copy_avx2.c
+++ b/avm_dsp/x86/avm_convolve_copy_avx2.c
@@ -32,20 +32,20 @@ void avm_convolve_copy_avx2(const uint8_t *src, ptrdiff_t src_stride,
 
   if (w == 2) {
     do {
-      memmove(dst, src, 2 * sizeof(*src));
+      memcpy(dst, src, 2 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
-      memmove(dst, src, 2 * sizeof(*src));
+      memcpy(dst, src, 2 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
       h -= 2;
     } while (h);
   } else if (w == 4) {
     do {
-      memmove(dst, src, 4 * sizeof(*src));
+      memcpy(dst, src, 4 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
-      memmove(dst, src, 4 * sizeof(*src));
+      memcpy(dst, src, 4 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
       h -= 2;
@@ -157,10 +157,10 @@ void avm_highbd_convolve_copy_avx2(const uint16_t *src, ptrdiff_t src_stride,
                                    int h) {
   if (w == 2) {
     do {
-      memmove(dst, src, 2 * sizeof(*src));
+      memcpy(dst, src, 2 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
-      memmove(dst, src, 2 * sizeof(*src));
+      memcpy(dst, src, 2 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
       h -= 2;

--- a/avm_dsp/x86/avm_convolve_copy_sse2.c
+++ b/avm_dsp/x86/avm_convolve_copy_sse2.c
@@ -40,20 +40,20 @@ void avm_convolve_copy_sse2(const uint8_t *src, ptrdiff_t src_stride,
 
   if (w == 2) {
     do {
-      memmove(dst, src, 2 * sizeof(*src));
+      memcpy(dst, src, 2 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
-      memmove(dst, src, 2 * sizeof(*src));
+      memcpy(dst, src, 2 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
       h -= 2;
     } while (h);
   } else if (w == 4) {
     do {
-      memmove(dst, src, 4 * sizeof(*src));
+      memcpy(dst, src, 4 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
-      memmove(dst, src, 4 * sizeof(*src));
+      memcpy(dst, src, 4 * sizeof(*src));
       src += src_stride;
       dst += dst_stride;
       h -= 2;


### PR DESCRIPTION
```
Call memcpy() instead of memmove() in avm_convolve_copy_*() and
avm_highbd_convolve_copy_*(). avm_highbd_convolve_copy_avx2() and 
avm_highbd_convolve_copy_sse2() do not handle overlapping src and dst 
buffers when w is 256, so it is not necessary to call memmove().
```