### PR TITLE
Enable TCQ for all speed levels

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -487,7 +487,7 @@ static void set_good_speed_features_framesize_independent(
     sf->interp_sf.use_interp_filter = 1;
     sf->tx_sf.tx_type_search.skip_tx_search = 1;
     sf->intra_sf.skip_intra_dip_search = true;
-    sf->rd_sf.disable_tcq = 1;
+    sf->rd_sf.disable_tcq = 0;
     // --- End ---
 
     sf->hl_sf.recode_loop = ALLOW_RECODE_KFARFGF;


### PR DESCRIPTION
Enable TCQ for all speed levels

Current it is disabled for speed levels greater than 3

Results:
Anchor: d6b40b789381601440e4ce2cc1164cd57e8c3c7d

Speed 3
```

+-------+-------+-------+-------+-------+-------+------+
| Class |  Y%   |  U%   |  V%   | YUV%  | ENC%  | DEC% |
+-------+-------+-------+-------+-------+-------+------+
| A1    | -1.18 |  0.20 |  0.21 | -1.02 | 114.3 | 98.7 |
| A2    | -1.63 | -0.76 | -0.58 | -1.55 | 115.9 | 99.6 |
+-------+-------+-------+-------+-------+-------+------+

```

Speed 4

```

+-------+-------+-------+-------+-------+-------+-------+
| Class |  Y%   |  U%   |  V%   | YUV%  | ENC%  | DEC%  |
+-------+-------+-------+-------+-------+-------+-------+
| A1    | -1.43 |  0.15 | -0.11 | -1.27 | 109.3 | 100.4 |
| A2    | -2.00 | -0.10 | -0.91 | -1.87 | 112.1 | 100.3 |
+-------+-------+-------+-------+-------+-------+-------+

```