### PR TITLE
Disable enable_winner_mode_for_coeff_opt

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -555,7 +555,9 @@ static void set_good_speed_features_framesize_independent(
 
     // TODO(any): Refactor the code related to following winner mode speed
     // features
-    sf->winner_mode_sf.enable_winner_mode_for_coeff_opt = 1;
+    // TODO(any):this speed feature cause coding loss with no speed up, disable
+    // it before the issue is fixed
+    // sf->winner_mode_sf.enable_winner_mode_for_coeff_opt = 1;
     // TODO(any): Re-enable for inter frames after fixing speed feature.
     sf->winner_mode_sf.enable_winner_mode_for_tx_size_srch = 0;
     sf->winner_mode_sf.enable_winner_mode_for_use_tx_domain_dist = 1;


### PR DESCRIPTION
sf->winner_mode_sf.enable_winner_mode_for_coeff_opt is set to 1 for speed >= 3. However it causes 0.94% coding loss with no speed up. This PR disables this speed feature.

33 frame RA test results with speed 3:

```
Sequence            PSNR-Y   PSNR-U   PSNR-V  PSNR-YUV   SSIM   MS-SSIM    VMAF   VMAF-N  EncTime  DecTime 
------------------------------------------------------------------------------------------------------------------
(RA, A1)                -0.76%    -0.79%     -0.74%    -0.75%     -0.63%    -0.69%    -0.92%   -0.95%    99.99%   99.48%
------------------------------------------------------------------------------------------------------------------
(RA, A2)               -1.01%    -0.98%     -0.32%    -0.98%    -0.96%    -1.02%     -1.25%    -1.31%     99.72%   99.27%
------------------------------------------------------------------------------------------------------------------ 

Overall w/o B2 (RA)  -0.94%   -0.80%   -0.83%     -0.94%    -0.82%    -0.93%    -1.27%     -1.30%     99.77%   99.43%
```