### PR TITLE
Enable dc block pred level 1 at Speed 3

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -562,6 +562,7 @@ static void set_good_speed_features_framesize_independent(
     // TODO(any): Re-enable for inter frames after fixing speed feature.
     sf->winner_mode_sf.enable_winner_mode_for_tx_size_srch = 0;
     sf->winner_mode_sf.enable_winner_mode_for_use_tx_domain_dist = 1;
+    sf->winner_mode_sf.dc_blk_pred_level = 1;
     sf->winner_mode_sf.motion_mode_for_winner_cand =
         boosted                                                      ? 0
         : gf_group->update_type[gf_group->index] == INTNL_ARF_UPDATE ? 1


### PR DESCRIPTION
Enabling the speed feature at speed 3 shows encoder speed up with acceptable neutral coding Performance.

Performance on RA speed 3
Testset           PSNR-YUV    EncSpeedUp
A1 (17 frames)    -0.01%       3.39%
A2 (33 frames)     0.01%       2.76%

STATS_CHANGED