### PR TITLE
Enable partition-deblock-rd for speed 3-6

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -490,8 +490,6 @@ static void set_good_speed_features_framesize_independent(
     sf->rd_sf.disable_tcq = 1;
     // --- End ---
 
-    sf->lpf_sf.enable_deblock_for_partition_search = 0;
-
     sf->hl_sf.recode_loop = ALLOW_RECODE_KFARFGF;
 
     sf->part_sf.allow_partition_search_skip = 1;


### PR DESCRIPTION
This PR is to applying deblocking filter during partition search for speed 3, 4, 5, 6.

With the fix in https://github.com/AOMediaCodec/avm/pull/5267, this feature provides coding gain for all speeds.

33 frame, RA results (Average of A1, A2, A3, A4, A5, B1) are as follows:

```
                   PSNR-Y   PSNR-U   PSNR-V  PSNR-YUV   SSIM   MS-SSIM    VMAF   VMAF-NEG  EncTime  DecTime
Speed 3:       -0.24%   -0.00%   -0.25%   **-0.23%**   -0.28%   -0.28%   -0.39%   -0.39%   101.16%  101.14%
Speed 4:       -0.27%   -0.43%   -0.29%   **-0.28%**   -0.30%   -0.33%   -0.30%   -0.30%    99.49%   99.81%
Speed 5:       -0.32%   -0.62%   -0.42%   **-0.33%**   -0.33%   -0.35%   -0.27%   -0.30%    99.50%  100.00%
Speed 5:       -0.27%   -0.44%   -0.03%   **-0.26%**   -0.27%   -0.29%   -0.22%   -0.26%    98.88%   99.53%
```