### PR TITLE
Handle near zero coefficients in tcq

### DIFF
--- a/av2/common/av2_rtcd_defs.pl
+++ b/av2/common/av2_rtcd_defs.pl
@@ -221,13 +221,21 @@ if (avm_config("CONFIG_AV2_ENCODER") eq "yes") {
   # trellis quant
   add_proto qw/void av2_decide_states/, "const struct tcq_node_t *prev, const struct tcq_rate_t *rd, const struct prequant_t *pq, int limits, int tru_eob, int64_t rdmult, struct tcq_node_t *decision";
   specialize qw/av2_decide_states avx2/;
+  add_proto qw/void av2_decide_states_q1/, "const struct tcq_node_t *prev, const struct tcq_rate_t *rd, const struct prequant_t *pq, int limits, int tru_eob, int64_t rdmult, struct tcq_node_t *decision";
+  specialize qw/av2_decide_states_q1 avx2/;
   add_proto qw/void av2_pre_quant/, "tran_low_t tqc, struct prequant_t* pqData, const int32_t* quant_ptr, int dqv, int log_scale, int scan_pos";
   specialize qw/av2_pre_quant avx2/;
+  add_proto qw/void av2_pre_quant_q1/, "tran_low_t tqc, struct prequant_t* pqData, const int32_t* quant_ptr, int dqv, int log_scale, int scan_pos";
+  specialize qw/av2_pre_quant_q1 avx2/;
 
   add_proto qw/void av2_get_rate_dist_def_luma/, "const struct tcq_param_t *p, const struct prequant_t *pq, const struct tcq_coeff_ctx_t *coeff_ctx, int blk_pos, int diag_ctx, int eob_rate, struct tcq_rate_t *rd";
   specialize qw/av2_get_rate_dist_def_luma avx2/;
+  add_proto qw/void av2_get_rate_dist_def_luma_q1/, "const struct tcq_param_t *p, const struct prequant_t *pq, const struct tcq_coeff_ctx_t *coeff_ctx, int blk_pos, int diag_ctx, int eob_rate, struct tcq_rate_t *rd";
+  specialize qw/av2_get_rate_dist_def_luma_q1 avx2/;
   add_proto qw/void av2_get_rate_dist_lf_luma/, "const struct tcq_param_t *p, const struct prequant_t *pq, const struct tcq_coeff_ctx_t *coeff_ctx, int blk_pos, int diag_ctx, int eob_rate, int coeff_sign, struct tcq_rate_t *rd";
   specialize qw/av2_get_rate_dist_lf_luma avx2/;
+  add_proto qw/void av2_get_rate_dist_lf_luma_q1/, "const struct tcq_param_t *p, const struct prequant_t *pq, const struct tcq_coeff_ctx_t *coeff_ctx, int blk_pos, int diag_ctx, int eob_rate, int coeff_sign, struct tcq_rate_t *rd";
+  specialize qw/av2_get_rate_dist_lf_luma_q1 avx2/;
   add_proto qw/void av2_update_states/, "const struct tcq_node_t *decision, int col, struct tcq_ctx_t *tcq_ctx";
   specialize qw/av2_update_states avx2/;
   add_proto qw/void av2_calc_block_eob_rate/, "struct macroblock *x, int plane, TX_SIZE tx_size, int eob, uint16_t *block_eob_rate";

--- a/av2/encoder/trellis_quant.c
+++ b/av2/encoder/trellis_quant.c
@@ -36,19 +36,30 @@ static AVM_INLINE void init_tcq_decision(tcq_node_t *decision) {
 // Initialize previous state storage to identity mapping.
 // As trellis decisions are made, magnitudes and
 // state transitions will be updated.
-static AVM_INLINE void init_tcq_ctx(struct tcq_ctx_t *tcq_ctx) {
+static AVM_INLINE void init_tcq_ctx(struct tcq_ctx_t *tcq_ctx,
+                                    const tcq_param_t *p, int si) {
+  int blk_pos = p->scan[si];
+  TX_SIZE tx_size = p->tx_size;
+  const int bwl = get_txb_bwl(tx_size);
+  const int row = blk_pos >> bwl;
+  const int col = blk_pos - (row << bwl);
+
+  int diag = AVMMIN(row + col, MAX_DIAG) + 2;
+  int ctx_array_size = diag << TCQ_N_STATES_LOG;
+
   static const int8_t init_st[4][TCQ_MAX_STATES] = {
     { 0, 1, 2, 3, 4, 5, 6, 7 },
     { 0, 1, 2, 3, 4, 5, 6, 7 },
     { 0, 1, 2, 3, 4, 5, 6, 7 },
     { 0, 1, 2, 3, 4, 5, 6, 7 },
   };
-  memset(&tcq_ctx->mag_base, 0, sizeof(tcq_ctx->mag_base));
-  memset(&tcq_ctx->mag_mid, 0, sizeof(tcq_ctx->mag_mid));
-  memset(&tcq_ctx->ctx, 0, sizeof(tcq_ctx->ctx));
-  memset(&tcq_ctx->lev_new, 0, sizeof(tcq_ctx->lev_new));
-  int n_elem = sizeof(tcq_ctx->prev_st) / sizeof(tcq_ctx->prev_st[0]);
-  for (int i = 0; i < n_elem; i += 4) {
+
+  memset(&tcq_ctx->mag_base, 0, ctx_array_size);
+  memset(&tcq_ctx->mag_mid, 0, ctx_array_size);
+  memset(&tcq_ctx->ctx, 0, ctx_array_size);
+  memset(&tcq_ctx->lev_new, 0, ctx_array_size);
+
+  for (int i = 0; i < diag; i += 4) {
     memcpy(tcq_ctx->prev_st[i], init_st, sizeof(init_st));
   }
 }
@@ -513,7 +524,7 @@ void av2_pre_quant_c(tran_low_t tqc, struct prequant_t *pqData,
   (void)scan_pos;
   // calculate qIdx
   tran_low_t abs_tqc = abs(tqc);
-  pqData->qIdx = AVMMAX(pqData->orig_qIdx - 1, 1);
+  pqData->qIdx = AVMMAX(pqData->orig_qIdx - 2, 1);
   int32_t qIdx = pqData->qIdx;
 
   const int64_t dist0 = get_coeff_dist(abs_tqc, 0, log_scale - 1);
@@ -674,9 +685,9 @@ void trellis_first_pos(const tcq_param_t *p, int scan_pos, tcq_ctx_t *tcq_ctx,
   int tempdqv = get_dqv(dequant, scan[scan_pos], iqmatrix);
   int shift = 16 - log_scale + QUANT_FP_BITS;
 
-  tran_low_t orig_qIdx = ((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0] +
-                          ((1 << shift) >> 1)) >>
-                         shift;
+  tran_low_t orig_qIdx =
+      (tran_low_t)(((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0]) >>
+                   shift);
   pqData.orig_qIdx = orig_qIdx;
 
   av2_pre_quant(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale, scan_pos);
@@ -968,9 +979,8 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
       int tempdqv = get_dqv(dequant, scan[scan_pos], iqmatrix);
 
       tran_low_t orig_qIdx =
-          ((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0] +
-           ((1 << shift) >> 1)) >>
-          shift;
+          (tran_low_t)(((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0]) >>
+                       shift);
       pqData.orig_qIdx = orig_qIdx;
 
       // Get coeff contexts
@@ -980,7 +990,7 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
       int eob_rate = block_eob_rate[scan_pos];
       tcq_rate_t rd;
 
-      if (pqData.orig_qIdx == 0) {
+      if (pqData.orig_qIdx < 2) {
         av2_pre_quant_q1(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
                          scan_pos);
         av2_get_rate_dist_def_luma_q1(p, &pqData, &coeff_ctx, blk_pos, diag_ctx,
@@ -1025,9 +1035,8 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
       int tempdqv = get_dqv(dequant, scan[scan_pos], iqmatrix);
 
       tran_low_t orig_qIdx =
-          ((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0] +
-           ((1 << shift) >> 1)) >>
-          shift;
+          (tran_low_t)(((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0]) >>
+                       shift);
       pqData.orig_qIdx = orig_qIdx;
 
       // Get coeff contexts
@@ -1037,7 +1046,7 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
       int eob_rate = block_eob_rate[scan_pos];
       tcq_rate_t rd;
 
-      if (pqData.orig_qIdx == 0) {
+      if (pqData.orig_qIdx < 2) {
         av2_pre_quant_q1(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
                          scan_pos);
         av2_get_rate_dist_lf_luma_q1(p, &pqData, &coeff_ctx, blk_pos, diag_ctx,
@@ -1336,7 +1345,7 @@ int av2_trellis_quant(const struct AV2_COMP *cpi, MACROBLOCK *x, int plane,
 
   // Buffers for diagonal contexts.
   tcq_ctx_t tcq_ctx;
-  init_tcq_ctx(&tcq_ctx);
+  init_tcq_ctx(&tcq_ctx, &param, first_scan_pos);
 
   // Process the first position
   trellis_first_pos(&param, first_scan_pos, &tcq_ctx, trellis);

--- a/av2/encoder/trellis_quant.c
+++ b/av2/encoder/trellis_quant.c
@@ -78,9 +78,9 @@ static INLINE int get_coeff_cost_eob(int ci, tran_low_t abs_qc, int sign,
   const int row = ci >> bwl;
   const int col = ci - (row << bwl);
   int limits = get_lf_limits(row, col, tx_class, plane);
-  const int (*base_lf_eob_cost_ptr)[LF_BASE_SYMBOLS - 1] =
+  const int(*base_lf_eob_cost_ptr)[LF_BASE_SYMBOLS - 1] =
       plane > 0 ? txb_costs->base_lf_eob_cost_uv : txb_costs->base_lf_eob_cost;
-  const int (*base_eob_cost_ptr)[3] =
+  const int(*base_eob_cost_ptr)[3] =
       plane > 0 ? txb_costs->base_eob_cost_uv : txb_costs->base_eob_cost;
 
   cost += limits ? base_lf_eob_cost_ptr[coeff_ctx]
@@ -136,8 +136,8 @@ static INLINE int get_coeff_cost_def(tran_low_t abs_qc, int coeff_ctx,
   int base_ctx = get_base_diag_ctx(diag_ctx) + get_base_ctx(coeff_ctx);
   int mid_ctx = get_mid_ctx(coeff_ctx);
 
-  const int (*base_cost_ptr)[TCQ_CTXS][8] = txb_costs->base_cost;
-  const int (*base_cost_uv_ptr)[8] = txb_costs->base_cost_uv;
+  const int(*base_cost_ptr)[TCQ_CTXS][8] = txb_costs->base_cost;
+  const int(*base_cost_uv_ptr)[8] = txb_costs->base_cost_uv;
   int cost = plane > 0 ? base_cost_uv_ptr[base_ctx][AVMMIN(abs_qc, 3)]
                        : base_cost_ptr[base_ctx][q_i][AVMMIN(abs_qc, 3)];
 
@@ -162,9 +162,9 @@ static INLINE int get_coeff_cost_general(int ci, tran_low_t abs_qc, int sign,
                                          const int32_t *tmp_sign, int plane,
                                          int limits, int q_i) {
   int cost = 0;
-  const int (*base_lf_cost_ptr)[TCQ_CTXS][LF_BASE_SYMBOLS * 2] =
+  const int(*base_lf_cost_ptr)[TCQ_CTXS][LF_BASE_SYMBOLS * 2] =
       txb_costs->base_lf_cost;
-  const int (*base_lf_cost_uv_ptr)[LF_BASE_SYMBOLS * 2] =
+  const int(*base_lf_cost_uv_ptr)[LF_BASE_SYMBOLS * 2] =
       txb_costs->base_lf_cost_uv;
   int base_lf_cost =
       plane > 0
@@ -172,8 +172,8 @@ static INLINE int get_coeff_cost_general(int ci, tran_low_t abs_qc, int sign,
           : base_lf_cost_ptr[coeff_ctx][q_i]
                             [AVMMIN(abs_qc, LF_BASE_SYMBOLS - 1)];
 
-  const int (*base_cost_ptr)[TCQ_CTXS][8] = txb_costs->base_cost;
-  const int (*base_cost_uv_ptr)[8] = txb_costs->base_cost_uv;
+  const int(*base_cost_ptr)[TCQ_CTXS][8] = txb_costs->base_cost;
+  const int(*base_cost_uv_ptr)[8] = txb_costs->base_cost_uv;
   int base_cost = plane > 0 ? base_cost_uv_ptr[coeff_ctx][AVMMIN(abs_qc, 3)]
                             : base_cost_ptr[coeff_ctx][q_i][AVMMIN(abs_qc, 3)];
 
@@ -411,10 +411,10 @@ void av2_decide_states_c(const struct tcq_node_t *prev,
 }
 
 void av2_decide_states_q1_c(const struct tcq_node_t *prev,
-                             const struct tcq_rate_t *rd,
-                             const struct prequant_t *pq, int limits,
-                             int try_eob, int64_t rdmult,
-                             struct tcq_node_t *decision) {
+                            const struct tcq_rate_t *rd,
+                            const struct prequant_t *pq, int limits,
+                            int try_eob, int64_t rdmult,
+                            struct tcq_node_t *decision) {
   const int32_t *rate = rd->rate;
   const int32_t *rate_zero = rd->rate_zero;
   const int32_t *rate_eob = rd->rate_eob;
@@ -479,8 +479,8 @@ void av2_decide_states_q1_c(const struct tcq_node_t *prev,
 }
 
 void av2_pre_quant_q1_c(tran_low_t tqc, struct prequant_t *pqData,
-                         const int32_t *quant_ptr, int dqv, int log_scale,
-                         int scan_pos) {
+                        const int32_t *quant_ptr, int dqv, int log_scale,
+                        int scan_pos) {
   // calculate qIdx
   (void)quant_ptr;
   (void)scan_pos;
@@ -509,15 +509,12 @@ void av2_pre_quant_q1_c(tran_low_t tqc, struct prequant_t *pqData,
 void av2_pre_quant_c(tran_low_t tqc, struct prequant_t *pqData,
                      const int32_t *quant_ptr, int dqv, int log_scale,
                      int scan_pos) {
+  (void)quant_ptr;
+  (void)scan_pos;
   // calculate qIdx
-  const int shift = 16 - log_scale + QUANT_FP_BITS;
-  tran_low_t add = -((2 << shift) >> 1);
   tran_low_t abs_tqc = abs(tqc);
-
-  tran_low_t qIdx = (int)AVMMAX(
-      1, AVMMIN(INT16_MAX,
-                ((int64_t)abs_tqc * quant_ptr[scan_pos != 0] + add) >> shift));
-  pqData->qIdx = qIdx;
+  pqData->qIdx = AVMMAX(pqData->orig_qIdx - 1, 1);
+  int32_t qIdx = pqData->qIdx;
 
   const int64_t dist0 = get_coeff_dist(abs_tqc, 0, log_scale - 1);
 
@@ -675,6 +672,13 @@ void trellis_first_pos(const tcq_param_t *p, int scan_pos, tcq_ctx_t *tcq_ctx,
 
   prequant_t pqData;
   int tempdqv = get_dqv(dequant, scan[scan_pos], iqmatrix);
+  int shift = 16 - log_scale + QUANT_FP_BITS;
+
+  tran_low_t orig_qIdx = ((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0] +
+                          ((1 << shift) >> 1)) >>
+                         shift;
+  pqData.orig_qIdx = orig_qIdx;
+
   av2_pre_quant(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale, scan_pos);
 
   // init state
@@ -979,8 +983,8 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
       if (pqData.orig_qIdx == 0) {
         av2_pre_quant_q1(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
                          scan_pos);
-        av2_get_rate_dist_def_luma_q1(p, &pqData, &coeff_ctx, blk_pos,
-                                      diag_ctx, eob_rate, &rd);
+        av2_get_rate_dist_def_luma_q1(p, &pqData, &coeff_ctx, blk_pos, diag_ctx,
+                                      eob_rate, &rd);
         av2_decide_states_q1(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
                              decision);
       } else {

--- a/av2/encoder/trellis_quant.c
+++ b/av2/encoder/trellis_quant.c
@@ -78,9 +78,9 @@ static INLINE int get_coeff_cost_eob(int ci, tran_low_t abs_qc, int sign,
   const int row = ci >> bwl;
   const int col = ci - (row << bwl);
   int limits = get_lf_limits(row, col, tx_class, plane);
-  const int(*base_lf_eob_cost_ptr)[LF_BASE_SYMBOLS - 1] =
+  const int (*base_lf_eob_cost_ptr)[LF_BASE_SYMBOLS - 1] =
       plane > 0 ? txb_costs->base_lf_eob_cost_uv : txb_costs->base_lf_eob_cost;
-  const int(*base_eob_cost_ptr)[3] =
+  const int (*base_eob_cost_ptr)[3] =
       plane > 0 ? txb_costs->base_eob_cost_uv : txb_costs->base_eob_cost;
 
   cost += limits ? base_lf_eob_cost_ptr[coeff_ctx]
@@ -136,8 +136,8 @@ static INLINE int get_coeff_cost_def(tran_low_t abs_qc, int coeff_ctx,
   int base_ctx = get_base_diag_ctx(diag_ctx) + get_base_ctx(coeff_ctx);
   int mid_ctx = get_mid_ctx(coeff_ctx);
 
-  const int(*base_cost_ptr)[TCQ_CTXS][8] = txb_costs->base_cost;
-  const int(*base_cost_uv_ptr)[8] = txb_costs->base_cost_uv;
+  const int (*base_cost_ptr)[TCQ_CTXS][8] = txb_costs->base_cost;
+  const int (*base_cost_uv_ptr)[8] = txb_costs->base_cost_uv;
   int cost = plane > 0 ? base_cost_uv_ptr[base_ctx][AVMMIN(abs_qc, 3)]
                        : base_cost_ptr[base_ctx][q_i][AVMMIN(abs_qc, 3)];
 
@@ -162,9 +162,9 @@ static INLINE int get_coeff_cost_general(int ci, tran_low_t abs_qc, int sign,
                                          const int32_t *tmp_sign, int plane,
                                          int limits, int q_i) {
   int cost = 0;
-  const int(*base_lf_cost_ptr)[TCQ_CTXS][LF_BASE_SYMBOLS * 2] =
+  const int (*base_lf_cost_ptr)[TCQ_CTXS][LF_BASE_SYMBOLS * 2] =
       txb_costs->base_lf_cost;
-  const int(*base_lf_cost_uv_ptr)[LF_BASE_SYMBOLS * 2] =
+  const int (*base_lf_cost_uv_ptr)[LF_BASE_SYMBOLS * 2] =
       txb_costs->base_lf_cost_uv;
   int base_lf_cost =
       plane > 0
@@ -172,8 +172,8 @@ static INLINE int get_coeff_cost_general(int ci, tran_low_t abs_qc, int sign,
           : base_lf_cost_ptr[coeff_ctx][q_i]
                             [AVMMIN(abs_qc, LF_BASE_SYMBOLS - 1)];
 
-  const int(*base_cost_ptr)[TCQ_CTXS][8] = txb_costs->base_cost;
-  const int(*base_cost_uv_ptr)[8] = txb_costs->base_cost_uv;
+  const int (*base_cost_ptr)[TCQ_CTXS][8] = txb_costs->base_cost;
+  const int (*base_cost_uv_ptr)[8] = txb_costs->base_cost_uv;
   int base_cost = plane > 0 ? base_cost_uv_ptr[coeff_ctx][AVMMIN(abs_qc, 3)]
                             : base_cost_ptr[coeff_ctx][q_i][AVMMIN(abs_qc, 3)];
 
@@ -303,6 +303,32 @@ static void update_node_general(int64_t costA, int64_t costB, int64_t cost_zero,
   }
 }
 
+static void update_node_q1(int64_t costB, int64_t cost_zero, int rateB,
+                           int rate_zero, tran_low_t absB, int limits,
+                           int prev_rate, int prev_state,
+                           tcq_node_t *decision_0, tcq_node_t *decision_1) {
+  assert(tcq_parity(absB) == 1);
+
+  (void)limits;
+  int even_bias = 1;
+  rateB += prev_rate;
+  rate_zero += prev_rate;
+
+  if (cost_zero < decision_0->rdCost + even_bias) {
+    decision_0->rdCost = cost_zero;
+    decision_0->rate = rate_zero;
+    decision_0->prevId = prev_state;
+    decision_0->absLevel = 0;
+  }
+
+  if (costB < decision_1->rdCost) {
+    decision_1->rdCost = costB;
+    decision_1->rate = rateB;
+    decision_1->prevId = prev_state;
+    decision_1->absLevel = absB;
+  }
+}
+
 // Evaluate NEW_EOB at the current position
 static void decide_eob(int64_t costA, int64_t costB, int rateA, int rateB,
                        tran_low_t absA, tran_low_t absB, tcq_node_t *decision_0,
@@ -382,6 +408,98 @@ void av2_decide_states_c(const struct tcq_node_t *prev,
                pq->absLevel[0], pq->absLevel[2], &decision[state0],
                &decision[state1]);
   }
+}
+
+void av2_decide_states_q1(const struct tcq_node_t *prev,
+                          const struct tcq_rate_t *rd,
+                          const struct prequant_t *pq, int limits, int try_eob,
+                          int64_t rdmult, struct tcq_node_t *decision) {
+  const int32_t *rate = rd->rate;
+  const int32_t *rate_zero = rd->rate_zero;
+  const int32_t *rate_eob = rd->rate_eob;
+  int64_t rdCost[2 * TCQ_MAX_STATES];
+  int64_t rdCost_zero[TCQ_MAX_STATES];
+  int64_t rdCost_eob[2];
+
+  // Init to 0 to avoid ASAN uninitialization warnings
+  memset(rdCost, 0, sizeof(rdCost));
+  memset(rdCost_zero, 0, sizeof(rdCost_zero));
+  init_tcq_decision(decision);
+
+  for (int i = 0; i < TCQ_N_STATES; i++) {
+    int a0 = tcq_quant(i);
+    int a1 = a0 + 2;
+    rdCost_zero[i] = prev[i].rdCost + RDCOST(rdmult, rate_zero[i], 0);
+
+    if (a0 == 1) {
+      rdCost[2 * i] =
+          prev[i].rdCost + RDCOST(rdmult, rate[2 * i], pq->deltaDist[a0]);
+    } else {
+      rdCost[2 * i + 1] =
+          prev[i].rdCost + RDCOST(rdmult, rate[2 * i + 1], pq->deltaDist[a1]);
+    }
+  }
+  rdCost_eob[0] = RDCOST(rdmult, rate_eob[0], pq->deltaDist[0]);
+  rdCost_eob[1] = RDCOST(rdmult, rate_eob[1], pq->deltaDist[2]);
+
+  update_node_q1(rdCost[1], rdCost_zero[0], rate[1], rate_zero[0],
+                 pq->absLevel[2], limits, prev[0].rate, 0, &decision[0],
+                 &decision[4]);
+  update_node_q1(rdCost[3], rdCost_zero[1], rate[3], rate_zero[1],
+                 pq->absLevel[2], limits, prev[1].rate, 1, &decision[4],
+                 &decision[0]);
+  update_node_q1(rdCost[4], rdCost_zero[2], rate[4], rate_zero[2],
+                 pq->absLevel[1], limits, prev[2].rate, 2, &decision[1],
+                 &decision[5]);
+  update_node_q1(rdCost[6], rdCost_zero[3], rate[6], rate_zero[3],
+                 pq->absLevel[1], limits, prev[3].rate, 3, &decision[5],
+                 &decision[1]);
+  update_node_q1(rdCost[9], rdCost_zero[4], rate[9], rate_zero[4],
+                 pq->absLevel[2], limits, prev[4].rate, 4, &decision[6],
+                 &decision[2]);
+  update_node_q1(rdCost[11], rdCost_zero[5], rate[11], rate_zero[5],
+                 pq->absLevel[2], limits, prev[5].rate, 5, &decision[2],
+                 &decision[6]);
+  update_node_q1(rdCost[12], rdCost_zero[6], rate[12], rate_zero[6],
+                 pq->absLevel[1], limits, prev[6].rate, 6, &decision[7],
+                 &decision[3]);
+  update_node_q1(rdCost[14], rdCost_zero[7], rate[14], rate_zero[7],
+                 pq->absLevel[1], limits, prev[7].rate, 7, &decision[3],
+                 &decision[7]);
+
+  if (try_eob) {
+    if (rdCost_eob[1] < decision[4].rdCost) {
+      decision[4].rdCost = rdCost_eob[1];
+      decision[4].rate = rate_eob[1];
+      decision[4].prevId = -1;
+      decision[4].absLevel = pq->absLevel[2];
+    }
+  }
+}
+
+void av2_pre_quant_q1(tran_low_t tqc, struct prequant_t *pqData,
+                      const int32_t *quant_ptr, int dqv, int log_scale,
+                      int scan_pos) {
+  // calculate qIdx
+  (void)quant_ptr;
+  (void)scan_pos;
+  tran_low_t abs_tqc = abs(tqc);
+
+  pqData->qIdx = 1;
+
+  const int64_t dist0 = get_coeff_dist(abs_tqc, 0, log_scale - 1);
+
+  tran_low_t dqca =
+      (tran_low_t)ROUND_POWER_OF_TWO_64(dqv, QUANT_TABLE_BITS) >> log_scale;
+
+  pqData->absLevel[1] = 1;
+  pqData->deltaDist[1] = get_coeff_dist(abs_tqc, dqca, log_scale - 1) - dist0;
+
+  tran_low_t dqcb =
+      (tran_low_t)ROUND_POWER_OF_TWO_64(dqv << 1, QUANT_TABLE_BITS) >>
+      log_scale;
+  pqData->absLevel[2] = 1;
+  pqData->deltaDist[2] = get_coeff_dist(abs_tqc, dqcb, log_scale - 1) - dist0;
 }
 
 // Prepare 4 quant candidates for each coeff
@@ -602,6 +720,87 @@ void trellis_first_pos(const tcq_param_t *p, int scan_pos, tcq_ctx_t *tcq_ctx,
   }
 }
 
+void av2_get_rate_dist_lf_luma_q1_c(const struct tcq_param_t *p,
+                                    const struct prequant_t *pq,
+                                    const struct tcq_coeff_ctx_t *coeff_ctx,
+                                    int blk_pos, int diag_ctx, int eob_rate,
+                                    int coeff_sign, struct tcq_rate_t *rd) {
+  const tran_low_t *absLevel = pq->absLevel;
+  const LV_MAP_COEFF_COST *txb_costs = p->txb_costs;
+  const int32_t *tmp_sign = p->tmp_sign;
+  TX_CLASS tx_class = p->tx_class;
+  int bwl = p->bwl;
+  int dc_sign_ctx = p->dc_sign_ctx;
+  int t_sign = tmp_sign[blk_pos];
+  int plane = 0;
+
+  for (int i = 0; i < TCQ_N_STATES; i++) {
+    int q_i = tcq_quant(i);
+    int base_ctx =
+        get_base_diag_ctx(diag_ctx) + get_base_ctx(coeff_ctx->coef[i]);
+    int mid_ctx = get_mid_diag_ctx(diag_ctx) + get_mid_ctx(coeff_ctx->coef[i]);
+
+    rd->rate_zero[i] = txb_costs->base_lf_cost[base_ctx][q_i][0];
+
+    if (q_i == 1) {
+      int a0 = q_i;  // 1
+      int cost0 = get_coeff_cost(blk_pos, absLevel[a0], coeff_sign, base_ctx,
+                                 mid_ctx, dc_sign_ctx, txb_costs, bwl, tx_class,
+                                 tmp_sign, plane, 1, q_i);
+      rd->rate[2 * i] = cost0;
+    } else {
+      int a1 = q_i + 2;
+      int cost1 = get_coeff_cost(blk_pos, absLevel[a1], coeff_sign, base_ctx,
+                                 mid_ctx, dc_sign_ctx, txb_costs, bwl, tx_class,
+                                 tmp_sign, plane, 1, q_i);
+      rd->rate[2 * i + 1] = cost1;
+    }
+  }
+  rd->rate_eob[1] =
+      eob_rate + get_coeff_cost_eob(blk_pos, absLevel[2], coeff_sign,
+                                    coeff_ctx->coef_eob, dc_sign_ctx, txb_costs,
+                                    bwl, tx_class, t_sign, plane);
+}
+
+void av2_get_rate_dist_def_luma_q1_c(const struct tcq_param_t *p,
+                                     const struct prequant_t *pq,
+                                     const struct tcq_coeff_ctx_t *coeff_ctx,
+                                     int blk_pos, int diag_ctx, int eob_rate,
+                                     struct tcq_rate_t *rd) {
+  const LV_MAP_COEFF_COST *txb_costs = p->txb_costs;
+  TX_CLASS tx_class = p->tx_class;
+  int bwl = p->bwl;
+  const int plane = 0;
+  const int t_sign = 0;
+  const int sign = 0;
+  const int dc_sign_ctx = 0;
+  const tran_low_t *absLevel = pq->absLevel;
+
+  for (int i = 0; i < TCQ_N_STATES; i++) {
+    int q_i = tcq_quant(i);
+    int base_ctx =
+        get_base_diag_ctx(diag_ctx) + get_base_ctx(coeff_ctx->coef[i]);
+
+    rd->rate_zero[i] = txb_costs->base_cost[base_ctx][q_i][0];
+
+    if (q_i == 1) {
+      int a0 = q_i;  // 1
+      int cost0 = get_coeff_cost_def(absLevel[a0], coeff_ctx->coef[i], diag_ctx,
+                                     plane, txb_costs, q_i, t_sign, sign);
+      rd->rate[2 * i] = cost0;
+    } else {
+      int a1 = q_i + 2;  // 1
+      int cost1 = get_coeff_cost_def(absLevel[a1], coeff_ctx->coef[i], diag_ctx,
+                                     plane, txb_costs, q_i, t_sign, sign);
+      rd->rate[2 * i + 1] = cost1;
+    }
+  }
+  rd->rate_eob[1] =
+      eob_rate + get_coeff_cost_eob(blk_pos, absLevel[2], sign,
+                                    coeff_ctx->coef_eob, dc_sign_ctx, txb_costs,
+                                    bwl, tx_class, t_sign, plane);
+}
+
 void av2_get_rate_dist_def_luma_c(const struct tcq_param_t *p,
                                   const struct prequant_t *pq,
                                   const struct tcq_coeff_ctx_t *coeff_ctx,
@@ -743,6 +942,7 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
   int dc_coeff_sign = tcoeff[0] < 0;
   int blk_pos_inc = (1 << bwl) - 1;
   int blk_pos, row, col;
+  int shift = 16 - log_scale + QUANT_FP_BITS;
 
   // Handle default region.
   while (scan_hi >= 10) {
@@ -761,22 +961,36 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
 
       prequant_t pqData;
       int tempdqv = get_dqv(dequant, scan[scan_pos], iqmatrix);
-      av2_pre_quant(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
-                    scan_pos);
+
+      tran_low_t orig_qIdx =
+          ((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0] +
+           ((1 << shift) >> 1)) >>
+          shift;
+      pqData.orig_qIdx = orig_qIdx;
 
       // Get coeff contexts
       tcq_coeff_ctx_t coeff_ctx;
       av2_get_coeff_ctx(tcq_ctx, col, &coeff_ctx);
       coeff_ctx.coef_eob = get_lower_levels_ctx_eob(bwl, height, scan_pos);
       int eob_rate = block_eob_rate[scan_pos];
-
-      // Calculate rate and distortion.
       tcq_rate_t rd;
-      av2_get_rate_dist_def_luma(p, &pqData, &coeff_ctx, blk_pos, diag_ctx,
-                                 eob_rate, &rd);
 
-      av2_decide_states(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
-                        decision);
+      if (pqData.orig_qIdx == 0) {
+        av2_pre_quant_q1(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
+                         scan_pos);
+        av2_get_rate_dist_def_luma_q1_c(p, &pqData, &coeff_ctx, blk_pos,
+                                        diag_ctx, eob_rate, &rd);
+        av2_decide_states_q1(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
+                             decision);
+      } else {
+        av2_pre_quant(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
+                      scan_pos);
+        av2_get_rate_dist_def_luma(p, &pqData, &coeff_ctx, blk_pos, diag_ctx,
+                                   eob_rate, &rd);
+
+        av2_decide_states(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
+                          decision);
+      }
 
       av2_update_states(decision, col, tcq_ctx);
 
@@ -804,22 +1018,36 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
 
       prequant_t pqData;
       int tempdqv = get_dqv(dequant, scan[scan_pos], iqmatrix);
-      av2_pre_quant(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
-                    scan_pos);
+
+      tran_low_t orig_qIdx =
+          ((int64_t)abs(tcoeff[blk_pos]) * quant[scan_pos != 0] +
+           ((1 << shift) >> 1)) >>
+          shift;
+      pqData.orig_qIdx = orig_qIdx;
 
       // Get coeff contexts
       tcq_coeff_ctx_t coeff_ctx;
       av2_get_coeff_ctx(tcq_ctx, col, &coeff_ctx);
       coeff_ctx.coef_eob = get_lower_levels_ctx_eob(bwl, height, scan_pos);
       int eob_rate = block_eob_rate[scan_pos];
-
-      // Calculate rate and distortion.
       tcq_rate_t rd;
-      av2_get_rate_dist_lf_luma(p, &pqData, &coeff_ctx, blk_pos, diag_ctx,
-                                eob_rate, dc_coeff_sign, &rd);
 
-      av2_decide_states(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
-                        decision);
+      if (pqData.orig_qIdx == 0) {
+        av2_pre_quant_q1(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
+                         scan_pos);
+        av2_get_rate_dist_lf_luma_q1_c(p, &pqData, &coeff_ctx, blk_pos,
+                                       diag_ctx, eob_rate, dc_coeff_sign, &rd);
+        av2_decide_states_q1(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
+                             decision);
+      } else {
+        // Calculate rate and distortion.
+        av2_pre_quant(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
+                      scan_pos);
+        av2_get_rate_dist_lf_luma(p, &pqData, &coeff_ctx, blk_pos, diag_ctx,
+                                  eob_rate, dc_coeff_sign, &rd);
+        av2_decide_states(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
+                          decision);
+      }
 
       av2_update_states(decision, col, tcq_ctx);
 

--- a/av2/encoder/trellis_quant.c
+++ b/av2/encoder/trellis_quant.c
@@ -410,10 +410,11 @@ void av2_decide_states_c(const struct tcq_node_t *prev,
   }
 }
 
-void av2_decide_states_q1(const struct tcq_node_t *prev,
-                          const struct tcq_rate_t *rd,
-                          const struct prequant_t *pq, int limits, int try_eob,
-                          int64_t rdmult, struct tcq_node_t *decision) {
+void av2_decide_states_q1_c(const struct tcq_node_t *prev,
+                             const struct tcq_rate_t *rd,
+                             const struct prequant_t *pq, int limits,
+                             int try_eob, int64_t rdmult,
+                             struct tcq_node_t *decision) {
   const int32_t *rate = rd->rate;
   const int32_t *rate_zero = rd->rate_zero;
   const int32_t *rate_eob = rd->rate_eob;
@@ -477,9 +478,9 @@ void av2_decide_states_q1(const struct tcq_node_t *prev,
   }
 }
 
-void av2_pre_quant_q1(tran_low_t tqc, struct prequant_t *pqData,
-                      const int32_t *quant_ptr, int dqv, int log_scale,
-                      int scan_pos) {
+void av2_pre_quant_q1_c(tran_low_t tqc, struct prequant_t *pqData,
+                         const int32_t *quant_ptr, int dqv, int log_scale,
+                         int scan_pos) {
   // calculate qIdx
   (void)quant_ptr;
   (void)scan_pos;
@@ -978,8 +979,8 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
       if (pqData.orig_qIdx == 0) {
         av2_pre_quant_q1(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
                          scan_pos);
-        av2_get_rate_dist_def_luma_q1_c(p, &pqData, &coeff_ctx, blk_pos,
-                                        diag_ctx, eob_rate, &rd);
+        av2_get_rate_dist_def_luma_q1(p, &pqData, &coeff_ctx, blk_pos,
+                                      diag_ctx, eob_rate, &rd);
         av2_decide_states_q1(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
                              decision);
       } else {
@@ -1035,8 +1036,8 @@ static void trellis_loop_diagonal_st8(const tcq_param_t *p, int scan_hi,
       if (pqData.orig_qIdx == 0) {
         av2_pre_quant_q1(tcoeff[blk_pos], &pqData, quant, tempdqv, log_scale,
                          scan_pos);
-        av2_get_rate_dist_lf_luma_q1_c(p, &pqData, &coeff_ctx, blk_pos,
-                                       diag_ctx, eob_rate, dc_coeff_sign, &rd);
+        av2_get_rate_dist_lf_luma_q1(p, &pqData, &coeff_ctx, blk_pos, diag_ctx,
+                                     eob_rate, dc_coeff_sign, &rd);
         av2_decide_states_q1(prev_decision, &rd, &pqData, lf, try_eob, rdmult,
                              decision);
       } else {

--- a/av2/encoder/trellis_quant.h
+++ b/av2/encoder/trellis_quant.h
@@ -70,6 +70,7 @@ typedef struct prequant_t {
   int32_t absLevel[4];
   int64_t deltaDist[4];
   int16_t qIdx;
+  int16_t orig_qIdx;
 } prequant_t;
 
 typedef struct tcq_rate_t {

--- a/av2/encoder/x86/trellis_quant_avx2.c
+++ b/av2/encoder/x86/trellis_quant_avx2.c
@@ -23,9 +23,20 @@
 
 // av2_decide_states_*() constants.
 static const int32_t kShuffle[8] = { 0, 2, 1, 3, 5, 7, 4, 6 };
+static const int32_t kShuffleOdd[8] = { 3, 1, 6, 4, 0, 0, 0, 0 };
 static const int32_t kPrevId[TCQ_MAX_STATES / 4][8] = {
   { 0, 0 << 24, 0, 1 << 24, 0, 2 << 24, 0, 3 << 24 },
   { 0, 4 << 24, 0, 5 << 24, 0, 6 << 24, 0, 7 << 24 },
+};
+static const int32_t kPrevIdQ1[2][2][8] = {
+  {
+    { 0, 0 << 24, 0, 1 << 24, 0, 2 << 24, 0, 3 << 24 },
+    { 0, 1 << 24, 0, 0 << 24, 0, 3 << 24, 0, 2 << 24 },
+  },
+  {
+    { 0, 4 << 24, 0, 5 << 24, 0, 6 << 24, 0, 7 << 24 },
+    { 0, 5 << 24, 0, 4 << 24, 0, 7 << 24, 0, 6 << 24 },
+  },
 };
 
 // clang-format off
@@ -187,6 +198,106 @@ void av2_decide_states_avx2(const struct tcq_node_t *prev,
   }
 }
 
+void av2_decide_states_q1_avx2(const struct tcq_node_t *prev,
+                               const struct tcq_rate_t *rd,
+                               const struct prequant_t *pq, int limits,
+                               int try_eob, int64_t rdmult,
+                               struct tcq_node_t *decision) {
+  (void)limits;
+  assert((rdmult >> 32) == 0);
+  static_assert(sizeof(tcq_node_t) == 16, "");
+
+  __m256i c_rdmult = _mm256_set1_epi64x(rdmult);
+  __m256i c_round = _mm256_set1_epi64x(1 << (AV2_PROB_COST_SHIFT - 1));
+
+  __m128i dist12 = _mm_lddqu_si128((__m128i *)&pq->deltaDist[1]);
+  __m256i dist_2211 =
+      _mm256_permute4x64_epi64(_mm256_castsi128_si256(dist12), 0x05);
+  dist_2211 = _mm256_slli_epi64(dist_2211, RDDIV_BITS);
+
+  __m256i *out_a = (__m256i *)&decision[0];
+  __m256i *out_b = (__m256i *)&decision[TCQ_N_STATES >> 1];
+
+  for (int i = 0; i < TCQ_N_STATES >> 2; i++) {
+    // Load prev states.
+    __m256i state01 = _mm256_lddqu_si256((__m256i *)&prev[4 * i]);
+    __m256i state23 = _mm256_lddqu_si256((__m256i *)&prev[4 * i + 2]);
+    __m256i state02 = _mm256_permute2x128_si256(state01, state23, 0x20);
+    __m256i state13 = _mm256_permute2x128_si256(state01, state23, 0x31);
+    __m256i prev_rd_zero = _mm256_unpacklo_epi64(state02, state13);
+    __m256i prev_rate_zero = _mm256_unpackhi_epi64(state02, state13);
+    prev_rate_zero =
+        _mm256_and_si256(prev_rate_zero, _mm256_set1_epi64x(0xFFFFFFFFULL));
+
+    __m256i prev_rd_odd = _mm256_shuffle_epi32(prev_rd_zero, 0x4E);
+    __m256i prev_rate_odd = _mm256_shuffle_epi32(prev_rate_zero, 0x4E);
+
+    // Calc rd-cost for zero quant.
+    __m128i ratezero_128 = _mm_lddqu_si128((__m128i *)&rd->rate_zero[4 * i]);
+    __m256i ratezero = _mm256_cvtepu32_epi64(ratezero_128);
+    __m256i rdcost_zero = _mm256_mul_epu32(c_rdmult, ratezero);
+    rdcost_zero = _mm256_add_epi64(rdcost_zero, c_round);
+    rdcost_zero = _mm256_srli_epi64(rdcost_zero, AV2_PROB_COST_SHIFT);
+    rdcost_zero = _mm256_add_epi64(rdcost_zero, prev_rd_zero);
+
+    // Calc rd-cost for odd quant.
+    __m256i rates = _mm256_lddqu_si256((__m256i *)&rd->rate[8 * i]);
+    __m256i permute_mask = _mm256_lddqu_si256((__m256i *)kShuffleOdd);
+    __m256i rate_odd_32 = _mm256_permutevar8x32_epi32(rates, permute_mask);
+    __m256i rate_odd =
+        _mm256_cvtepu32_epi64(_mm256_castsi256_si128(rate_odd_32));
+    __m256i rdcost_odd = _mm256_mul_epu32(c_rdmult, rate_odd);
+    rdcost_odd = _mm256_add_epi64(rdcost_odd, c_round);
+    rdcost_odd = _mm256_srli_epi64(rdcost_odd, AV2_PROB_COST_SHIFT);
+    rdcost_odd = _mm256_add_epi64(rdcost_odd, dist_2211);
+    rdcost_odd = _mm256_add_epi64(rdcost_odd, prev_rd_odd);
+
+    __m256i rate_zero_tot = _mm256_add_epi64(ratezero, prev_rate_zero);
+    __m256i rate_odd_tot = _mm256_add_epi64(rate_odd, prev_rate_odd);
+
+    // Compare Zero vs Odd.
+    __m256i use_odd = _mm256_cmpgt_epi64(rdcost_zero, rdcost_odd);
+    __m256i rdcost_best = _mm256_blendv_epi8(rdcost_zero, rdcost_odd, use_odd);
+    __m256i rate_best =
+        _mm256_blendv_epi8(rate_zero_tot, rate_odd_tot, use_odd);
+    __m256i prev_id_zero = _mm256_lddqu_si256((__m256i *)kPrevIdQ1[i][0]);
+    __m256i prev_id_odd = _mm256_lddqu_si256((__m256i *)kPrevIdQ1[i][1]);
+    __m256i prev_id = _mm256_blendv_epi8(prev_id_zero, prev_id_odd, use_odd);
+    __m256i abs_best = _mm256_and_si256(use_odd, _mm256_set1_epi64x(1ULL << 32));
+
+    // Compare with EOB candidate (only state 4 in iteration 0).
+    if (try_eob && i == 0) {
+      int rate_eob1 = rd->rate_eob[1];
+      int64_t dist_eob1 = pq->deltaDist[2];
+      int64_t rdcost_eob1 =
+          ((int64_t)rdmult * rate_eob1 + (1 << (AV2_PROB_COST_SHIFT - 1))) >>
+          AV2_PROB_COST_SHIFT;
+      rdcost_eob1 += (dist_eob1 << RDDIV_BITS);
+      __m256i v_rdcost_eob = _mm256_set_epi64x(0, 0, rdcost_eob1, 0);
+      __m256i mask_eob = _mm256_set_epi64x(0, 0, (int64_t)-1, 0);
+      __m256i use_eob = _mm256_and_si256(
+          _mm256_cmpgt_epi64(rdcost_best, v_rdcost_eob), mask_eob);
+      rdcost_best = _mm256_blendv_epi8(rdcost_best, v_rdcost_eob, use_eob);
+      rate_best = _mm256_blendv_epi8(
+          rate_best, _mm256_set_epi64x(0, 0, rate_eob1, 0), use_eob);
+      prev_id = _mm256_blendv_epi8(
+          prev_id, _mm256_set_epi64x(0, 0, (int64_t)-1 << 56, 0), use_eob);
+      abs_best = _mm256_blendv_epi8(
+          abs_best, _mm256_set_epi64x(0, 0, 1ULL << 32, 0), use_eob);
+    }
+
+    // Pack and store state info.
+    __m256i info_best = _mm256_or_si256(rate_best, abs_best);
+    info_best = _mm256_or_si256(info_best, prev_id);
+    __m256i info01 = _mm256_unpacklo_epi64(rdcost_best, info_best);
+    __m256i info23 = _mm256_unpackhi_epi64(rdcost_best, info_best);
+    _mm256_storeu_si256(out_a, info01);
+    _mm256_storeu_si256(out_b, info23);
+    out_a = (__m256i *)&decision[6];
+    out_b = (__m256i *)&decision[2];
+  }
+}
+
 void av2_pre_quant_avx2(tran_low_t tqc, struct prequant_t *pqData,
                         const int32_t *quant_ptr, int dqv, int log_scale,
                         int scan_pos) {
@@ -231,6 +342,32 @@ void av2_pre_quant_avx2(tran_low_t tqc, struct prequant_t *pqData,
   __m256i dist = _mm256_mul_epi32(diff, diff);
   dist = _mm256_sub_epi64(dist, dist0);
   _mm256_storeu_si256((__m256i *)pqData->deltaDist, dist);
+}
+
+void av2_pre_quant_q1_avx2(tran_low_t tqc, struct prequant_t *pqData,
+                           const int32_t *quant_ptr, int dqv, int log_scale,
+                           int scan_pos) {
+  (void)quant_ptr;
+  (void)scan_pos;
+  int32_t abs_tqc = abs(tqc);
+
+  pqData->qIdx = 1;
+  pqData->absLevel[1] = 1;
+  pqData->absLevel[2] = 1;
+
+  __m128i dqv_12 = _mm_set_epi64x((int64_t)dqv << 1, (int64_t)dqv);
+  __m128i dq_round = _mm_set1_epi64x(1 << (QUANT_TABLE_BITS - 1));
+  __m128i dqv_rnd = _mm_add_epi64(dqv_12, dq_round);
+  __m128i dqc = _mm_srli_epi64(dqv_rnd, QUANT_TABLE_BITS + log_scale);
+
+  __m128i abs_tqc_sh = _mm_set1_epi64x(abs_tqc << (log_scale - 1));
+  __m128i dist0 = _mm_mul_epi32(abs_tqc_sh, abs_tqc_sh);
+  __m128i dqc_sh = _mm_slli_epi32(dqc, log_scale - 1);
+  __m128i diff = _mm_sub_epi32(dqc_sh, abs_tqc_sh);
+  __m128i dist = _mm_mul_epi32(diff, diff);
+  __m128i deltaDist = _mm_sub_epi64(dist, dist0);
+
+  _mm_storeu_si128((__m128i *)&pqData->deltaDist[1], deltaDist);
 }
 
 void av2_update_states_avx2(const tcq_node_t *decision, int col,
@@ -469,6 +606,75 @@ void av2_get_rate_dist_def_luma_avx2(const struct tcq_param_t *p,
       }
     }
   }
+}
+
+void av2_get_rate_dist_def_luma_q1_avx2(
+    const struct tcq_param_t *p, const struct prequant_t *pq,
+    const struct tcq_coeff_ctx_t *coeff_ctx, int blk_pos, int diag_ctx,
+    int eob_rate, struct tcq_rate_t *rd) {
+  const LV_MAP_COEFF_COST *txb_costs = p->txb_costs;
+  (void)blk_pos;
+  (void)pq;
+  const int32_t(*cost_zero)[SIG_COEF_CONTEXTS] = txb_costs->base_cost_zero;
+  const uint16_t(*cost_low_tbl)[SIG_COEF_CONTEXTS][TCQ_CTXS][2] =
+      txb_costs->base_cost_low_tbl;
+  const uint16_t(*cost_eob_tbl)[SIG_COEF_CONTEXTS_EOB][2] =
+      txb_costs->base_eob_cost_tbl;
+  int base_diag_ctx = get_base_diag_ctx(diag_ctx);
+
+  // Calc zero coeff costs.
+  __m256i zero = _mm256_setzero_si256();
+  __m256i cost_zero_dq0 =
+      _mm256_lddqu_si256((__m256i *)&cost_zero[0][base_diag_ctx]);
+  __m256i cost_zero_dq1 =
+      _mm256_lddqu_si256((__m256i *)&cost_zero[1][base_diag_ctx]);
+
+  __m256i coef_ctx = _mm256_castsi128_si256(_mm_loadu_si64(&coeff_ctx->coef));
+  __m256i ctx16 = _mm256_unpacklo_epi8(coef_ctx, zero);
+  __m256i ctx = _mm256_shuffle_epi32(ctx16, 0xD8);
+  __m256i ctx_dq0 = _mm256_unpacklo_epi16(ctx, zero);
+  __m256i ctx_dq1 = _mm256_unpackhi_epi16(ctx, zero);
+  __m256i ratez_dq0 = _mm256_permutevar8x32_epi32(cost_zero_dq0, ctx_dq0);
+  __m256i ratez_dq1 = _mm256_permutevar8x32_epi32(cost_zero_dq1, ctx_dq1);
+  __m256i ratez_0123 = _mm256_unpacklo_epi64(ratez_dq0, ratez_dq1);
+  _mm_storeu_si128((__m128i *)&rd->rate_zero[0],
+                   _mm256_castsi256_si128(ratez_0123));
+  __m256i ratez_4567 = _mm256_unpackhi_epi64(ratez_dq0, ratez_dq1);
+  _mm_storeu_si128((__m128i *)&rd->rate_zero[4],
+                   _mm256_castsi256_si128(ratez_4567));
+
+  // Calc coeff_base rate (qIdx = 1, idx = 0).
+  const int idx = 0;
+  __m128i c_zero = _mm_setzero_si128();
+  __m256i diag = _mm256_set1_epi16(base_diag_ctx);
+  __m256i base_ctx = _mm256_slli_epi16(ctx16, 12);
+  base_ctx = _mm256_srli_epi16(base_ctx, 12);
+  base_ctx = _mm256_add_epi16(base_ctx, diag);
+  for (int i = 0; i < (TCQ_N_STATES >> 2); i++) {
+    int ctx0 = _mm256_extract_epi16(base_ctx, 0);
+    int ctx1 = _mm256_extract_epi16(base_ctx, 1);
+    int ctx2 = _mm256_extract_epi16(base_ctx, 2);
+    int ctx3 = _mm256_extract_epi16(base_ctx, 3);
+    base_ctx = _mm256_bsrli_epi128(base_ctx, 8);
+    __m128i rate_01 = _mm_loadu_si64(&cost_low_tbl[idx][ctx0][0]);
+    __m128i rate_23 = _mm_loadu_si64(&cost_low_tbl[idx][ctx1][0]);
+    __m128i rate_45 = _mm_loadu_si64(&cost_low_tbl[idx][ctx2][1]);
+    __m128i rate_67 = _mm_loadu_si64(&cost_low_tbl[idx][ctx3][1]);
+    __m128i rate_0123 = _mm_unpacklo_epi32(rate_01, rate_23);
+    __m128i rate_4567 = _mm_unpacklo_epi32(rate_45, rate_67);
+    rate_0123 = _mm_unpacklo_epi16(rate_0123, c_zero);
+    rate_4567 = _mm_unpacklo_epi16(rate_4567, c_zero);
+    _mm_storeu_si128((__m128i *)&rd->rate[8 * i], rate_0123);
+    _mm_storeu_si128((__m128i *)&rd->rate[8 * i + 4], rate_4567);
+  }
+
+  // Calc coeff/eob cost.
+  int eob_ctx = coeff_ctx->coef_eob;
+  __m128i rate_eob_coef = _mm_loadu_si64(&cost_eob_tbl[idx][eob_ctx][0]);
+  rate_eob_coef = _mm_unpacklo_epi16(rate_eob_coef, c_zero);
+  __m128i rate_eob_position = _mm_set1_epi32(eob_rate);
+  __m128i rate_eob = _mm_add_epi32(rate_eob_coef, rate_eob_position);
+  _mm_storeu_si64(&rd->rate_eob[0], rate_eob);
 }
 
 static __m128i map_state(__m128i state, __m128i prev_st) {
@@ -740,6 +946,106 @@ void av2_get_rate_dist_lf_luma_avx2(const struct tcq_param_t *p,
       }
     }
   }
+}
+
+void av2_get_rate_dist_lf_luma_q1_avx2(
+    const struct tcq_param_t *p, const struct prequant_t *pq,
+    const struct tcq_coeff_ctx_t *coeff_ctx, int blk_pos, int diag_ctx,
+    int eob_rate, int coeff_sign, struct tcq_rate_t *rd) {
+  (void)pq;
+  const LV_MAP_COEFF_COST *txb_costs = p->txb_costs;
+  static const int8_t kShuf[2][32] = {
+    { 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15,
+      0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15 },
+    { 0, 8,  Z, Z, 1, 9,  Z, Z, 2, 10, Z, Z, 3, 11, Z, Z,
+      4, 12, Z, Z, 5, 13, Z, Z, 6, 14, Z, Z, 7, 15, Z, Z }
+  };
+  const uint16_t(*cost_zero)[LF_SIG_COEF_CONTEXTS] =
+      txb_costs->base_lf_cost_zero;
+  const uint16_t(*cost_low_tbl)[LF_SIG_COEF_CONTEXTS][TCQ_CTXS][2] =
+      txb_costs->base_lf_cost_low_tbl;
+  const uint16_t(*cost_eob_tbl)[SIG_COEF_CONTEXTS_EOB][2] =
+      txb_costs->base_lf_eob_cost_tbl;
+  int bwl = p->bwl;
+  TX_CLASS tx_class = p->tx_class;
+  int dc_sign_ctx = p->dc_sign_ctx;
+  int base_diag_ctx = get_base_diag_ctx(diag_ctx);
+
+  // Calc zero coeff costs.
+  __m256i cost_zero_dq0 =
+      _mm256_lddqu_si256((__m256i *)&cost_zero[0][base_diag_ctx]);
+  __m256i cost_zero_dq1 =
+      _mm256_lddqu_si256((__m256i *)&cost_zero[1][base_diag_ctx]);
+  __m256i shuf = _mm256_lddqu_si256((__m256i *)kShuf[0]);
+  cost_zero_dq0 = _mm256_shuffle_epi8(cost_zero_dq0, shuf);
+  cost_zero_dq1 = _mm256_shuffle_epi8(cost_zero_dq1, shuf);
+  __m256i cost_dq0 = _mm256_permute4x64_epi64(cost_zero_dq0, 0xD8);
+  __m256i cost_dq1 = _mm256_permute4x64_epi64(cost_zero_dq1, 0xD8);
+  __m256i ctx = _mm256_castsi128_si256(_mm_loadu_si64(&coeff_ctx->coef));
+  __m256i fifteen = _mm256_set1_epi8(15);
+  __m256i base_ctx = _mm256_and_si256(ctx, fifteen);
+  __m256i base_ctx1 = _mm256_permute4x64_epi64(base_ctx, 0);
+  __m256i ratez_dq0 = _mm256_shuffle_epi8(cost_dq0, base_ctx1);
+  __m256i ratez_dq1 = _mm256_shuffle_epi8(cost_dq1, base_ctx1);
+  __m256i ratez = _mm256_blend_epi16(ratez_dq0, ratez_dq1, 0xAA);
+  ratez = _mm256_permute4x64_epi64(ratez, 0x88);
+  __m256i shuf1 = _mm256_lddqu_si256((__m256i *)kShuf[1]);
+  ratez = _mm256_shuffle_epi8(ratez, shuf1);
+  _mm256_storeu_si256((__m256i *)&rd->rate_zero[0], ratez);
+
+  // Calc coeff_base rate (qIdx = 1, idx = 0).
+  const int idx = 0;
+  __m256i zero = _mm256_setzero_si256();
+  __m128i c_zero = _mm256_castsi256_si128(zero);
+  __m256i base_diag = _mm256_set1_epi8(base_diag_ctx);
+  base_ctx = _mm256_add_epi8(base_ctx, base_diag);
+
+  const int row = blk_pos >> bwl;
+  const int col = blk_pos - (row << bwl);
+  const bool dc_2dtx = (blk_pos == 0);
+  const bool dc_hor = (col == 0) && tx_class == TX_CLASS_HORIZ;
+  const bool dc_ver = (row == 0) && tx_class == TX_CLASS_VERT;
+  const bool is_dc_coeff = dc_2dtx || dc_hor || dc_ver;
+  __m128i v_dc_cost = c_zero;
+  if (is_dc_coeff) {
+    const int dc_ph_group = 0;
+    int dc_cost = txb_costs->dc_sign_cost[dc_ph_group][dc_sign_ctx][coeff_sign] -
+                  av2_cost_literal(1);
+    v_dc_cost = _mm_set1_epi32(dc_cost);
+  }
+
+  for (int i = 0; i < (TCQ_N_STATES >> 2); i++) {
+    int ctx0 = _mm256_extract_epi8(base_ctx, 0);
+    int ctx1 = _mm256_extract_epi8(base_ctx, 1);
+    int ctx2 = _mm256_extract_epi8(base_ctx, 2);
+    int ctx3 = _mm256_extract_epi8(base_ctx, 3);
+    base_ctx = _mm256_bsrli_epi128(base_ctx, 4);
+    __m128i rate_01 = _mm_loadu_si64(&cost_low_tbl[idx][ctx0][0]);
+    __m128i rate_23 = _mm_loadu_si64(&cost_low_tbl[idx][ctx1][0]);
+    __m128i rate_45 = _mm_loadu_si64(&cost_low_tbl[idx][ctx2][1]);
+    __m128i rate_67 = _mm_loadu_si64(&cost_low_tbl[idx][ctx3][1]);
+    __m128i rate_0123 = _mm_unpacklo_epi32(rate_01, rate_23);
+    __m128i rate_4567 = _mm_unpacklo_epi32(rate_45, rate_67);
+    rate_0123 = _mm_unpacklo_epi16(rate_0123, c_zero);
+    rate_4567 = _mm_unpacklo_epi16(rate_4567, c_zero);
+    if (is_dc_coeff) {
+      rate_0123 = _mm_add_epi32(rate_0123, v_dc_cost);
+      rate_4567 = _mm_add_epi32(rate_4567, v_dc_cost);
+    }
+    _mm_storeu_si128((__m128i *)&rd->rate[8 * i], rate_0123);
+    _mm_storeu_si128((__m128i *)&rd->rate[8 * i + 4], rate_4567);
+  }
+
+  // Calc coeff/eob cost.
+  int eob_ctx = coeff_ctx->coef_eob;
+  __m128i rate_eob_coef = _mm_loadu_si64(&cost_eob_tbl[idx][eob_ctx][0]);
+  rate_eob_coef = _mm_unpacklo_epi16(rate_eob_coef, c_zero);
+  __m128i rate_eob_position = _mm_set1_epi32(eob_rate);
+  __m128i rate_eob = _mm_add_epi32(rate_eob_coef, rate_eob_position);
+  if (is_dc_coeff) {
+    rate_eob = _mm_add_epi32(rate_eob, v_dc_cost);
+  }
+  _mm_storeu_si64(&rd->rate_eob[0], rate_eob);
 }
 
 // Pre-calculate eob bits (rate) for each EOB candidate position from 1

--- a/av2/encoder/x86/trellis_quant_avx2.c
+++ b/av2/encoder/x86/trellis_quant_avx2.c
@@ -205,7 +205,6 @@ void av2_decide_states_q1_avx2(const struct tcq_node_t *prev,
                                struct tcq_node_t *decision) {
   (void)limits;
   assert((rdmult >> 32) == 0);
-  static_assert(sizeof(tcq_node_t) == 16, "");
 
   __m256i c_rdmult = _mm256_set1_epi64x(rdmult);
   __m256i c_round = _mm256_set1_epi64x(1 << (AV2_PROB_COST_SHIFT - 1));
@@ -273,7 +272,7 @@ void av2_decide_states_q1_avx2(const struct tcq_node_t *prev,
       int64_t rdcost_eob1 =
           ((int64_t)rdmult * rate_eob1 + (1 << (AV2_PROB_COST_SHIFT - 1))) >>
           AV2_PROB_COST_SHIFT;
-      rdcost_eob1 += (dist_eob1 << RDDIV_BITS);
+      rdcost_eob1 += dist_eob1 * (1 << RDDIV_BITS);
       __m256i v_rdcost_eob = _mm256_set_epi64x(0, 0, rdcost_eob1, 0);
       __m256i mask_eob = _mm256_set_epi64x(0, 0, (int64_t)-1, 0);
       __m256i use_eob = _mm256_and_si256(

--- a/av2/encoder/x86/trellis_quant_avx2.c
+++ b/av2/encoder/x86/trellis_quant_avx2.c
@@ -30,12 +30,12 @@ static const int32_t kPrevId[TCQ_MAX_STATES / 4][8] = {
 };
 static const int32_t kPrevIdQ1[2][2][8] = {
   {
-    { 0, 0 << 24, 0, 1 << 24, 0, 2 << 24, 0, 3 << 24 },
-    { 0, 1 << 24, 0, 0 << 24, 0, 3 << 24, 0, 2 << 24 },
+      { 0, 0 << 24, 0, 1 << 24, 0, 2 << 24, 0, 3 << 24 },
+      { 0, 1 << 24, 0, 0 << 24, 0, 3 << 24, 0, 2 << 24 },
   },
   {
-    { 0, 4 << 24, 0, 5 << 24, 0, 6 << 24, 0, 7 << 24 },
-    { 0, 5 << 24, 0, 4 << 24, 0, 7 << 24, 0, 6 << 24 },
+      { 0, 4 << 24, 0, 5 << 24, 0, 6 << 24, 0, 7 << 24 },
+      { 0, 5 << 24, 0, 4 << 24, 0, 7 << 24, 0, 6 << 24 },
   },
 };
 
@@ -263,7 +263,8 @@ void av2_decide_states_q1_avx2(const struct tcq_node_t *prev,
     __m256i prev_id_zero = _mm256_lddqu_si256((__m256i *)kPrevIdQ1[i][0]);
     __m256i prev_id_odd = _mm256_lddqu_si256((__m256i *)kPrevIdQ1[i][1]);
     __m256i prev_id = _mm256_blendv_epi8(prev_id_zero, prev_id_odd, use_odd);
-    __m256i abs_best = _mm256_and_si256(use_odd, _mm256_set1_epi64x(1ULL << 32));
+    __m256i abs_best =
+        _mm256_and_si256(use_odd, _mm256_set1_epi64x(1ULL << 32));
 
     // Compare with EOB candidate (only state 4 in iteration 0).
     if (try_eob && i == 0) {
@@ -281,7 +282,7 @@ void av2_decide_states_q1_avx2(const struct tcq_node_t *prev,
       rate_best = _mm256_blendv_epi8(
           rate_best, _mm256_set_epi64x(0, 0, rate_eob1, 0), use_eob);
       prev_id = _mm256_blendv_epi8(
-          prev_id, _mm256_set_epi64x(0, 0, (int64_t)-1 << 56, 0), use_eob);
+          prev_id, _mm256_set_epi64x(0, 0, 0xff00000000000000, 0), use_eob);
       abs_best = _mm256_blendv_epi8(
           abs_best, _mm256_set_epi64x(0, 0, 1ULL << 32, 0), use_eob);
     }
@@ -305,15 +306,13 @@ void av2_pre_quant_avx2(tran_low_t tqc, struct prequant_t *pqData,
     { 0, 1, 2, 3 }, { 3, 0, 1, 2 }, { 2, 3, 0, 1 }, { 1, 2, 3, 0 }
   };
 
-  // calculate qIdx
-  int shift = 16 - log_scale + QUANT_FP_BITS;
-  int32_t add = -((2 << shift) >> 1);
-  int32_t abs_tqc = abs(tqc);
+  (void)quant_ptr;
+  (void)scan_pos;
 
-  int32_t qIdx = (int)AVMMAX(
-      1, AVMMIN(INT16_MAX,
-                ((int64_t)abs_tqc * quant_ptr[scan_pos != 0] + add) >> shift));
-  pqData->qIdx = qIdx;
+  // calculate qIdx
+  int32_t abs_tqc = abs(tqc);
+  pqData->qIdx = AVMMAX(pqData->orig_qIdx - 2, 1);
+  int32_t qIdx = pqData->qIdx;
 
   __m256i c_zero = _mm256_setzero_si256();
   __m128i base_qc = _mm_set1_epi32(qIdx);
@@ -608,10 +607,11 @@ void av2_get_rate_dist_def_luma_avx2(const struct tcq_param_t *p,
   }
 }
 
-void av2_get_rate_dist_def_luma_q1_avx2(
-    const struct tcq_param_t *p, const struct prequant_t *pq,
-    const struct tcq_coeff_ctx_t *coeff_ctx, int blk_pos, int diag_ctx,
-    int eob_rate, struct tcq_rate_t *rd) {
+void av2_get_rate_dist_def_luma_q1_avx2(const struct tcq_param_t *p,
+                                        const struct prequant_t *pq,
+                                        const struct tcq_coeff_ctx_t *coeff_ctx,
+                                        int blk_pos, int diag_ctx, int eob_rate,
+                                        struct tcq_rate_t *rd) {
   const LV_MAP_COEFF_COST *txb_costs = p->txb_costs;
   (void)blk_pos;
   (void)pq;
@@ -948,10 +948,11 @@ void av2_get_rate_dist_lf_luma_avx2(const struct tcq_param_t *p,
   }
 }
 
-void av2_get_rate_dist_lf_luma_q1_avx2(
-    const struct tcq_param_t *p, const struct prequant_t *pq,
-    const struct tcq_coeff_ctx_t *coeff_ctx, int blk_pos, int diag_ctx,
-    int eob_rate, int coeff_sign, struct tcq_rate_t *rd) {
+void av2_get_rate_dist_lf_luma_q1_avx2(const struct tcq_param_t *p,
+                                       const struct prequant_t *pq,
+                                       const struct tcq_coeff_ctx_t *coeff_ctx,
+                                       int blk_pos, int diag_ctx, int eob_rate,
+                                       int coeff_sign, struct tcq_rate_t *rd) {
   (void)pq;
   const LV_MAP_COEFF_COST *txb_costs = p->txb_costs;
   static const int8_t kShuf[2][32] = {
@@ -1009,8 +1010,9 @@ void av2_get_rate_dist_lf_luma_q1_avx2(
   __m128i v_dc_cost = c_zero;
   if (is_dc_coeff) {
     const int dc_ph_group = 0;
-    int dc_cost = txb_costs->dc_sign_cost[dc_ph_group][dc_sign_ctx][coeff_sign] -
-                  av2_cost_literal(1);
+    int dc_cost =
+        txb_costs->dc_sign_cost[dc_ph_group][dc_sign_ctx][coeff_sign] -
+        av2_cost_literal(1);
     v_dc_cost = _mm_set1_epi32(dc_cost);
   }
 

--- a/test/trellis_test.cc
+++ b/test/trellis_test.cc
@@ -344,6 +344,93 @@ TEST_P(TcqRateLumaTest, RandomValues) {
   }
 }
 
+class TcqRateLumaQ1Test : public FunctionEquivalenceTest<TcqRateLuma> {
+ protected:
+  static const int kIterations = 100000;
+
+  void Execute(tcq_rate_t *rate_ref, tcq_rate_t *rate_tst) {
+    memset(rate_ref, 0, sizeof(*rate_ref));
+    memset(rate_tst, 0, sizeof(*rate_tst));
+    params_.ref_func(&param_, &pre_quant_, &coeff_ctx_, blk_pos_, diag_ctx_,
+                     eob_rate_, rate_ref);
+    ASM_REGISTER_STATE_CHECK(params_.tst_func(&param_, &pre_quant_, &coeff_ctx_,
+                                              blk_pos_, diag_ctx_, eob_rate_,
+                                              rate_tst));
+  }
+
+  void RunTest() {
+    for (int iter = 0; iter < kIterations && !HasFatalFailure(); ++iter) {
+      int log_scale = 1;
+      int shift = 16 - log_scale + QUANT_FP_BITS;
+      const int32_t quant[2] = { 1 << shift, 1 << shift };
+      int dqv = 1 << QUANT_TABLE_BITS;
+      int tqc = 0;
+
+      // Initialize param structure.
+      int bwl = 3 + (rng_.Rand8() & 2);
+      int height = 1 << bwl;
+      int max = (1 << bwl) - 1;
+      int row = rng_.Rand8() & max;
+      int col = rng_.Rand8() & max;
+      row = AVMMAX(row, 4);
+      col = AVMMAX(col, 4);
+      int blk_pos = (row << bwl) + col;
+      int scan_pos = blk_pos;
+      int diag_ctx = get_nz_map_ctx_from_stats(0, blk_pos, bwl, TX_CLASS_2D, 0);
+
+      blk_pos_ = blk_pos;
+      diag_ctx_ = diag_ctx;
+      param_.bwl = bwl;
+      param_.txb_height = height;
+      param_.tx_class = 0;
+      param_.txb_costs = &txb_costs_;
+
+      // Generate random syntax costs.
+      generate_random_cost_tables(&rng_, &txb_costs_);
+
+      // Generate pre_quant info with random coeff.
+      av2_pre_quant_q1(tqc, &pre_quant_, quant, dqv, log_scale, scan_pos);
+      eob_rate_ = rng_(512 * 4);
+
+      // Generate random coeff_ctx
+      for (int i = 0; i < 8; i++) {
+        coeff_ctx_.coef[i] = (rng_(4) << 4) + rng_(4);
+      }
+      coeff_ctx_.coef_eob = get_lower_levels_ctx_eob(bwl, height, scan_pos);
+      coeff_ctx_.pad[0] = 0;
+      coeff_ctx_.pad[1] = 0;
+      coeff_ctx_.pad[2] = 0;
+
+      tcq_rate_t rate_ref, rate_tst;
+      Execute(&rate_ref, &rate_tst);
+
+      for (int i = 0; i < 8; i++) {
+        ASSERT_EQ(rate_ref.rate_zero[i], rate_tst.rate_zero[i])
+            << "rate_zero mismatch at i=" << i;
+      }
+      ASSERT_EQ(rate_ref.rate_eob[1], rate_tst.rate_eob[1]);
+      ASSERT_EQ(rate_ref.rate[1], rate_tst.rate[1]);
+      ASSERT_EQ(rate_ref.rate[3], rate_tst.rate[3]);
+      ASSERT_EQ(rate_ref.rate[4], rate_tst.rate[4]);
+      ASSERT_EQ(rate_ref.rate[6], rate_tst.rate[6]);
+      ASSERT_EQ(rate_ref.rate[9], rate_tst.rate[9]);
+      ASSERT_EQ(rate_ref.rate[11], rate_tst.rate[11]);
+      ASSERT_EQ(rate_ref.rate[12], rate_tst.rate[12]);
+      ASSERT_EQ(rate_ref.rate[14], rate_tst.rate[14]);
+    }
+  }
+
+  tcq_param_t param_;
+  LV_MAP_COEFF_COST txb_costs_;
+  prequant_t pre_quant_;
+  tcq_coeff_ctx_t coeff_ctx_;
+  int blk_pos_;
+  int diag_ctx_;
+  int eob_rate_;
+};
+
+TEST_P(TcqRateLumaQ1Test, RandomValues) { RunTest(); }
+
 TEST_P(TcqRateLfLumaTest, RandomValues) {
   for (int iter = 0; iter < kIterations && !HasFatalFailure(); ++iter) {
     int log_scale = 1;
@@ -395,6 +482,100 @@ TEST_P(TcqRateLfLumaTest, RandomValues) {
     Common();
   }
 }
+
+class TcqRateLfLumaQ1Test : public FunctionEquivalenceTest<TcqRateLfLuma> {
+ protected:
+  static const int kIterations = 100000;
+
+  void Execute(tcq_rate_t *rate_ref, tcq_rate_t *rate_tst) {
+    memset(rate_ref, 0, sizeof(*rate_ref));
+    memset(rate_tst, 0, sizeof(*rate_tst));
+    params_.ref_func(&param_, &pre_quant_, &coeff_ctx_, blk_pos_, diag_ctx_,
+                     eob_rate_, coeff_sign_, rate_ref);
+    ASM_REGISTER_STATE_CHECK(params_.tst_func(&param_, &pre_quant_, &coeff_ctx_,
+                                              blk_pos_, diag_ctx_, eob_rate_,
+                                              coeff_sign_, rate_tst));
+  }
+
+  void RunTest() {
+    for (int iter = 0; iter < kIterations && !HasFatalFailure(); ++iter) {
+      int log_scale = 1;
+      int shift = 16 - log_scale + QUANT_FP_BITS;
+      const int32_t quant[2] = { 1 << shift, 1 << shift };
+      int dqv = 1 << QUANT_TABLE_BITS;
+      int tqc = 0;
+
+      // Initialize param structure.
+      int bwl = 2 + (rng_.Rand8() & 3);
+      int height = 1 << bwl;
+      int diag = rng_.Rand8() & 3;
+      int row = rng_.Rand8() % (diag + 1);
+      int col = diag - row;
+      int blk_pos = (row << bwl) + col;
+      int scan_pos = blk_pos;
+      int diag_ctx = get_nz_map_ctx_from_stats_lf(0, blk_pos, bwl, TX_CLASS_2D);
+      if (scan_pos > 0) {
+        diag_ctx += 7 << 8;
+      }
+
+      blk_pos_ = blk_pos;
+      diag_ctx_ = diag_ctx;
+      coeff_sign_ = rng_.Rand8() & 1;
+      param_.bwl = bwl;
+      param_.txb_height = height;
+      param_.tx_class = 0;
+      param_.txb_costs = &txb_costs_;
+      param_.tmp_sign = tmp_sign_;
+      param_.dc_sign_ctx = rng_.Rand8() % DC_SIGN_CONTEXTS;
+      tmp_sign_[blk_pos] = rng_.Rand8() % CROSS_COMPONENT_CONTEXTS;
+
+      // Generate random syntax costs.
+      generate_random_cost_tables(&rng_, &txb_costs_);
+
+      // Generate pre_quant info for q1.
+      av2_pre_quant_q1(tqc, &pre_quant_, quant, dqv, log_scale, scan_pos);
+      eob_rate_ = rng_(512 * 4);
+
+      // Generate random coeff_ctx
+      for (int i = 0; i < 8; i++) {
+        coeff_ctx_.coef[i] = (rng_(4) << 4) + rng_(4);
+      }
+      coeff_ctx_.coef_eob = get_lower_levels_ctx_eob(bwl, height, scan_pos);
+      coeff_ctx_.pad[0] = 0;
+      coeff_ctx_.pad[1] = 0;
+      coeff_ctx_.pad[2] = 0;
+
+      tcq_rate_t rate_ref, rate_tst;
+      Execute(&rate_ref, &rate_tst);
+
+      for (int i = 0; i < 8; i++) {
+        ASSERT_EQ(rate_ref.rate_zero[i], rate_tst.rate_zero[i])
+            << "rate_zero mismatch at i=" << i;
+      }
+      ASSERT_EQ(rate_ref.rate_eob[1], rate_tst.rate_eob[1]);
+      ASSERT_EQ(rate_ref.rate[1], rate_tst.rate[1]);
+      ASSERT_EQ(rate_ref.rate[3], rate_tst.rate[3]);
+      ASSERT_EQ(rate_ref.rate[4], rate_tst.rate[4]);
+      ASSERT_EQ(rate_ref.rate[6], rate_tst.rate[6]);
+      ASSERT_EQ(rate_ref.rate[9], rate_tst.rate[9]);
+      ASSERT_EQ(rate_ref.rate[11], rate_tst.rate[11]);
+      ASSERT_EQ(rate_ref.rate[12], rate_tst.rate[12]);
+      ASSERT_EQ(rate_ref.rate[14], rate_tst.rate[14]);
+    }
+  }
+
+  tcq_param_t param_;
+  LV_MAP_COEFF_COST txb_costs_;
+  prequant_t pre_quant_;
+  tcq_coeff_ctx_t coeff_ctx_;
+  int blk_pos_;
+  int diag_ctx_;
+  int eob_rate_;
+  int coeff_sign_;
+  int tmp_sign_[1024];
+};
+
+TEST_P(TcqRateLfLumaQ1Test, RandomValues) { RunTest(); }
 
 typedef void (*TcqUpdateNbrDiagonalFunc)(struct tcq_ctx_t *tcq_ctx, int row,
                                          int col, int bwl);
@@ -470,16 +651,271 @@ class TcqUpdateNbrDiagonalTest
 
 TEST_P(TcqUpdateNbrDiagonalTest, RandomValues) { RunTest(); }
 
+typedef void (*PreQuantFunc)(tran_low_t tqc, struct prequant_t *pqData,
+                             const int32_t *quant_ptr, int dqv, int log_scale,
+                             int scan_pos);
+typedef libavm_test::FuncParam<PreQuantFunc> PreQuantTestFuncs;
+
+class PreQuantTest : public FunctionEquivalenceTest<PreQuantFunc> {
+ protected:
+  static const int kIterations = 100000;
+
+  void Execute(prequant_t *ref, prequant_t *tst) {
+    memset(ref, 0, sizeof(*ref));
+    memset(tst, 0, sizeof(*tst));
+    params_.ref_func(tqc_, ref, quant_, dqv_, log_scale_, scan_pos_);
+    ASM_REGISTER_STATE_CHECK(
+        params_.tst_func(tqc_, tst, quant_, dqv_, log_scale_, scan_pos_));
+  }
+
+  void RunTest() {
+    for (int iter = 0; iter < kIterations && !HasFatalFailure(); ++iter) {
+      log_scale_ = 1 + (rng_.Rand8() % 3);
+      int shift = 16 - log_scale_ + QUANT_FP_BITS;
+      quant_[0] = 1 << shift;
+      quant_[1] = 1 << shift;
+      dqv_ = rng_(1 << (QUANT_TABLE_BITS + 4));
+      scan_pos_ = rng_.Rand8() % 64;
+      tqc_ = (tran_low_t)(rng_.Rand16() - 32768);
+
+      prequant_t ref, tst;
+      Execute(&ref, &tst);
+
+      ASSERT_EQ(ref.qIdx, tst.qIdx);
+      for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(ref.absLevel[i], tst.absLevel[i]);
+        ASSERT_EQ(ref.deltaDist[i], tst.deltaDist[i]);
+      }
+    }
+  }
+
+  tran_low_t tqc_;
+  int32_t quant_[2];
+  int dqv_;
+  int log_scale_;
+  int scan_pos_;
+};
+
+TEST_P(PreQuantTest, RandomValues) { RunTest(); }
+
+class PreQuantQ1Test : public FunctionEquivalenceTest<PreQuantFunc> {
+ protected:
+  static const int kIterations = 100000;
+
+  void Execute(prequant_t *ref, prequant_t *tst) {
+    memset(ref, 0, sizeof(*ref));
+    memset(tst, 0, sizeof(*tst));
+    params_.ref_func(tqc_, ref, quant_, dqv_, log_scale_, scan_pos_);
+    ASM_REGISTER_STATE_CHECK(
+        params_.tst_func(tqc_, tst, quant_, dqv_, log_scale_, scan_pos_));
+  }
+
+  void RunTest() {
+    for (int iter = 0; iter < kIterations && !HasFatalFailure(); ++iter) {
+      log_scale_ = 1 + (rng_.Rand8() % 3);
+      int shift = 16 - log_scale_ + QUANT_FP_BITS;
+      quant_[0] = 1 << shift;
+      quant_[1] = 1 << shift;
+      dqv_ = rng_(1 << (QUANT_TABLE_BITS + 4));
+      scan_pos_ = rng_.Rand8() % 64;
+      tqc_ = (tran_low_t)(rng_.Rand16() - 32768);
+
+      prequant_t ref, tst;
+      Execute(&ref, &tst);
+
+      ASSERT_EQ(ref.qIdx, tst.qIdx);
+      ASSERT_EQ(ref.absLevel[1], tst.absLevel[1]);
+      ASSERT_EQ(ref.absLevel[2], tst.absLevel[2]);
+      ASSERT_EQ(ref.deltaDist[1], tst.deltaDist[1]);
+      ASSERT_EQ(ref.deltaDist[2], tst.deltaDist[2]);
+    }
+  }
+
+  tran_low_t tqc_;
+  int32_t quant_[2];
+  int dqv_;
+  int log_scale_;
+  int scan_pos_;
+};
+
+TEST_P(PreQuantQ1Test, RandomValues) { RunTest(); }
+
+typedef void (*TcqDecideStatesFunc)(const struct tcq_node_t *prev,
+                                    const struct tcq_rate_t *rd,
+                                    const struct prequant_t *pq, int limits,
+                                    int try_eob, int64_t rdmult,
+                                    struct tcq_node_t *decision);
+typedef libavm_test::FuncParam<TcqDecideStatesFunc> TcqDecideStatesTestFuncs;
+
+class TcqDecideStatesTest
+    : public FunctionEquivalenceTest<TcqDecideStatesFunc> {
+ protected:
+  static const int kIterations = 100000;
+
+  void Execute(tcq_node_t *ref, tcq_node_t *tst) {
+    memset(ref, 0, sizeof(tcq_node_t) * TCQ_N_STATES);
+    memset(tst, 0, sizeof(tcq_node_t) * TCQ_N_STATES);
+    params_.ref_func(prev_, &rd_, &pq_, limits_, try_eob_, rdmult_, ref);
+    ASM_REGISTER_STATE_CHECK(
+        params_.tst_func(prev_, &rd_, &pq_, limits_, try_eob_, rdmult_, tst));
+  }
+
+  void RunTest() {
+    for (int iter = 0; iter < kIterations && !HasFatalFailure(); ++iter) {
+      for (int i = 0; i < TCQ_N_STATES; i++) {
+        prev_[i].rdCost = rng_(1 << 20);
+        prev_[i].rate = rng_(1 << 16);
+        prev_[i].absLevel = rng_.Rand8() % 16;
+        prev_[i].prevId = rng_.Rand8() % 8;
+      }
+      for (int i = 0; i < 2 * TCQ_MAX_STATES; i++) {
+        rd_.rate[i] = rng_(1 << 16);
+      }
+      for (int i = 0; i < TCQ_MAX_STATES; i++) {
+        rd_.rate_zero[i] = rng_(1 << 16);
+      }
+      rd_.rate_eob[0] = rng_(1 << 16);
+      rd_.rate_eob[1] = rng_(1 << 16);
+
+      pq_.absLevel[0] = (rng_.Rand8() % 8) * 2;
+      pq_.absLevel[1] = (rng_.Rand8() % 8) * 2 + 1;
+      pq_.absLevel[2] = (rng_.Rand8() % 8) * 2 + 1;
+      pq_.absLevel[3] = (rng_.Rand8() % 8) * 2;
+      for (int i = 0; i < 4; i++) {
+        pq_.deltaDist[i] = (int64_t)rng_(1 << 20);
+      }
+      pq_.qIdx = 1 + (rng_.Rand8() % 16);
+      limits_ = 0;
+      try_eob_ = rng_.Rand8() & 1;
+      rdmult_ = rng_(1 << 16);
+
+      tcq_node_t ref[TCQ_N_STATES], tst[TCQ_N_STATES];
+      Execute(ref, tst);
+
+      for (int i = 0; i < TCQ_N_STATES; i++) {
+        ASSERT_EQ(ref[i].rdCost, tst[i].rdCost) << "rdCost mismatch at i=" << i;
+        ASSERT_EQ(ref[i].rate, tst[i].rate) << "rate mismatch at i=" << i;
+        ASSERT_EQ(ref[i].absLevel, tst[i].absLevel)
+            << "absLevel mismatch at i=" << i;
+        ASSERT_EQ(ref[i].prevId, tst[i].prevId) << "prevId mismatch at i=" << i;
+      }
+    }
+  }
+
+  tcq_node_t prev_[TCQ_N_STATES];
+  tcq_rate_t rd_;
+  prequant_t pq_;
+  int limits_;
+  int try_eob_;
+  int64_t rdmult_;
+};
+
+TEST_P(TcqDecideStatesTest, RandomValues) { RunTest(); }
+
+class TcqDecideStatesQ1Test
+    : public FunctionEquivalenceTest<TcqDecideStatesFunc> {
+ protected:
+  static const int kIterations = 100000;
+
+  void Execute(tcq_node_t *ref, tcq_node_t *tst) {
+    memset(ref, 0, sizeof(tcq_node_t) * TCQ_N_STATES);
+    memset(tst, 0, sizeof(tcq_node_t) * TCQ_N_STATES);
+    params_.ref_func(prev_, &rd_, &pq_, limits_, try_eob_, rdmult_, ref);
+    ASM_REGISTER_STATE_CHECK(
+        params_.tst_func(prev_, &rd_, &pq_, limits_, try_eob_, rdmult_, tst));
+  }
+
+  void RunTest() {
+    for (int iter = 0; iter < kIterations && !HasFatalFailure(); ++iter) {
+      for (int i = 0; i < TCQ_N_STATES; i++) {
+        prev_[i].rdCost = rng_(1 << 20);
+        prev_[i].rate = rng_(1 << 16);
+        prev_[i].absLevel = rng_.Rand8() % 16;
+        prev_[i].prevId = rng_.Rand8() % 8;
+      }
+      for (int i = 0; i < 2 * TCQ_MAX_STATES; i++) {
+        rd_.rate[i] = rng_(1 << 16);
+      }
+      for (int i = 0; i < TCQ_MAX_STATES; i++) {
+        rd_.rate_zero[i] = rng_(1 << 16);
+      }
+      rd_.rate_eob[0] = rng_(1 << 16);
+      rd_.rate_eob[1] = rng_(1 << 16);
+
+      pq_.absLevel[0] = 0;
+      pq_.absLevel[1] = 1;
+      pq_.absLevel[2] = 1;
+      pq_.absLevel[3] = 0;
+      pq_.deltaDist[0] = (int64_t)rng_(1 << 20);
+      pq_.deltaDist[1] = (int64_t)rng_(1 << 20);
+      pq_.deltaDist[2] = (int64_t)rng_(1 << 20);
+      pq_.deltaDist[3] = (int64_t)rng_(1 << 20);
+      pq_.qIdx = 1;
+      limits_ = 0;
+      try_eob_ = rng_.Rand8() & 1;
+      rdmult_ = rng_(1 << 16);
+
+      tcq_node_t ref[TCQ_N_STATES], tst[TCQ_N_STATES];
+      Execute(ref, tst);
+
+      for (int i = 0; i < TCQ_N_STATES; i++) {
+        ASSERT_EQ(ref[i].rdCost, tst[i].rdCost) << "rdCost mismatch at i=" << i;
+        ASSERT_EQ(ref[i].rate, tst[i].rate) << "rate mismatch at i=" << i;
+        ASSERT_EQ(ref[i].absLevel, tst[i].absLevel)
+            << "absLevel mismatch at i=" << i;
+        ASSERT_EQ(ref[i].prevId, tst[i].prevId) << "prevId mismatch at i=" << i;
+      }
+    }
+  }
+
+  tcq_node_t prev_[TCQ_N_STATES];
+  tcq_rate_t rd_;
+  prequant_t pq_;
+  int limits_;
+  int try_eob_;
+  int64_t rdmult_;
+};
+
+TEST_P(TcqDecideStatesQ1Test, RandomValues) { RunTest(); }
+
 #if HAVE_AVX2
+INSTANTIATE_TEST_SUITE_P(
+    AVX2, TcqDecideStatesTest,
+    ::testing::Values(TcqDecideStatesTestFuncs(av2_decide_states_c,
+                                               av2_decide_states_avx2)));
+
+INSTANTIATE_TEST_SUITE_P(
+    AVX2, TcqDecideStatesQ1Test,
+    ::testing::Values(TcqDecideStatesTestFuncs(av2_decide_states_q1_c,
+                                               av2_decide_states_q1_avx2)));
+
+INSTANTIATE_TEST_SUITE_P(
+    AVX2, PreQuantTest,
+    ::testing::Values(PreQuantTestFuncs(av2_pre_quant_c, av2_pre_quant_avx2)));
+
+INSTANTIATE_TEST_SUITE_P(
+    AVX2, PreQuantQ1Test,
+    ::testing::Values(PreQuantTestFuncs(av2_pre_quant_q1_c, av2_pre_quant_q1_avx2)));
+
 INSTANTIATE_TEST_SUITE_P(
     AVX2, TcqRateLumaTest,
     ::testing::Values(TcqRateLumaTestFuncs(av2_get_rate_dist_def_luma_c,
                                            av2_get_rate_dist_def_luma_avx2)));
 
 INSTANTIATE_TEST_SUITE_P(
+    AVX2, TcqRateLumaQ1Test,
+    ::testing::Values(TcqRateLumaTestFuncs(av2_get_rate_dist_def_luma_q1_c,
+                                           av2_get_rate_dist_def_luma_q1_avx2)));
+
+INSTANTIATE_TEST_SUITE_P(
     AVX2, TcqRateLfLumaTest,
     ::testing::Values(TcqRateLfLumaTestFuncs(av2_get_rate_dist_lf_luma_c,
                                              av2_get_rate_dist_lf_luma_avx2)));
+
+INSTANTIATE_TEST_SUITE_P(
+    AVX2, TcqRateLfLumaQ1Test,
+    ::testing::Values(TcqRateLfLumaTestFuncs(av2_get_rate_dist_lf_luma_q1_c,
+                                             av2_get_rate_dist_lf_luma_q1_avx2)));
 
 INSTANTIATE_TEST_SUITE_P(AVX2, TcqUpdateNbrDiagonalTest,
                          ::testing::Values(TcqUpdateNbrDiagonalTestFuncs(
@@ -487,9 +923,21 @@ INSTANTIATE_TEST_SUITE_P(AVX2, TcqUpdateNbrDiagonalTest,
                              av2_update_nbr_diagonal_avx2)));
 #endif  // HAVE_AVX2
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TcqDecideStatesTest);
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TcqDecideStatesQ1Test);
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PreQuantTest);
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PreQuantQ1Test);
+
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TcqRateLumaTest);
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TcqRateLumaQ1Test);
+
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TcqRateLfLumaTest);
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TcqRateLfLumaQ1Test);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TcqUpdateNbrDiagonalTest);
 

--- a/test/trellis_test.cc
+++ b/test/trellis_test.cc
@@ -879,10 +879,9 @@ class TcqDecideStatesQ1Test
 TEST_P(TcqDecideStatesQ1Test, RandomValues) { RunTest(); }
 
 #if HAVE_AVX2
-INSTANTIATE_TEST_SUITE_P(
-    AVX2, TcqDecideStatesTest,
-    ::testing::Values(TcqDecideStatesTestFuncs(av2_decide_states_c,
-                                               av2_decide_states_avx2)));
+INSTANTIATE_TEST_SUITE_P(AVX2, TcqDecideStatesTest,
+                         ::testing::Values(TcqDecideStatesTestFuncs(
+                             av2_decide_states_c, av2_decide_states_avx2)));
 
 INSTANTIATE_TEST_SUITE_P(
     AVX2, TcqDecideStatesQ1Test,
@@ -893,29 +892,29 @@ INSTANTIATE_TEST_SUITE_P(
     AVX2, PreQuantTest,
     ::testing::Values(PreQuantTestFuncs(av2_pre_quant_c, av2_pre_quant_avx2)));
 
-INSTANTIATE_TEST_SUITE_P(
-    AVX2, PreQuantQ1Test,
-    ::testing::Values(PreQuantTestFuncs(av2_pre_quant_q1_c, av2_pre_quant_q1_avx2)));
+INSTANTIATE_TEST_SUITE_P(AVX2, PreQuantQ1Test,
+                         ::testing::Values(PreQuantTestFuncs(
+                             av2_pre_quant_q1_c, av2_pre_quant_q1_avx2)));
 
 INSTANTIATE_TEST_SUITE_P(
     AVX2, TcqRateLumaTest,
     ::testing::Values(TcqRateLumaTestFuncs(av2_get_rate_dist_def_luma_c,
                                            av2_get_rate_dist_def_luma_avx2)));
 
-INSTANTIATE_TEST_SUITE_P(
-    AVX2, TcqRateLumaQ1Test,
-    ::testing::Values(TcqRateLumaTestFuncs(av2_get_rate_dist_def_luma_q1_c,
-                                           av2_get_rate_dist_def_luma_q1_avx2)));
+INSTANTIATE_TEST_SUITE_P(AVX2, TcqRateLumaQ1Test,
+                         ::testing::Values(TcqRateLumaTestFuncs(
+                             av2_get_rate_dist_def_luma_q1_c,
+                             av2_get_rate_dist_def_luma_q1_avx2)));
 
 INSTANTIATE_TEST_SUITE_P(
     AVX2, TcqRateLfLumaTest,
     ::testing::Values(TcqRateLfLumaTestFuncs(av2_get_rate_dist_lf_luma_c,
                                              av2_get_rate_dist_lf_luma_avx2)));
 
-INSTANTIATE_TEST_SUITE_P(
-    AVX2, TcqRateLfLumaQ1Test,
-    ::testing::Values(TcqRateLfLumaTestFuncs(av2_get_rate_dist_lf_luma_q1_c,
-                                             av2_get_rate_dist_lf_luma_q1_avx2)));
+INSTANTIATE_TEST_SUITE_P(AVX2, TcqRateLfLumaQ1Test,
+                         ::testing::Values(TcqRateLfLumaTestFuncs(
+                             av2_get_rate_dist_lf_luma_q1_c,
+                             av2_get_rate_dist_lf_luma_q1_avx2)));
 
 INSTANTIATE_TEST_SUITE_P(AVX2, TcqUpdateNbrDiagonalTest,
                          ::testing::Values(TcqUpdateNbrDiagonalTestFuncs(


### PR DESCRIPTION
Add functions to handle the coefficients that are quantized to 1.
In such cases, there is no need to check upper abs levels in the
trellis framework, and hence reducing the complexity.

Anchor: https://github.com/AOMediaCodec/avm/commit/b5bb354c8000eff7a0e535b93639b813a2f7f352

Test condition: CTC, RA, 33 frames, speed 1
```
+---------+--------+--------+--------+--------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time |
+---------+--------+--------+--------+--------+----------+
| A1      |  0.03% |  0.06% |  -0.12% |  0.02% | 96.12%   |
| A2      |  0.06% |  0.31% |  -0.19% |  0.06% | 96.18%   |
| A3      |  0.11% |  -0.21% | -0.42% |  0.06% | 97.11%   |
| A4      |  0.16% |  0.76% |  -0.91% |  0.14% | 97.20%   |
| A5      | -0.12% | -0.17% | -1.18% | -0.20% | 96.32%   |
| B1      | -0.12% |  0.03% |  0.03% | -0.11% | 96.15%   |
|avg wo b2|  0.03% |  0.16% | -0.32% |  0.01% | 96.42%   |
+---------+--------+--------+--------+--------+----------+
STATS_CHANGED