### PR TITLE
rtc: Reuse pc_tree in non-RD partition search

### DIFF
--- a/av2/encoder/context_tree.c
+++ b/av2/encoder/context_tree.c
@@ -200,6 +200,21 @@ PICK_MODE_CONTEXT *av2_alloc_pmc(const AV2_COMMON *cm, TREE_TYPE tree_type,
   return ctx;
 }
 
+// Resets the state of a PICK_MODE_CONTEXT node so it can be reused across
+// blocks/superblocks without re-allocation.
+void av2_reset_pmc(PICK_MODE_CONTEXT *ctx) {
+  if (ctx == NULL) return;
+  ctx->rd_mode_is_ready = 0;
+  av2_invalid_rd_stats(&ctx->rd_stats);
+  if (ctx->tx_type_map) av2_zero_array(ctx->tx_type_map, ctx->num_4x4_blk);
+  if (ctx->cctx_type_map)
+    av2_zero_array(ctx->cctx_type_map, ctx->num_4x4_blk_chroma);
+  ctx->skippable = 0;
+  ctx->hybrid_pred_diff = 0;
+  ctx->comp_pred_diff = 0;
+  ctx->single_pred_diff = 0;
+}
+
 void av2_free_pmc(PICK_MODE_CONTEXT *ctx, int num_planes) {
   if (ctx == NULL) return;
 

--- a/av2/encoder/context_tree.h
+++ b/av2/encoder/context_tree.h
@@ -136,6 +136,11 @@ PICK_MODE_CONTEXT *av2_alloc_pmc(const AV2_COMMON *cm, TREE_TYPE tree_type,
                                  int subsampling_x, int subsampling_y,
                                  PC_TREE_SHARED_BUFFERS *shared_bufs);
 void av2_free_pmc(PICK_MODE_CONTEXT *ctx, int num_planes);
+/*!\brief Resets the state of a PICK_MODE_CONTEXT node for reuse.
+ *
+ * \param[in,out]  ctx  Pointer to the PICK_MODE_CONTEXT to reset
+ */
+void av2_reset_pmc(PICK_MODE_CONTEXT *ctx);
 void av2_copy_tree_context(PICK_MODE_CONTEXT *dst_ctx,
                            PICK_MODE_CONTEXT *src_ctx, int num_planes);
 

--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -817,9 +817,19 @@ static AVM_INLINE void encode_rd_sb(AV2_COMP *cpi, ThreadData *td,
       const BLOCK_SIZE min_partition_size = x->sb_enc.min_partition_size;
       init_encode_rd_sb(cpi, td, tile_data, sms_root, &dummy_rdc, mi_row,
                         mi_col, 1);
-      PC_TREE *const pc_root = av2_alloc_pc_tree_node(
-          xd->tree_type, mi_row, mi_col, cm->sb_size, sb_size, NULL,
-          PARTITION_NONE, 0, 1, ss_x, ss_y);
+      PC_TREE *pc_root;
+      if (cpi->sf.rt_sf.use_nonrd_partition) {
+        if (!td->pc_root) {
+          td->pc_root = av2_alloc_pc_tree_node(
+              xd->tree_type, mi_row, mi_col, cm->sb_size, sb_size, NULL,
+              PARTITION_NONE, 0, 1, ss_x, ss_y);
+        }
+        pc_root = td->pc_root;
+      } else {
+        pc_root = av2_alloc_pc_tree_node(xd->tree_type, mi_row, mi_col,
+                                         cm->sb_size, sb_size, NULL,
+                                         PARTITION_NONE, 0, 1, ss_x, ss_y);
+      }
       av2_reset_ptree_in_sbi(xd->sbi, xd->tree_type);
       av2_build_partition_tree_fixed_partitioning(
           cm, xd->tree_type, mi_row, mi_col,
@@ -843,8 +853,8 @@ static AVM_INLINE void encode_rd_sb(AV2_COMP *cpi, ThreadData *td,
             &dummy_rate, &dummy_dist, 1,
             xd->sbi->ptree_root[av2_get_sdp_idx(xd->tree_type)], pc_root,
             ptree_luma);
+        av2_free_pc_tree_recursive(pc_root, num_planes, 0, 0);
       }
-      av2_free_pc_tree_recursive(pc_root, num_planes, 0, 0);
       x->sb_enc.min_partition_size = min_partition_size;
     }
     xd->tree_type = SHARED_PART;
@@ -2184,10 +2194,18 @@ static AVM_INLINE void encode_frame_internal(AV2_COMP *cpi) {
     enc_row_mt->sync_write_ptr = av2_row_mt_sync_write;
     av2_encode_tiles_row_mt(cpi);
   } else {
-    if (AVMMIN(mt_info->num_workers, cm->tiles.cols * cm->tiles.rows) > 1)
+    if (AVMMIN(mt_info->num_workers, cm->tiles.cols * cm->tiles.rows) > 1) {
       av2_encode_tiles_mt(cpi);
-    else
+    } else {
+      if (cpi->sf.rt_sf.use_nonrd_partition) {
+        cpi->td.pc_root = av2_alloc_pc_tree_node(
+            SHARED_PART, 0, 0, cm->sb_size, cm->sb_size, NULL, PARTITION_NONE,
+            0, 1, cm->seq_params.subsampling_x, cm->seq_params.subsampling_y);
+      }
       encode_tiles(cpi);
+      av2_free_pc_tree_recursive(cpi->td.pc_root, av2_num_planes(cm), 0, 0);
+      cpi->td.pc_root = NULL;
+    }
   }
 
   // If intrabc is allowed but never selected, reset the allow_intrabc flag.

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -1406,6 +1406,8 @@ void av2_change_config(struct AV2_COMP *cpi, const AV2EncoderConfig *oxcf) {
       av2_free_shared_coeff_buffer(&cpi->td.shared_coeff_buf);
       av2_free_sms_tree(&cpi->td);
       av2_free_sms_bufs(&cpi->td);
+      av2_free_pc_tree_recursive(cpi->td.pc_root, av2_num_planes(cm), 0, 0);
+      cpi->td.pc_root = NULL;
 #if CONFIG_ML_PART_SPLIT
       av2_part_prune_tflite_close(&(cpi->td.partition_model));
 #endif  // CONFIG_ML_PART_SPLIT
@@ -1813,6 +1815,9 @@ static AVM_INLINE void free_thread_data(AV2_COMP *cpi) {
     thread_data->td->vt64x64 = NULL;
     av2_free_sms_tree(thread_data->td);
     av2_free_sms_bufs(thread_data->td);
+    av2_free_pc_tree_recursive(thread_data->td->pc_root, av2_num_planes(cm), 0,
+                               0);
+    thread_data->td->pc_root = NULL;
 #if CONFIG_ML_PART_SPLIT
     av2_part_prune_tflite_close(&(thread_data->td->partition_model));
 #endif  // CONFIG_ML_PART_SPLIT
@@ -2541,6 +2546,8 @@ int av2_set_size_literal(AV2_COMP *cpi, int width, int height) {
       av2_free_shared_coeff_buffer(&cpi->td.shared_coeff_buf);
       av2_free_sms_tree(&cpi->td);
       av2_free_sms_bufs(&cpi->td);
+      av2_free_pc_tree_recursive(cpi->td.pc_root, av2_num_planes(cm), 0, 0);
+      cpi->td.pc_root = NULL;
 #if CONFIG_ML_PART_SPLIT
       av2_part_prune_tflite_close(&(cpi->td.partition_model));
 #endif  // CONFIG_ML_PART_SPLIT

--- a/av2/encoder/encoder.h
+++ b/av2/encoder/encoder.h
@@ -1747,6 +1747,9 @@ typedef struct ThreadData {
   void *partition_model;
 #endif  // CONFIG_ML_PART_SPLIT
   void *dip_pruning_model;
+  // Root node for pre-allocated partition context tree (PC_TREE) reused
+  // across superblocks in real-time non-RD mode.
+  struct PC_TREE *pc_root;
 } ThreadData;
 
 struct EncWorkerData;

--- a/av2/encoder/encoder_alloc.h
+++ b/av2/encoder/encoder_alloc.h
@@ -239,6 +239,8 @@ static AVM_INLINE void dealloc_compressor_data(AV2_COMP *cpi) {
   cpi->td.vt64x64 = NULL;
   av2_free_sms_tree(&cpi->td);
   av2_free_sms_bufs(&cpi->td);
+  av2_free_pc_tree_recursive(cpi->td.pc_root, av2_num_planes(cm), 0, 0);
+  cpi->td.pc_root = NULL;
 #if CONFIG_ML_PART_SPLIT
   av2_part_prune_tflite_close(&(cpi->td.partition_model));
 #endif  // CONFIG_ML_PART_SPLIT

--- a/av2/encoder/ethread.c
+++ b/av2/encoder/ethread.c
@@ -418,6 +418,9 @@ static int enc_row_mt_worker_hook(void *arg1, void *unused) {
     pthread_mutex_unlock(enc_row_mt_mutex_);
 #endif
     set_encoding_done(cpi);
+    av2_free_pc_tree_recursive(thread_data->td->pc_root,
+                               av2_num_planes(&cpi->common), 0, 0);
+    thread_data->td->pc_root = NULL;
     return 0;
   }
   error_info->setjmp = 1;
@@ -426,6 +429,12 @@ static int enc_row_mt_worker_hook(void *arg1, void *unused) {
   int cur_tile_id = enc_row_mt->thread_id_to_tile_id[thread_id];
 
   assert(cur_tile_id != -1);
+
+  if (cpi->sf.rt_sf.use_nonrd_partition) {
+    thread_data->td->pc_root = av2_alloc_pc_tree_node(
+        SHARED_PART, 0, 0, cm->sb_size, cm->sb_size, NULL, PARTITION_NONE, 0, 1,
+        cm->seq_params.subsampling_x, cm->seq_params.subsampling_y);
+  }
 
   int end_of_frame = 0;
   bool row_mt_exit = false;
@@ -491,6 +500,9 @@ static int enc_row_mt_worker_hook(void *arg1, void *unused) {
 #endif
   }
 
+  av2_free_pc_tree_recursive(thread_data->td->pc_root, av2_num_planes(cm), 0,
+                             0);
+  thread_data->td->pc_root = NULL;
   error_info->setjmp = 0;
   return 1;
 }
@@ -514,9 +526,18 @@ static int enc_worker_hook(void *arg1, void *unused) {
   // before it returns.
   if (setjmp(error_info->jmp)) {
     error_info->setjmp = 0;
+    av2_free_pc_tree_recursive(thread_data->td->pc_root, av2_num_planes(cm), 0,
+                               0);
+    thread_data->td->pc_root = NULL;
     return 0;
   }
   error_info->setjmp = 1;
+
+  if (cpi->sf.rt_sf.use_nonrd_partition) {
+    thread_data->td->pc_root = av2_alloc_pc_tree_node(
+        SHARED_PART, 0, 0, cm->sb_size, cm->sb_size, NULL, PARTITION_NONE, 0, 1,
+        cm->seq_params.subsampling_x, cm->seq_params.subsampling_y);
+  }
 
   for (t = thread_data->start; t < tile_rows * tile_cols;
        t += cpi->mt_info.num_workers) {
@@ -529,6 +550,9 @@ static int enc_worker_hook(void *arg1, void *unused) {
     av2_encode_tile(cpi, thread_data->td, tile_row, tile_col);
   }
 
+  av2_free_pc_tree_recursive(thread_data->td->pc_root, av2_num_planes(cm), 0,
+                             0);
+  thread_data->td->pc_root = NULL;
   error_info->setjmp = 0;
   return 1;
 }

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -2428,12 +2428,32 @@ void av2_nonrd_use_partition(AV2_COMP *cpi, ThreadData *td,
       pc_tree->none_chroma =
           av2_alloc_pmc(cm, xd->tree_type, mi_row, mi_col, bsize, pc_tree,
                         PARTITION_NONE, 0, ss_x, ss_y, &td->shared_coeff_buf);
+    } else {
+      av2_reset_pmc(pc_tree->none_chroma);
+      set_chroma_ref_info(
+          xd->tree_type, mi_row, mi_col, 0, bsize,
+          &pc_tree->none_chroma->chroma_ref_info,
+          pc_tree->parent ? &pc_tree->parent->chroma_ref_info : NULL,
+          pc_tree->parent ? pc_tree->parent->block_size : BLOCK_INVALID,
+          PARTITION_NONE, ss_x, ss_y);
+      pc_tree->none_chroma->mic.chroma_ref_info =
+          pc_tree->none_chroma->chroma_ref_info;
     }
   } else {
     if (pc_tree->none[cur_region_type] == NULL) {
       pc_tree->none[cur_region_type] =
           av2_alloc_pmc(cm, xd->tree_type, mi_row, mi_col, bsize, pc_tree,
                         PARTITION_NONE, 0, ss_x, ss_y, &td->shared_coeff_buf);
+    } else {
+      av2_reset_pmc(pc_tree->none[cur_region_type]);
+      set_chroma_ref_info(
+          xd->tree_type, mi_row, mi_col, 0, bsize,
+          &pc_tree->none[cur_region_type]->chroma_ref_info,
+          pc_tree->parent ? &pc_tree->parent->chroma_ref_info : NULL,
+          pc_tree->parent ? pc_tree->parent->block_size : BLOCK_INVALID,
+          PARTITION_NONE, ss_x, ss_y);
+      pc_tree->none[cur_region_type]->mic.chroma_ref_info =
+          pc_tree->none[cur_region_type]->chroma_ref_info;
     }
   }
 
@@ -2487,12 +2507,16 @@ void av2_nonrd_use_partition(AV2_COMP *cpi, ThreadData *td,
                partition, ctx_none, &rate);
       break;
     case PARTITION_HORZ:
-      pc_tree->horizontal[cur_region_type][0] = av2_alloc_pc_tree_node(
-          xd->tree_type, mi_row, mi_col, cm->sb_size, subsize, pc_tree,
-          PARTITION_HORZ, 0, 0, ss_x, ss_y);
-      pc_tree->horizontal[cur_region_type][1] = av2_alloc_pc_tree_node(
-          xd->tree_type, mi_row + hbh, mi_col, cm->sb_size, subsize, pc_tree,
-          PARTITION_HORZ, 1, 1, ss_x, ss_y);
+      if (!pc_tree->horizontal[cur_region_type][0]) {
+        pc_tree->horizontal[cur_region_type][0] = av2_alloc_pc_tree_node(
+            xd->tree_type, mi_row, mi_col, cm->sb_size, subsize, pc_tree,
+            PARTITION_HORZ, 0, 0, ss_x, ss_y);
+      }
+      if (!pc_tree->horizontal[cur_region_type][1]) {
+        pc_tree->horizontal[cur_region_type][1] = av2_alloc_pc_tree_node(
+            xd->tree_type, mi_row + hbh, mi_col, cm->sb_size, subsize, pc_tree,
+            PARTITION_HORZ, 1, 1, ss_x, ss_y);
+      }
 
       av2_nonrd_use_partition(cpi, td, tile_data, mib, tp, mi_row, mi_col,
                               subsize, ptree ? ptree->sub_tree[0] : NULL,
@@ -2507,12 +2531,16 @@ void av2_nonrd_use_partition(AV2_COMP *cpi, ThreadData *td,
       }
       break;
     case PARTITION_VERT:
-      pc_tree->vertical[cur_region_type][0] = av2_alloc_pc_tree_node(
-          xd->tree_type, mi_row, mi_col, cm->sb_size, subsize, pc_tree,
-          PARTITION_VERT, 0, 0, ss_x, ss_y);
-      pc_tree->vertical[cur_region_type][1] = av2_alloc_pc_tree_node(
-          xd->tree_type, mi_row, mi_col + hbw, cm->sb_size, subsize, pc_tree,
-          PARTITION_VERT, 1, 1, ss_x, ss_y);
+      if (!pc_tree->vertical[cur_region_type][0]) {
+        pc_tree->vertical[cur_region_type][0] = av2_alloc_pc_tree_node(
+            xd->tree_type, mi_row, mi_col, cm->sb_size, subsize, pc_tree,
+            PARTITION_VERT, 0, 0, ss_x, ss_y);
+      }
+      if (!pc_tree->vertical[cur_region_type][1]) {
+        pc_tree->vertical[cur_region_type][1] = av2_alloc_pc_tree_node(
+            xd->tree_type, mi_row, mi_col + hbw, cm->sb_size, subsize, pc_tree,
+            PARTITION_VERT, 1, 1, ss_x, ss_y);
+      }
       av2_nonrd_use_partition(cpi, td, tile_data, mib, tp, mi_row, mi_col,
                               subsize, ptree ? ptree->sub_tree[0] : NULL,
                               pc_tree->vertical[cur_region_type][0],
@@ -2533,9 +2561,11 @@ void av2_nonrd_use_partition(AV2_COMP *cpi, ThreadData *td,
         if ((mi_row + y_idx >= mi_params->mi_rows) ||
             (mi_col + x_idx >= mi_params->mi_cols))
           continue;
-        pc_tree->split[cur_region_type][i] = av2_alloc_pc_tree_node(
-            xd->tree_type, mi_row + y_idx, mi_col + x_idx, cm->sb_size, subsize,
-            pc_tree, PARTITION_SPLIT, i, i == 3, ss_x, ss_y);
+        if (!pc_tree->split[cur_region_type][i]) {
+          pc_tree->split[cur_region_type][i] = av2_alloc_pc_tree_node(
+              xd->tree_type, mi_row + y_idx, mi_col + x_idx, cm->sb_size,
+              subsize, pc_tree, PARTITION_SPLIT, i, i == 3, ss_x, ss_y);
+        }
         av2_nonrd_use_partition(
             cpi, td, tile_data,
             mib + jj * hbh * mi_params->mi_stride + ii * hbw, tp,


### PR DESCRIPTION
Pre-allocate and reuse the partition context tree (pc_root / PC_TREE) per thread in real-time non-RD partition search instead of allocating and freeing nodes for every superblock.

- Add pc_root to ThreadData and pre-allocate once per thread/frame.
- Add av2_reset_pmc to reset PICK_MODE_CONTEXT state on node reuse.
- In av2_nonrd_use_partition, lazily allocate child pc_tree nodes and reset existing PMC nodes across superblocks.

This change is bitexact for RTC with 2.5% speed up for QVGA and 1.5% speed up for VGA and HD on speed 6.