### PR TITLE
Add reference-frame-selective warp search speed feature

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -2440,13 +2440,20 @@ static AVM_INLINE int handle_simple_translation_mode(
   return 0;
 }
 
+static AVM_INLINE WARP_SEARCH_METHOD get_warp_search_method(
+    const AV2_COMP *cpi, int eval_motion_mode, MV_REFERENCE_FRAME ref_frame) {
+  if (eval_motion_mode || ref_frame == 0)
+    return cpi->sf.mv_sf.warp_search_method;
+  return cpi->sf.mv_sf.warp_search_method_sec_ref;
+}
+
 // Handle WARP_CAUSAL motion mode: compute least-squares warp models from
 // projection samples, optionally refine MVs, build warped predictor.
 // Returns -1 to skip this motion mode iteration, 0 on success.
 static AVM_INLINE int handle_warp_causal_mode(
     const AV2_COMP *cpi, MACROBLOCK *x, BLOCK_SIZE bsize, MB_MODE_INFO *mbmi,
     PREDICTION_MODE this_mode, int rate2_nocoeff, int rate_mv0,
-    int *tmp_rate_mv, int *tmp_rate2) {
+    int *tmp_rate_mv, int *tmp_rate2, int eval_motion_mode) {
   const AV2_COMMON *cm = &cpi->common;
   MACROBLOCKD *xd = &x->e_mbd;
   const int mi_row = xd->mi_row;
@@ -2500,9 +2507,10 @@ static AVM_INLINE int handle_warp_causal_mode(
       av2_make_default_subpel_ms_params(
           &ms_params, cpi, x, bsize, &ref_mv.as_mv, pb_mv_precision, 0, NULL);
       // Refine MV in a small range.
-      av2_refine_warped_mv(xd, cm, &ms_params, bsize, pts0, pts_inref0,
-                           total_samples0, 0, cpi->sf.mv_sf.warp_search_method,
-                           cpi->sf.mv_sf.warp_search_iters);
+      av2_refine_warped_mv(
+          xd, cm, &ms_params, bsize, pts0, pts_inref0, total_samples0, 0,
+          get_warp_search_method(cpi, eval_motion_mode, mbmi->ref_frame[0]),
+          cpi->sf.mv_sf.warp_search_iters);
       if (mv0.as_int != mbmi->mv[0].as_int) {
         if (mbmi->mode == NEW_NEWMV) {
           int tmp_rate_mv0 = av2_mv_bit_cost(
@@ -2530,9 +2538,10 @@ static AVM_INLINE int handle_warp_causal_mode(
       av2_make_default_subpel_ms_params(
           &ms_params, cpi, x, bsize, &ref_mv.as_mv, pb_mv_precision, 0, NULL);
       // Refine MV in a small range.
-      av2_refine_warped_mv(xd, cm, &ms_params, bsize, pts1, pts_inref1,
-                           total_samples1, 1, cpi->sf.mv_sf.warp_search_method,
-                           cpi->sf.mv_sf.warp_search_iters);
+      av2_refine_warped_mv(
+          xd, cm, &ms_params, bsize, pts1, pts_inref1, total_samples1, 1,
+          get_warp_search_method(cpi, eval_motion_mode, mbmi->ref_frame[1]),
+          cpi->sf.mv_sf.warp_search_iters);
 
       if (mv1.as_int != mbmi->mv[1].as_int) {
         int tmp_rate_mv1 = av2_mv_bit_cost(
@@ -2628,7 +2637,8 @@ static AVM_INLINE int handle_warp_delta_mode(
     if (!cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode ||
         !eval_motion_mode)
       valid = av2_refine_mv_for_base_param_warp_model(
-          cm, xd, mbmi, mbmi_ext, &ms_params, cpi->sf.mv_sf.warp_search_method,
+          cm, xd, mbmi, mbmi_ext, &ms_params,
+          get_warp_search_method(cpi, eval_motion_mode, mbmi->ref_frame[0]),
           cpi->sf.mv_sf.warp_search_iters);
   } else {
     mbmi->six_param_warp_model_flag = get_default_six_param_flag(cm, mbmi);
@@ -2673,7 +2683,7 @@ static AVM_INLINE int handle_warp_delta_mode(
 static AVM_INLINE int handle_warp_extend_mode(
     const AV2_COMP *cpi, MACROBLOCK *x, BLOCK_SIZE bsize, MB_MODE_INFO *mbmi,
     const MB_MODE_INFO_EXT *mbmi_ext, int rate2_nocoeff, int rate_mv0,
-    int *tmp_rate_mv, int *tmp_rate2) {
+    int *tmp_rate_mv, int *tmp_rate2, int eval_motion_mode) {
   const AV2_COMMON *cm = &cpi->common;
   MACROBLOCKD *xd = &x->e_mbd;
   const int mi_row = xd->mi_row;
@@ -2743,7 +2753,8 @@ static AVM_INLINE int handle_warp_extend_mode(
   // Refine motion vector
   av2_refine_mv_for_warp_extend(
       cm, xd, &ms_params, neighbor_is_above, bsize, &neighbor_params,
-      cpi->sf.mv_sf.warp_search_method, cpi->sf.mv_sf.warp_search_iters);
+      get_warp_search_method(cpi, eval_motion_mode, mbmi->ref_frame[0]),
+      cpi->sf.mv_sf.warp_search_iters);
 
   // If we changed the MV, update costs
   if (mv0.as_int != mbmi->mv[0].as_int) {
@@ -2996,7 +3007,7 @@ static AVM_INLINE int evaluate_motion_mode_trial(
   } else if (mbmi->motion_mode == WARP_CAUSAL) {
     if (handle_warp_causal_mode(cpi, x, bsize, mbmi, base_mbmi->mode,
                                 ctx->rate2_nocoeff, ctx->rate_mv0, &tmp_rate_mv,
-                                &tmp_rate2) < 0)
+                                &tmp_rate2, eval_motion_mode) < 0)
       return -1;
   } else if (mbmi->motion_mode == INTERINTRA) {
     if (cpi->sf.inter_sf.prune_interintra_by_ref_idx && mbmi->ref_frame[0] > 1)
@@ -3017,7 +3028,7 @@ static AVM_INLINE int evaluate_motion_mode_trial(
   } else if (mbmi->motion_mode == WARP_EXTEND) {
     if (handle_warp_extend_mode(cpi, x, bsize, mbmi, mbmi_ext,
                                 ctx->rate2_nocoeff, ctx->rate_mv0, &tmp_rate_mv,
-                                &tmp_rate2) < 0)
+                                &tmp_rate2, eval_motion_mode) < 0)
       return -1;
   }
 

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -418,6 +418,8 @@ static void set_good_speed_features_framesize_independent(
   }
 
   if (speed >= 2) {
+    sf->mv_sf.warp_search_method_sec_ref = WARP_SEARCH_DIAMOND;
+
     sf->lpf_sf.early_terminate_ccso_search_by_cost = 1;
     sf->part_sf.partition_pruning_with_mlp_none_thresh = 2.5f;
     sf->part_sf.intra_cnn_split = 0;
@@ -796,6 +798,7 @@ static AVM_INLINE void init_mv_sf(MV_SPEED_FEATURES *mv_sf) {
   mv_sf->use_fullpel_costlist = 0;
   mv_sf->use_downsampled_sad = 0;
   mv_sf->warp_search_method = WARP_SEARCH_SQUARE;
+  mv_sf->warp_search_method_sec_ref = WARP_SEARCH_SQUARE;
   mv_sf->warp_search_iters = 8;
   mv_sf->fast_motion_estimation_on_block_256 = 0;
 }

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -538,8 +538,13 @@ typedef struct MV_SPEED_FEATURES {
   // Method to use for refining WARP_CAUSAL motion vectors
   WARP_SEARCH_METHOD warp_search_method;
 
+  // Method to use for refining WARP_CAUSAL motion vectors on secondary reference
+  // frames during coarse inter-mode search
+  WARP_SEARCH_METHOD warp_search_method_sec_ref;
+
   // Maximum number of iterations in WARP_CAUSAL refinement search
   int warp_search_iters;
+
   // Use faster motion search settings for partition blocks with at least one
   // dimension that's >= 256
   int fast_motion_estimation_on_block_256;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -538,8 +538,8 @@ typedef struct MV_SPEED_FEATURES {
   // Method to use for refining WARP_CAUSAL motion vectors
   WARP_SEARCH_METHOD warp_search_method;
 
-  // Method to use for refining WARP_CAUSAL motion vectors on secondary reference
-  // frames during coarse inter-mode search
+  // Method to use for refining WARP_CAUSAL motion vectors on secondary
+  // reference frames during coarse inter-mode search
   WARP_SEARCH_METHOD warp_search_method_sec_ref;
 
   // Maximum number of iterations in WARP_CAUSAL refinement search


### PR DESCRIPTION
Add warp_search_method_sec_ref to MV_SPEED_FEATURES to allow using a faster warp motion search method (DIAMOND) on secondary reference frames during the initial inter-mode search loop, while preserving the primary search method (SQUARE) for the primary reference (LAST_FRAME) and winner mode candidate evaluations.

Enabled for speed >= 2.

Tests: 33 frame CTC against [82a8d03](https://github.com/AOMediaCodec/avm/commit/82a8d033681e0146697ad5d8ec0f175e4aeadb74)

Speed 2:
| Set | Y | U | V | YUV | Enc-time |
| :--- | :--- | :--- | :--- | :--- | :--- |
| A1 | +0.03% | +0.15% | +0.18% | +0.05% | 98.75% | 
| A2 | +0.05% | +0.24% | -0.08% | +0.05% | 98.25% | 
| A3 | +0.05% | +0.27% | +0.11% | +0.06% | 98.12% | 
| A4 | +0.04% | -0.04% | +0.20% | +0.04% | 97.10% | 
| A5 | -0.05% | +0.06% | -0.49% | -0.06% | 96.99% | 
| B1 | +0.02% | -0.02% | +0.00% | +0.02% | 98.03% | 
| B2 | +0.03% | +0.02% | +0.07% | +0.03% | 99.93% | 
| **Overall w/o B2** | **+0.03%** |**+0.14%** | **+0.00%** | **+0.04%** | **98.05%** |

STATS_CHANGED