### PR TITLE
Add a speed feature to prune ref_mv_idx for WARP_NEWMV 

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -5147,6 +5147,22 @@ static void evaluate_inter_predictor(AV2_COMP *const cpi,
   mbmi->motion_mode = SIMPLE_TRANSLATION;
 }
 
+// Prune ref_mv_idx > 0 for WARP_NEWMV mode based on best motion mode chosen so
+// far and ref_frame
+static INLINE bool prune_ref_mv_idx_for_warp_newmv(
+    const MB_MODE_INFO *mbmi, int64_t best_rd, int64_t best_mode_rd_so_far,
+    int is_best_mode_warp, int ref_mv_idx_0, bool prune_warp_newmv_ref_mv_idx) {
+  if (!prune_warp_newmv_ref_mv_idx) return false;
+  if (mbmi->mode != WARP_NEWMV) return false;
+  if ((is_best_mode_warp || best_rd < best_mode_rd_so_far) &&
+      mbmi->ref_frame[0] == 0)
+    return false;
+
+  if (ref_mv_idx_0 > 0) return true;
+
+  return false;
+}
+
 /*!\brief AV2 inter mode RD computation
  *
  * \ingroup inter_mode_search
@@ -5207,6 +5223,9 @@ static void evaluate_inter_predictor(AV2_COMP *const cpi,
  * data collected in the TPL model.
  * \param[in]     top_motion_mode_model_rd A buffer to store N number of model
  * RD
+ * \param[in]     is_best_mode_warp        Flag indicating whether the best
+ *                                         motion mode chosen so far is a warp
+ *                                         motion mode.
  *
  * \return The RD cost for the mode being searched.
  */
@@ -5220,7 +5239,7 @@ static int64_t handle_inter_mode(
     InterModesInfo *inter_modes_info, motion_mode_candidate *motion_mode_cand,
     int64_t *skip_rd, PREDICTION_MODE best_ref_mode,
     int64_t top_motion_mode_model_rd[],
-    PruneInfoFromTpl *inter_cost_info_from_tpl) {
+    PruneInfoFromTpl *inter_cost_info_from_tpl, int is_best_mode_warp) {
   const AV2_COMMON *cm = &cpi->common;
   const int num_planes = av2_num_planes(cm);
   MACROBLOCKD *xd = &x->e_mbd;
@@ -5266,6 +5285,7 @@ static int64_t handle_inter_mode(
   int64_t newmv_ret_val = INT64_MAX;
   const int is_pb_mv_prec_active = is_pb_mv_precision_active(cm, mbmi, bsize);
   const int has_two_drls = has_second_drl(mbmi);
+  int64_t best_mode_rd_so_far = ref_best_rd;
 
   // First, perform a simple translation search for each of the indices. If
   // an index performs well, it will be fully searched in the main loop
@@ -5458,6 +5478,11 @@ static int64_t handle_inter_mode(
     int ref_mv_idx[2];
     for (ref_mv_idx[1] = 0; ref_mv_idx[1] < ref_set[1]; ++ref_mv_idx[1]) {
       for (ref_mv_idx[0] = 0; ref_mv_idx[0] < ref_set[0]; ++ref_mv_idx[0]) {
+        if (prune_ref_mv_idx_for_warp_newmv(
+                mbmi, *search_state.best_rd, best_mode_rd_so_far,
+                is_best_mode_warp, ref_mv_idx[0],
+                cpi->sf.inter_sf.prune_warp_newmv_ref_mv_idx))
+          continue;
         // apply early termination method to jmvd scaling factors
         if (cpi->sf.inter_sf.early_terminate_jmvd_scale_factor) {
           if (scale_index > 0 && (ref_mv_idx[0] > 0 || ref_mv_idx[1] > 0) &&
@@ -9367,11 +9392,14 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
           enable_tx_prune
               ? (share_across_modes ? pool_shared : pool_per_mode[this_mode])
               : NULL;
+      const int is_best_mode_warp =
+          is_warp_mode(search_state.best_mbmode.motion_mode);
       int64_t this_rd = handle_inter_mode(
           cpi, tile_data, x, bsize, &rd_stats, &rd_stats_y, &rd_stats_uv, &args,
           ref_best_rd, tmp_buf, &x->comp_rd_buffer, &best_est_rd, do_tx_search,
           inter_modes_info, &motion_mode_cand, skip_rd,
-          search_state.best_mbmode.mode, pool, &inter_cost_info_from_tpl);
+          search_state.best_mbmode.mode, pool, &inter_cost_info_from_tpl,
+          is_best_mode_warp);
 
       // collect_single_states uses simple_rd/modelled_rd populated by
       // handle_inter_mode even when this_rd == INT64_MAX, so call before

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -361,6 +361,7 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.prune_warp_delta_by_ref_idx = 1;
     sf->intra_sf.intra_pruning_with_mlp = 1;
     sf->inter_sf.prune_comp_mode_eval_using_est_rd = true;
+    sf->inter_sf.prune_warp_newmv_ref_mv_idx = true;
 
     sf->intra_sf.include_dip_for_top_n_model_rd_pruning = true;
 
@@ -886,6 +887,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->prune_amvd_newmv = 0;
   inter_sf->enable_enhanced_inter_mode_cache_reuse = 0;
   inter_sf->prune_comp_mode_eval_using_est_rd = false;
+  inter_sf->prune_warp_newmv_ref_mv_idx = false;
 }
 
 static AVM_INLINE void init_interp_sf(INTERP_FILTER_SPEED_FEATURES *interp_sf) {

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -798,6 +798,10 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // Prune further evaluation of compound mode using estimated RD Cost of best
   // compound type chosen.
   bool prune_comp_mode_eval_using_est_rd;
+
+  // Prune the evaluation of ref_mv_idx > 0 for WARP_NEWMV modes based on RD
+  // Cost of ref_mv_idx = 0 and best mode so far.
+  bool prune_warp_newmv_ref_mv_idx;
 } INTER_MODE_SPEED_FEATURES;
 
 typedef struct INTERP_FILTER_SPEED_FEATURES {


### PR DESCRIPTION
A speed feature is added to prune ref_mv_idx > 0 for 
WARP_NEWMV modes based on best mode/motion 
mode and ref_frame index. For ref_frame = 0, 
ref_mv_idx > 0 pruning is based on best motion 
mode/mode chosen so far. For other reference frames, 
ref_mv_idx > 0 is always pruned.
  
STATS_CHANGED for speed >= 1

Test results (RA) for Speed 1
  Anchor: commit e0b55de
  A1 - 17 frames
  A2 - 33 frames
    
  ```
  +------------+-------+-------+-------+-------+-------------+
  | Class      |     Y |    Cb |    Cr |  wAvg |EncInstCount%|
  +------------+-------+-------+-------+-------+-------------+
  | A1         |  0.12 |  0.15 | -0.04 |  0.11 |    95.01    |
  | A2         |  0.09 |  0.20 |  0.23 |  0.10 |    94.54    |
  +------------+-------+-------+-------+-------+-------------+
  ```