### PR TITLE
Allow MV precision based on last frame MV data for < 4K resolution.

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -137,7 +137,8 @@ static void set_good_speed_feature_framesize_dependent(
   const int is_1080p_or_larger = AVMMIN(cm->width, cm->height) >= 1080;
   const int is_4k_or_larger = AVMMIN(cm->width, cm->height) >= 2160;
   if (cm->seq_params.enable_flex_mvres) {
-    if (is_1080p_or_larger) {
+    if (is_4k_or_larger ||
+        (is_1080p_or_larger && cm->features.allow_screen_content_tools)) {
       sf->hl_sf.high_precision_mv_usage = QTR_ONLY;
     }
 


### PR DESCRIPTION
In particular, use last frame MV data for 1080p resolution that was NOT used before.

Only exception are:
- screen content at 1080p+ resolution will use QTR_ONLY MV precision mode
- 4k or larger:  will also use QTR_ONLY MV precision mode

In CTC, affects A2 and B1 sets only.

Results for anchor: 2abcfff1f

- RA CTC 33 frames, speed 4:

```
+---------+--------+----------+
| Summary |  YUV   | Enc-time |
+---------+--------+----------+
| A2      | -0.11% |  98.35%  |
| B1      |  0.01% |  97.89%  |
+---------+--------+----------+
```

- RA CTC 33 frames, speed 1:

```
+---------+--------+----------+
| Summary |  YUV   | Enc-time |
+---------+--------+----------+
| A2      | -0.03% |  98.61%  |
| B1      |  0.01% |  99.72%  |
+---------+--------+----------+
```

STATS_CHANGED