### PR TITLE
Promote tx stat pruning to Speed 3

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -217,6 +217,10 @@ static void set_good_speed_feature_framesize_dependent(
       sf->part_sf.partition_search_breakout_dist_thr = (1 << 23);
       sf->part_sf.partition_search_breakout_rate_thr = 120;
     }
+
+    if (is_480p_or_larger) {
+      sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 1;
+    }
   }
 
   if (speed >= 4) {
@@ -224,10 +228,6 @@ static void set_good_speed_feature_framesize_dependent(
       sf->part_sf.partition_search_breakout_dist_thr = (1 << 26);
     } else {
       sf->part_sf.partition_search_breakout_dist_thr = (1 << 24);
-    }
-
-    if (is_480p_or_larger) {
-      sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 1;
     }
 
     // On small resolutions (<=360p), keep the smallest RU size available at


### PR DESCRIPTION
Promote tx stat pruning to Speed 3
The speed feature was at speed 4.

Enabling the speed feature at speed 3 shows
encoder speed up with acceptable coding loss.

New test on top of base commit [5d628d8](https://github.com/AOMediaCodec/avm/commit/5d628d840b84be2eef1d0b1e2b7353719cc1f92a)

Speed 3
Testset                  PSNR-YUV      EncSpeedUp     Ratio
A1 (17 frames)       0.14%              8.28%               59.1
A2 (33 frames)       0.17%              6.53%               38.4

Original test on top of base commit https://github.com/AOMediaCodec/avm/commit/fe1bfdee5427ea2e01149c5ebce904084a93ba79

Performance on RA speed 3
Testset           PSNR-YUV    EncSpeedUp
A1 (17 frames)    0.15%        6.55%
A2 (33 frames)    0.22%        5.68%

Besides, we tested the speed feature at speed 2, it does not
meet the bar for A1.

Performance on RA speed 2
Testset           PSNR-YUV    EncSpeedUp
A1 (17 frames)    0.16%        4.02%
A2 (33 frames)    0.13%        4.46%

STATS_CHANGED