### PR TITLE
Disable extended SDP at speed 2

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -429,6 +429,7 @@ static void set_good_speed_features_framesize_independent(
 
     sf->part_sf.disable_uneven_4way_partitions = true;
     sf->part_sf.disable_ext_partitions = true;
+    sf->part_sf.disable_extended_sdp = true;
 
     if (cpi->twopass.fr_content_type == FC_HIGHMOTION ||
         cpi->is_screen_content_type) {
@@ -776,6 +777,7 @@ static AVM_INLINE void init_part_sf(PARTITION_SPEED_FEATURES *part_sf) {
 #endif  // CONFIG_ML_PART_SPLIT
   part_sf->disable_ext_partitions = false;
   part_sf->disable_uneven_4way_partitions = false;
+  part_sf->disable_extended_sdp = false;
 }
 
 static AVM_INLINE void init_mv_sf(MV_SPEED_FEATURES *mv_sf) {
@@ -1223,6 +1225,10 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
 
     cpi->common.seq_params.enable_masked_compound &=
         !sf->inter_sf.disable_masked_comp;
+
+    if (sf->part_sf.disable_extended_sdp) {
+      cpi->common.seq_params.enable_extended_sdp = 0;
+    }
 
     if (sf->inter_sf.reduce_comp_refs) {
       cpi->common.seq_params.num_same_ref_compound =

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -461,6 +461,7 @@ typedef struct PARTITION_SPEED_FEATURES {
 
   bool disable_ext_partitions;
   bool disable_uneven_4way_partitions;
+  bool disable_extended_sdp;
 } PARTITION_SPEED_FEATURES;
 
 typedef struct MV_SPEED_FEATURES {


### PR DESCRIPTION
Extended SDP is disabled for speed >= 2.

Anchor: https://github.com/AOMediaCodec/avm/commit/e2810080c0208f323183e58126c3fee1802a7ac6
Tests: RA

cpu-used=2:
```
+---------+--------+--------+--------+--------+----------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time | Dec-time |
+---------+--------+--------+--------+--------+----------+----------+
| A1      |  0.01% | -0.15% |  0.06% |  0.00% | 98.6%    | 100%     |
| A2      |  0.00% |  0.14% |  0.74% |  0.03% | 98.4%    | 100%     |
+---------+--------+--------+--------+--------+----------+----------+
```

cpu-used=3:
```
+---------+--------+--------+--------+--------+----------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time | Dec-time |
+---------+--------+--------+--------+--------+----------+----------+
| A1      | -0.18% | -0.24% | -0.07% | -0.18% | 99.3%    | 101%     |
| A2      | -0.39% |  0.18% |  0.83% | -0.32% | 98.8%    | 101%     |
+---------+--------+--------+--------+--------+----------+----------+
```

cpu-used=4:
```
+---------+--------+--------+--------+--------+----------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time | Dec-time |
+---------+--------+--------+--------+--------+----------+----------+
| A1      | -0.08% | 0.03% | 0.00% | -0.07% | 98.3%    | 99%     |
| A2      | -0.14% |  0.14% |  0.86% | -0.10% | 98.6%    | 100%     |
+---------+--------+--------+--------+--------+----------+----------+
```