### PR TITLE
Disable a speed feature to recover coding gains at sp4

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -587,7 +587,10 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.fast_warp_delta_decoupled_search = 1;
 
     sf->inter_sf.prune_inter_modes_based_on_tpl = boosted ? 0 : 3;
-    sf->inter_sf.prune_comp_using_best_single_mode_ref = 2;
+    // TODO(any): prune_comp_using_best_single_mode_ref introduces a large
+    // coding loss (> 1%) without enough encoding speed up (5% - 11%).
+    // Disabling it until it is fixed.
+    // sf->inter_sf.prune_comp_using_best_single_mode_ref = 2;
 
     sf->intra_sf.intra_uv_mode_mask[TX_16X16] = UV_INTRA_DC_H_V_CFL;
     sf->intra_sf.intra_uv_mode_mask[TX_32X32] = UV_INTRA_DC_H_V_CFL;


### PR DESCRIPTION
The speed feature "prune_comp_using_best_single_mode_ref" currently performs below the bar for quality and speed tradeoff.

By disabling the feature, we recover coding gains with about 5.5% (A1), 11.5% (A2) encoding time slowdown.

Speed4          PSNR-YUV   EncTime
A1 (17 frames)   -1.11%    105.52%
A2 (33 frames)   -0.88%    111.53%

STATS_CHANGED

Change-Id: I91afc0b8130c6e538ac11a804a17078da480065b