### PR TITLE
Conditionally reduce max DRL ref MVs for speeds >= 2

### DIFF
--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -1133,14 +1133,11 @@ static void set_max_drl_bits(struct AV2_COMP *cpi) {
     cm->features.max_drl_bits = cm->seq_params.def_max_drl_bits;
   } else {  // Can be changed with logic later
     if (cpi->oxcf.tool_cfg.max_drl_refmvs == 0) {
-      if (cpi->sf.inter_sf.reduce_max_drl_refmvs) {
-        const int is_high_tier_ref =
-            frame_is_kf_gf_arf(cpi) || cm->current_frame.pyramid_level <= 2;
-        cm->features.max_drl_bits = is_high_tier_ref ? (DEF_MAX_DRL_REFMVS - 1)
-                                                     : (DEF_MAX_DRL_REFMVS - 2);
-      } else {
-        cm->features.max_drl_bits = DEF_MAX_DRL_REFMVS - 1;
-      }
+      // Spend one fewer DRL bit on low importance frames
+      const int reduce_drl = cpi->sf.inter_sf.reduce_max_drl_refmvs &&
+                             cm->current_frame.pyramid_level > 2 &&
+                             !frame_is_kf_gf_arf(cpi);
+      cm->features.max_drl_bits = DEF_MAX_DRL_REFMVS - 1 - reduce_drl;
     } else {
       cm->features.max_drl_bits = cpi->oxcf.tool_cfg.max_drl_refmvs - 1;
     }

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -1136,9 +1136,8 @@ static void set_max_drl_bits(struct AV2_COMP *cpi) {
       if (cpi->sf.inter_sf.reduce_max_drl_refmvs) {
         const int is_high_tier_ref =
             frame_is_kf_gf_arf(cpi) || cm->current_frame.pyramid_level <= 2;
-        cm->features.max_drl_bits = is_high_tier_ref
-                                        ? (DEF_MAX_DRL_REFMVS - 1)
-                                        : (DEF_MAX_DRL_REFMVS - 2);
+        cm->features.max_drl_bits = is_high_tier_ref ? (DEF_MAX_DRL_REFMVS - 1)
+                                                     : (DEF_MAX_DRL_REFMVS - 2);
       } else {
         cm->features.max_drl_bits = DEF_MAX_DRL_REFMVS - 1;
       }

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -1133,7 +1133,15 @@ static void set_max_drl_bits(struct AV2_COMP *cpi) {
     cm->features.max_drl_bits = cm->seq_params.def_max_drl_bits;
   } else {  // Can be changed with logic later
     if (cpi->oxcf.tool_cfg.max_drl_refmvs == 0) {
-      cm->features.max_drl_bits = DEF_MAX_DRL_REFMVS - 1;
+      if (cpi->sf.inter_sf.reduce_max_drl_refmvs) {
+        const int is_high_tier_ref =
+            frame_is_kf_gf_arf(cpi) || cm->current_frame.pyramid_level <= 2;
+        cm->features.max_drl_bits = is_high_tier_ref
+                                        ? (DEF_MAX_DRL_REFMVS - 1)
+                                        : (DEF_MAX_DRL_REFMVS - 2);
+      } else {
+        cm->features.max_drl_bits = DEF_MAX_DRL_REFMVS - 1;
+      }
     } else {
       cm->features.max_drl_bits = cpi->oxcf.tool_cfg.max_drl_refmvs - 1;
     }

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -410,10 +410,6 @@ static void set_good_speed_features_framesize_independent(
     // Predictive single-ref NEWMV reuse across the DRL.
     sf->mv_sf.predict_repeated_newmv = 1;
     sf->inter_sf.enable_six_param_warp_in_winner_mode = 1;
-
-    // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
-    // nearest searched result beyond the cap.
-    sf->mv_sf.newmv_drl_search_limit = 2;
     sf->inter_sf.prune_amvd_newmv = 1;
 
     sf->tx_sf.tx_type_search.skip_tx_search = 1;
@@ -435,8 +431,17 @@ static void set_good_speed_features_framesize_independent(
     sf->part_sf.partition_pruning_with_mlp = 1;
     sf->part_sf.partition_pruning_with_mlp_none_thresh = 3.5f;
     sf->lpf_sf.enable_deblock_for_partition_search = 1;
+    // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
+    // nearest searched result beyond the cap.
+    sf->inter_sf.reduce_max_drl_refmvs = 1;
+    sf->mv_sf.newmv_drl_search_limit = 2;
     if (!allow_screen_content_tools) {
-      sf->mv_sf.newmv_drl_search_limit = boosted ? 2 : 1;
+      // When reduce_max_drl_refmvs is enabled, the DRL candidate list is
+      // reduced. Keep newmv_drl_search_limit at 2 to search both ref_mv_idx 0
+      // and 1 before reusing results, preserving motion vector predictor
+      // diversity and mitigating coding loss.
+      sf->mv_sf.newmv_drl_search_limit =
+          (sf->inter_sf.reduce_max_drl_refmvs || boosted) ? 2 : 1;
     }
     sf->mv_sf.reduce_search_range = 1;
     sf->mv_sf.subpel_search_type = boosted ? USE_8_TAPS : USE_4_TAPS;
@@ -477,6 +482,13 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.reuse_inter_intra_mode = 1;
     sf->inter_sf.selective_ref_frame = 2;
     sf->inter_sf.skip_repeated_newmv = 1;
+    sf->inter_sf.reduce_max_drl_refmvs = 1;
+    if (!allow_screen_content_tools) {
+      // Re-evaluate newmv_drl_search_limit now that reduce_max_drl_refmvs is
+      // set to 1, ensuring both ref_mv_idx 0 and 1 are searched.
+      sf->mv_sf.newmv_drl_search_limit =
+          (sf->inter_sf.reduce_max_drl_refmvs || boosted) ? 2 : 1;
+    }
 
     sf->intra_sf.prune_palette_search_level = 1;
 
@@ -871,6 +883,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->alt_ref_search_fp = 0;
   inter_sf->disable_switchable_refinemv = 0;
   inter_sf->reduce_comp_refs = 0;
+  inter_sf->reduce_max_drl_refmvs = 0;
   inter_sf->selective_ref_frame = 0;
   inter_sf->prune_newmv_modes_using_prior_rd = 0;
   inter_sf->share_motion_mode_prune_pool = 0;
@@ -1305,6 +1318,12 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
 
     if (sf->intra_sf.skip_intra_dip_search) {
       cpi->common.seq_params.enable_intra_dip = 0;
+    }
+
+    if (oxcf->tool_cfg.max_drl_refmvs == 0 &&
+        !cpi->common.seq_params.single_picture_header_flag &&
+        sf->inter_sf.reduce_max_drl_refmvs) {
+      cpi->common.seq_params.allow_frame_max_drl_bits = 1;
     }
     // Disable tcq modes in sequence header when cpu-used >= 2
     if (sf->rd_sf.disable_tcq) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -410,6 +410,10 @@ static void set_good_speed_features_framesize_independent(
     // Predictive single-ref NEWMV reuse across the DRL.
     sf->mv_sf.predict_repeated_newmv = 1;
     sf->inter_sf.enable_six_param_warp_in_winner_mode = 1;
+
+    // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
+    // nearest searched result beyond the cap.
+    sf->mv_sf.newmv_drl_search_limit = 2;
     sf->inter_sf.prune_amvd_newmv = 1;
 
     sf->tx_sf.tx_type_search.skip_tx_search = 1;
@@ -431,17 +435,8 @@ static void set_good_speed_features_framesize_independent(
     sf->part_sf.partition_pruning_with_mlp = 1;
     sf->part_sf.partition_pruning_with_mlp_none_thresh = 3.5f;
     sf->lpf_sf.enable_deblock_for_partition_search = 1;
-    // Cap the DRL depth for a fresh single-ref NEWMV search; reuse the
-    // nearest searched result beyond the cap.
-    sf->inter_sf.reduce_max_drl_refmvs = 1;
-    sf->mv_sf.newmv_drl_search_limit = 2;
     if (!allow_screen_content_tools) {
-      // When reduce_max_drl_refmvs is enabled, the DRL candidate list is
-      // reduced. Keep newmv_drl_search_limit at 2 to search both ref_mv_idx 0
-      // and 1 before reusing results, preserving motion vector predictor
-      // diversity and mitigating coding loss.
-      sf->mv_sf.newmv_drl_search_limit =
-          (sf->inter_sf.reduce_max_drl_refmvs || boosted) ? 2 : 1;
+      sf->mv_sf.newmv_drl_search_limit = boosted ? 2 : 1;
     }
     sf->mv_sf.reduce_search_range = 1;
     sf->mv_sf.subpel_search_type = boosted ? USE_8_TAPS : USE_4_TAPS;
@@ -484,10 +479,10 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.skip_repeated_newmv = 1;
     sf->inter_sf.reduce_max_drl_refmvs = 1;
     if (!allow_screen_content_tools) {
-      // Re-evaluate newmv_drl_search_limit now that reduce_max_drl_refmvs is
-      // set to 1, ensuring both ref_mv_idx 0 and 1 are searched.
-      sf->mv_sf.newmv_drl_search_limit =
-          (sf->inter_sf.reduce_max_drl_refmvs || boosted) ? 2 : 1;
+      // When reduce_max_drl_refmvs is enabled, keep newmv_drl_search_limit at 2
+      // to search both ref_mv_idx 0 and 1 before reusing results, preserving
+      // motion vector predictor diversity and mitigating coding loss.
+      sf->mv_sf.newmv_drl_search_limit = 2;
     }
 
     sf->intra_sf.prune_palette_search_level = 1;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -647,6 +647,11 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // compound reference combinations in priority order.
   int reduce_comp_refs;
 
+  // Reduce max DRL reference MVs signaled for frames at a higher pyramid level
+  // 0: default (DEF_MAX_DRL_REFMVS - 1)
+  // 1: reduce by 1 (DEF_MAX_DRL_REFMVS - 2)
+  int reduce_max_drl_refmvs;
+
   // Prune reference frames for ALTREF
   int alt_ref_search_fp;
 


### PR DESCRIPTION
- Introduce the reduce_max_drl_refmvs speed feature to reduce the default DRL candidate count from 4 to 3 in higher encode speeds.
- Enable frame-level DRL adaptation (allow_frame_max_drl_bits = 1) when reduce_max_drl_refmvs is active: key, boosted, and low pyramid level frames (<= 2) retain 4 candidates (max_drl_bits = 3) to retain reference quality, while leaf frames use 3 candidates (max_drl_bits = 2).
- Condition newmv_drl_search_limit on reduce_max_drl_refmvs to ensure both ref_mv_idx 0 and 1 are searched before reusing results, preventing motion predictor diversity collapse.
- The existing --max-drl-refmvs CLI flag can override this behavior.

Evaluation based on 2abcfff1f9 with 33 frames at speed 2:
```
+---------+--------+--------+--------+--------+----------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time | Dec-time |
+---------+--------+--------+--------+--------+----------+----------+
| A1      | +0.05% | -0.05% | +0.10% | +0.05% |  98.1%   | 100.0%   |
| A2      | +0.08% | +0.27% | -0.03% | +0.08% |  97.5%   | 100.5%   |
+---------+--------+--------+--------+--------+----------+----------+
```