### PR TITLE
mv_sf tuning for speed >= 1

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -177,6 +177,12 @@ static void set_good_speed_feature_framesize_dependent(
     sf->mv_sf.use_downsampled_sad = 1;
   }
 
+  if (speed >= 1) {
+    if (!is_4k_or_larger) {
+      sf->mv_sf.prune_mesh_search = 1;
+    }
+  }
+
   if (speed >= 2) {
     if (is_720p_or_larger) {
       sf->part_sf.use_square_partition_only_threshold = BLOCK_128X128;
@@ -415,6 +421,12 @@ static void set_good_speed_features_framesize_independent(
     sf->part_sf.partition_pruning_with_mlp = 1;
     sf->part_sf.partition_pruning_with_mlp_none_thresh = 3.5f;
     sf->lpf_sf.enable_deblock_for_partition_search = 1;
+    if (!allow_screen_content_tools) {
+      sf->mv_sf.newmv_drl_search_limit = boosted ? 2 : 1;
+    }
+    sf->mv_sf.reduce_search_range = 1;
+    sf->mv_sf.subpel_search_type = boosted ? USE_8_TAPS : USE_4_TAPS;
+    sf->mv_sf.subpel_iters_per_step = boosted ? 2 : 1;
   }
 
   if (speed >= 2) {


### PR DESCRIPTION
mv_sf tuning for speed >= 1

Anchor: a341351f73129e48ee134579154c16b80496de05

Test condition: CTC, RA, 33 frames, speed 1
```
+---------+--------+--------+--------+--------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time |
+---------+--------+--------+--------+--------+----------+
| A1      |  0.04% |  0.11% |  0.04% |  0.04% | 98.76%   |
| A2      |  0.05% |  0.26% |  0.04% |  0.05% | 96.51%   |
| A3      | -0.04% |  0.09% | -0.19% | -0.05% | 99.35%   |
| A4      | -0.05% | -0.61% |  0.18% | -0.06% | 97.19%   |
| A5      | -0.09% | -0.67% | -0.51% | -0.15% | 96.38%   |
| B1      |  0.09% |  0.12% |  0.02% |  0.08% | 96.24%   |
|avg wo b2|  0.02% |  0.03% | -0.02% |  0.01% | 97.26%   |
+---------+--------+--------+--------+--------+----------+

STATS_CHANGED