### PR TITLE
check_frame_unit_data returns 0 if vcl_found false

### DIFF
--- a/av2/av2_dx_iface.c
+++ b/av2/av2_dx_iface.c
@@ -891,6 +891,7 @@ static size_t check_frame_unit_data(struct AV2Decoder *pbi, const uint8_t *data,
     bytes_available -= bytes_read + payload_size;
   }
 
+  if (!vcl_found) return 0;
   // one frame unit in this data
   return data_sz;
 }


### PR DESCRIPTION
check_frame_unit_data() should return data_sz at the end of the function only when vcl_found is true.

Fixes issue https://github.com/AOMediaCodec/avm/issues/5276.