### PR TITLE
avm_highbd_upsampled_pred_c: Set temp to comp_pred

### DIFF
--- a/avm_dsp/variance.c
+++ b/avm_dsp/variance.c
@@ -550,8 +550,7 @@ void avm_highbd_upsampled_pred_c(MACROBLOCKD *xd,
     avm_highbd_convolve8_vert(ref, ref_stride, comp_pred, width, NULL, -1,
                               kernel, 16, width, height, bd);
   } else {
-    DECLARE_ALIGNED(16, uint16_t,
-                    temp[((MAX_SB_SIZE + 16) + 16) * MAX_SB_SIZE]);
+    uint16_t *temp = comp_pred;
     const int16_t *const kernel_x =
         av2_get_interp_filter_subpel_kernel(filter, subpel_x_q3 << 1);
     const int16_t *const kernel_y =


### PR DESCRIPTION
This ports libaom CL
https://aomedia-review.googlesource.com/c/aom/+/215601.

Use the heap allocated buffer `comp_pred` as a temporary buffer in avm_highbd_upsampled_pred_c(), as done in
avm_highbd_upsampled_pred_sse2().