### PR TITLE
Further increase exhaustive search threshold for speed 1

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -388,7 +388,7 @@ static void set_good_speed_features_framesize_independent(
 
     if (!cpi->is_screen_content_type &&
         cpi->twopass.fr_content_type == FC_HIGHMOTION) {
-      sf->mv_sf.exhaustive_searches_thresh <<= 1;
+      sf->mv_sf.exhaustive_searches_thresh = (1 << 26);
     }
     // Skip the second-best full-pel candidate's subpel refinement in the
     // single-ref NEWMV search.
@@ -447,8 +447,6 @@ static void set_good_speed_features_framesize_independent(
 
     if (cpi->is_screen_content_type) {
       sf->mv_sf.exhaustive_searches_thresh = (1 << 21);
-    } else {
-      sf->mv_sf.exhaustive_searches_thresh = (1 << 26);
     }
     sf->mv_sf.subpel_search_type = USE_4_TAPS;
 


### PR DESCRIPTION
Results for RA CTC, A1 17 frames, A2 33 frames, speed 1: (Anchor: a341351)
```
+------------+-------+-------+-------+-------+---------------+
| Class      |     Y |    Cb |    Cr |  wAvg |EncInstCount(%)|
+------------+-------+-------+-------+-------+---------------+
| A2         |  0.04 |  0.58 |  0.21 |  0.07 |   85.89       |
| A1         |  0.09 |  0.18 | -0.07 |  0.09 |   90.75       |
+------------+-------+-------+-------+-------+---------------+
```
STATS_CHANGED for speed=1