### PR TITLE
Reduce intra mode top count to 3 for speed 3 and 4

### DIFF
--- a/av2/common/pred_common.c
+++ b/av2/common/pred_common.c
@@ -798,12 +798,13 @@ int av2_get_cdef_context(const AV2_COMMON *const cm,
   const int block_mask = ~(cdef_size - 1);
 
   const CommonModeInfoParams *const mi_params = &cm->mi_params;
+  const TileInfo *const tile = &xd->tile;
   const int mi_row = xd->mi_row;
   const int mi_col = xd->mi_col;
 
   const int left_cdef_mi_col = mi_col - cdef_size;
   MB_MODE_INFO *neighbor0 = NULL;
-  if (left_cdef_mi_col >= 0) {
+  if (left_cdef_mi_col >= tile->mi_col_start) {
     const int left_grid_idx = get_mi_grid_idx(mi_params, mi_row & block_mask,
                                               left_cdef_mi_col & block_mask);
     neighbor0 = mi_params->mi_grid_base[left_grid_idx];
@@ -811,8 +812,9 @@ int av2_get_cdef_context(const AV2_COMMON *const cm,
 
   const int above_cdef_mi_row = mi_row - cdef_size;
   MB_MODE_INFO *neighbor1 = NULL;
-  if (above_cdef_mi_row >= 0 && (mi_row >> cm->mib_size_log2) ==
-                                    (above_cdef_mi_row >> cm->mib_size_log2)) {
+  if (above_cdef_mi_row >= tile->mi_row_start &&
+      (mi_row >> cm->mib_size_log2) ==
+          (above_cdef_mi_row >> cm->mib_size_log2)) {
     const int above_grid_idx = get_mi_grid_idx(
         mi_params, above_cdef_mi_row & block_mask, mi_col & block_mask);
     neighbor1 = mi_params->mi_grid_base[above_grid_idx];

--- a/av2/encoder/encodeframe_utils.h
+++ b/av2/encoder/encodeframe_utils.h
@@ -198,8 +198,9 @@ static AVM_INLINE void av2_set_two_pass_flags(
     x->inter_mode_prune_top = 4;
   } else {
     // Full pool.
-    x->intra_mode_prune_top =
-        cpi->sf.intra_sf.intra_pruning_with_mlp ? 4 : TOP_INTRA_MODEL_COUNT;
+    x->intra_mode_prune_top = cpi->sf.intra_sf.intra_pruning_with_mlp
+                                  ? cpi->sf.intra_sf.intra_mode_prune_top
+                                  : TOP_INTRA_MODEL_COUNT;
     x->inter_mode_prune_top = TOP_MOTION_MODE_MODEL_COUNT;
   }
 }

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -370,6 +370,7 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.prune_interintra_by_ref_idx = 1;
     sf->inter_sf.prune_warp_delta_by_ref_idx = 1;
     sf->intra_sf.intra_pruning_with_mlp = 1;
+    sf->intra_sf.intra_mode_prune_top = 4;
     sf->inter_sf.prune_comp_mode_eval_using_est_rd = true;
     sf->inter_sf.prune_warp_newmv_ref_mv_idx = true;
 
@@ -551,6 +552,7 @@ static void set_good_speed_features_framesize_independent(
     // sf->intra_sf.disable_smooth_intra =
     //    !frame_is_intra_only(&cpi->common) || (cpi->rc.frames_to_key != 1);
     sf->intra_sf.prune_palette_search_level = 2;
+    sf->intra_sf.intra_mode_prune_top = 3;
 
     sf->tpl_sf.prune_ref_frames_in_tpl = 1;
     sf->tpl_sf.skip_alike_starting_mv = 2;
@@ -925,6 +927,7 @@ static AVM_INLINE void init_intra_sf(INTRA_MODE_SPEED_FEATURES *intra_sf) {
   intra_sf->skip_intra_in_interframe = 1;
   intra_sf->intra_pruning_with_hog = 0;
   intra_sf->intra_pruning_with_mlp = 0;
+  intra_sf->intra_mode_prune_top = TOP_INTRA_MODEL_COUNT;
   intra_sf->src_var_thresh_intra_skip = 1;
   intra_sf->prune_palette_search_level = 0;
   intra_sf->reuse_uv_mode_rd_info = false;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -894,6 +894,9 @@ typedef struct INTRA_MODE_SPEED_FEATURES {
   bool include_dip_for_top_n_model_rd_pruning;
 
   bool skip_intra_dip_search;
+
+  // Number of top intra mode candidates to keep during model RD pruning.
+  int intra_mode_prune_top;
 } INTRA_MODE_SPEED_FEATURES;
 
 typedef struct TX_SPEED_FEATURES {


### PR DESCRIPTION
By reducing the number of candidates, we achieve a considerable
speed up with accepted coding loss.

Result of reducing the count to 3 for speed 4:

TestSet          PSNR-YUV   EncTime    Ratio
A1 (17 frames)    0.10%      96.70%    34.1
A2 (33 frames)    0.07%      96.81%    47.0

Result of reducing the count to 3 for speed 3:

TestSet          PSNR-YUV   EncTime    Ratio
A1 (17 frames)    0.11%      96.87%    29.4
A2 (33 frames)    0.09%      96.41%    41.3

If we reduce the count to 2
The speedup/loss ratio is good for A2, but not good enough for A1.
On speed 4, RA, the performance is:

TestSet          PSNR-YUV   EncTime    Ratio
A1 (17 frames)    0.41%      92.76%    19.0
A2 (33 frames)    0.19%      93.44%    36.9

STATS_CHANGED
