### PR TITLE
Promote feature DC-block-pred-level to speed 3

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -573,6 +573,7 @@ static void set_good_speed_features_framesize_independent(
     // For screen content, "prune_sgr_based_on_wiener = 2" cause large quality
     // loss.
     sf->lpf_sf.disable_loop_restoration_chroma = boosted ? 0 : 1;
+    sf->winner_mode_sf.dc_blk_pred_level = 2;
   }
 
   if (speed >= 4) {
@@ -630,7 +631,6 @@ static void set_good_speed_features_framesize_independent(
 
     sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
     sf->mv_sf.newmv_drl_search_limit = 1;
-    sf->winner_mode_sf.dc_blk_pred_level = 2;
   }
 
   if (speed >= 5) {


### PR DESCRIPTION
The speed feature works for speed 4. Its tradeoff is still good when we promote it to speed 3.

On speed 3, RA, the performance is

Test-set        PSNR-YUV    EncTime
A1 (17 frames)   0.04%       94.78%
A2 (33 frames)   0.00%       98.01%

STATS_CHANGED

Change-Id: Ib510a6b42898d6fba923fa92bede2b4de21b12d2