### PR TITLE
Fix MSDO/LCR conformance check for the 12-bit profile

### DIFF
--- a/av2/common/annexA.c
+++ b/av2/common/annexA.c
@@ -84,14 +84,6 @@ typedef enum {
 */
 /* clang-format on */
 
-typedef enum {
-  INTEROP_0,
-  INTEROP_1,
-  INTEROP_2,
-  INTEROP_3,
-  NUM_INTEROP_POINTS = 16,
-} INTEROP_POINTS;
-
 static const int seq_profile_max_mlayer_cnt[MAX_PROFILES] = {
   1, 2, 3, 2, 2,
 #if CONFIG_12BIT_PROFILE
@@ -143,8 +135,33 @@ static const int seq_profile_max_mlayer_cnt[MAX_PROFILES] = {
 // Profile Conformance Functions
 //=================================================================
 // Helper functions
-// Get interoperability point from seq_profile_idc
-// Return -1 for reserved seq_profile_idc values
+
+// Interoperability point of each defined profile, per Table A.1. Keep in sync
+// with the BITSTREAM_PROFILE enum in enums.h when a profile is added.
+static const int seq_profile_interop[] = {
+  INTEROP_0,  // MAIN_420_10_IP0
+  INTEROP_1,  // MAIN_420_10_IP1
+  INTEROP_2,  // MAIN_420_10_IP2
+  INTEROP_1,  // MAIN_422_10_IP1
+  INTEROP_1,  // MAIN_444_10_IP1
+#if CONFIG_12BIT_PROFILE
+  INTEROP_2,  // MAIN_444C_12_IP2
+#endif        // CONFIG_12BIT_PROFILE
+};
+
+static_assert((int)(sizeof(seq_profile_interop) /
+                    sizeof(seq_profile_interop[0])) ==
+                  (int)RESERVED_PROFILES_START,
+              "seq_profile_interop[] must cover every defined profile");
+
+int av2_get_interop_from_profile(int seq_profile_idc) {
+  if (seq_profile_idc < 0 || seq_profile_idc >= MAX_PROFILES)
+    return INTEROP_INVALID;
+  // CONFIGURABLE has no interoperability point in Table A.1.
+  if (seq_profile_idc == CONFIGURABLE) return INTEROP_NONE;
+  if (seq_profile_idc >= RESERVED_PROFILES_START) return INTEROP_INVALID;
+  return seq_profile_interop[seq_profile_idc];
+}
 
 static INLINE int av2_get_max_mlayer_cnt_from_profile(int seq_profile_idc) {
   if (seq_profile_idc < 0 || seq_profile_idc >= MAX_PROFILES) return -1;

--- a/av2/common/annexA.h
+++ b/av2/common/annexA.h
@@ -35,6 +35,29 @@ struct avm_internal_error_info;
 struct SequenceHeader;
 
 //==========================================
+// Interoperability Points
+//===========================================
+// Interoperability points (Table A.3). The values 0..15 are the ones that can
+// be signalled in the bitstream (e.g. lcr_max_interop, ops_max_interop); the
+// two negative values are returned by av2_get_interop_from_profile() for
+// profiles that have no interoperability point.
+typedef enum {
+  INTEROP_INVALID = -2,  // Reserved or out-of-range seq_profile_idc
+  INTEROP_NONE = -1,     // CONFIGURABLE: no interoperability point (Table A.1)
+  INTEROP_0 = 0,
+  INTEROP_1 = 1,
+  INTEROP_2 = 2,
+  INTEROP_3 = 3,
+  INTEROP_MAX = 15,
+  NUM_INTEROP_POINTS = 16,
+} INTEROP_POINTS;
+
+// Returns the interoperability point of seq_profile_idc (Table A.1):
+// INTEROP_0, INTEROP_1 or INTEROP_2 for a defined profile, INTEROP_NONE for
+// CONFIGURABLE, and INTEROP_INVALID for reserved or out-of-range values.
+int av2_get_interop_from_profile(int seq_profile_idc);
+
+//==========================================
 // Profile Conformance Function
 //===========================================
 // Validates the bitstream parameters conform to the specified profile

--- a/av2/decoder/obu.c
+++ b/av2/decoder/obu.c
@@ -2098,52 +2098,67 @@ static void check_valid_layer_id(ObuHeader obu_header, AV2_COMMON *const cm) {
   }
 }
 
-static BITSTREAM_PROFILE get_msdo_profile(struct AV2Decoder *pbi) {
-  return pbi->common.msdo_params.multistream_profile_idc;
+static int get_msdo_interop(struct AV2Decoder *pbi) {
+  return av2_get_interop_from_profile(
+      pbi->common.msdo_params.multistream_profile_idc);
 }
 
-static BITSTREAM_PROFILE get_lcr_global_profile(struct AV2Decoder *pbi) {
-  // Return the lcr_max_interop from the first valid global LCR's aggregate PTL.
-  // lcr_max_interop maps directly to the IOP (0, 1, 2) which corresponds to
-  // MAIN_420_10_IP0, MAIN_420_10_IP1, MAIN_420_10_IP2 respectively.
+static int get_lcr_global_interop(struct AV2Decoder *pbi) {
+  // Return the interoperability point of the first valid global LCR.
+  // lcr_max_interop in the aggregate PTL is already an interoperability point,
+  // so it is used directly; the seq PTL fallback signals a profile instead and
+  // must be mapped through Table A.1.
   for (int j = 0; j < MAX_NUM_LCR; j++) {
     if (pbi->lcr_list[GLOBAL_XLAYER_ID][j].valid) {
       const struct GlobalLayerConfigurationRecord *glcr =
           &pbi->lcr_list[GLOBAL_XLAYER_ID][j].global_lcr;
       if (glcr->lcr_aggregate_info_present_flag)
-        return (BITSTREAM_PROFILE)glcr->aggregate_ptl.lcr_max_interop;
+        return glcr->aggregate_ptl.lcr_max_interop;
       // Fall back to the first seq PTL if aggregate PTL is not present.
       if (glcr->lcr_seq_profile_tier_level_info_present_flag &&
           glcr->LcrMaxNumXLayerCount > 0)
-        return (BITSTREAM_PROFILE)glcr->seq_ptl[glcr->LcrXLayerID[0]]
-            .lcr_seq_profile_idc;
+        return av2_get_interop_from_profile(
+            glcr->seq_ptl[glcr->LcrXLayerID[0]].lcr_seq_profile_idc);
     }
   }
-  (void)pbi;
-  return MAIN_420_10_IP2;  // Fallback
+  return INTEROP_2;  // Fallback
 }
 
-static BITSTREAM_PROFILE get_lcr_local_profile(struct AV2Decoder *pbi) {
-  // Return the lcr_seq_profile_idc from the first valid local LCR.
+static int get_lcr_local_interop(struct AV2Decoder *pbi) {
+  // Return the interoperability point of the first valid local LCR, mapped
+  // from its lcr_seq_profile_idc.
   for (int i = 0; i < GLOBAL_XLAYER_ID; i++) {
     for (int j = 0; j < MAX_NUM_LCR; j++) {
       if (pbi->lcr_list[i][j].valid) {
         const struct LocalLayerConfigurationRecord *llcr =
             &pbi->lcr_list[i][j].local_lcr;
         if (llcr->lcr_profile_tier_level_info_present_flag)
-          return (BITSTREAM_PROFILE)llcr->seq_ptl.lcr_seq_profile_idc;
+          return av2_get_interop_from_profile(
+              llcr->seq_ptl.lcr_seq_profile_idc);
       }
     }
   }
-  (void)pbi;
-  return MAIN_420_10_IP2;  // Fallback
+  return INTEROP_2;  // Fallback
+}
+
+// Returns true if the Annex A OBU requirements table does not constrain this
+// interoperability point: INTEROP_NONE (the CONFIGURABLE profile) and any IOP
+// >= INTEROP_3 (reserved and max) are unconstrained. INTEROP_INVALID (a
+// reserved profile) is not exempted, so such a stream is rejected here.
+static bool interop_is_unconstrained(int interop) {
+  return interop == INTEROP_NONE || interop >= INTEROP_3;
 }
 
 // Conformance check for the presence of MSDO and LCR.
 // The OBU requirements table in Annex A only applies when IOP < 3, i.e.
-// when the MSDO profile or LCR profile is one of the IP profiles (0, 1, 2).
-// For profile == 31 (CONFIGURABLE) the table does
+// when the MSDO profile or LCR profile has an interoperability point of
+// 0, 1 or 2. For the CONFIGURABLE profile and for IOPs >= 3 the table does
 // not impose additional constraints, so we return true.
+//
+// The checks below are expressed in terms of interoperability points rather
+// than individual profile labels, so that profiles sharing an IOP (e.g.
+// MAIN_420_10_IP2 and MAIN_444C_12_IP2) are treated identically and newly
+// added profiles need no change here.
 bool conformance_check_msdo_lcr(struct AV2Decoder *pbi, bool global_lcr_present,
                                 bool local_lcr_present) {
   int msdo_present = pbi->multistream_decoder_mode;
@@ -2165,17 +2180,16 @@ bool conformance_check_msdo_lcr(struct AV2Decoder *pbi, bool global_lcr_present,
   }
   assert(num_extended_layers > 0 && num_embedded_layers > 0);
 
-  // Determine the effective MSDO and LCR profiles.
-  const BITSTREAM_PROFILE msdo_prof = get_msdo_profile(pbi);
-  const BITSTREAM_PROFILE glcr_prof = get_lcr_global_profile(pbi);
-  const BITSTREAM_PROFILE llcr_prof = get_lcr_local_profile(pbi);
+  // Determine the effective MSDO and LCR interoperability points.
+  const int msdo_iop = get_msdo_interop(pbi);
+  const int glcr_iop = get_lcr_global_interop(pbi);
+  const int llcr_iop = get_lcr_local_interop(pbi);
 
-  // The IOP table only applies for IOPs 0-2 (profiles IP0, IP1, IP2).
-  // If the signaled profile is >= 3, the table does not apply.
-  if (msdo_present && msdo_prof == CONFIGURABLE) return true;
-  if (global_lcr_present && glcr_prof == CONFIGURABLE) return true;
+  // The IOP table only applies for IOPs 0-2.
+  if (msdo_present && interop_is_unconstrained(msdo_iop)) return true;
+  if (global_lcr_present && interop_is_unconstrained(glcr_iop)) return true;
   if (!msdo_present && !global_lcr_present && local_lcr_present &&
-      llcr_prof == CONFIGURABLE) {
+      interop_is_unconstrained(llcr_iop)) {
     return true;
   }
   if (!msdo_present && !global_lcr_present && !local_lcr_present) {
@@ -2187,31 +2201,32 @@ bool conformance_check_msdo_lcr(struct AV2Decoder *pbi, bool global_lcr_present,
   }
 
   if (num_extended_layers > 1 && num_embedded_layers == 1) {
-    if (msdo_present &&
-        (msdo_prof == MAIN_420_10_IP0 || msdo_prof == MAIN_420_10_IP1 ||
-         msdo_prof == MAIN_420_10_IP2 || msdo_prof == MAIN_422_10_IP1 ||
-         msdo_prof == MAIN_444_10_IP1))
-      return true;
+    // Every IOP constrained by the table (0..2) allows multiple extended layers
+    // with a single embedded layer.
+    if (msdo_present && msdo_iop >= INTEROP_0) return true;
 
-    if (global_lcr_present && glcr_prof == MAIN_420_10_IP2) return true;
+    if (global_lcr_present && glcr_iop >= INTEROP_2) return true;
   }
 
   if (num_extended_layers == 1 && num_embedded_layers > 1) {
-    if (!msdo_present && local_lcr_present &&
-        (llcr_prof == MAIN_420_10_IP1 || llcr_prof == MAIN_422_10_IP1 ||
-         llcr_prof == MAIN_444_10_IP1))
+    // Multiple embedded layers require IOP >= 1.
+    if (!msdo_present && local_lcr_present && llcr_iop >= INTEROP_1)
       return true;
 
-    if (!msdo_present && (global_lcr_present || local_lcr_present) &&
-        (glcr_prof == MAIN_420_10_IP2 || llcr_prof == MAIN_420_10_IP2))
+    // Each interoperability point is only consulted when the corresponding LCR
+    // is actually present, so that the permissive fallback returned by
+    // get_lcr_{global,local}_interop() for an absent LCR cannot allow a
+    // configuration the present LCR's IOP forbids.
+    if (!msdo_present && ((global_lcr_present && glcr_iop >= INTEROP_2) ||
+                          (local_lcr_present && llcr_iop >= INTEROP_2)))
       return true;
   }
 
   if (num_extended_layers > 1 && num_embedded_layers > 1) {
-    if (msdo_present && local_lcr_present && msdo_prof == MAIN_420_10_IP2)
-      return true;
+    // Combinations of multiple extended and embedded layers require IOP 2.
+    if (msdo_present && local_lcr_present && msdo_iop >= INTEROP_2) return true;
 
-    if (global_lcr_present && glcr_prof == MAIN_420_10_IP2) return true;
+    if (global_lcr_present && glcr_iop >= INTEROP_2) return true;
   }
   return false;
 }

--- a/test/lcr_test.cc
+++ b/test/lcr_test.cc
@@ -16,6 +16,7 @@
 
 #include "av2/encoder/lcr_syntax.h"
 #include "av2/encoder/atlas_syntax.h"
+#include "av2/common/annexA.h"
 #include "av2/decoder/decoder.h"
 #include "av2/decoder/decodeframe.h"
 extern "C" {
@@ -840,7 +841,7 @@ TEST_F(LcrTest, ConformanceCheckMsdoConfigurable) {
   EXPECT_TRUE(conformance_check_msdo_lcr(pbi_, false, false));
 }
 
-TEST_F(LcrTest, ConformanceCheckGlobalLcrConfigurable) {
+TEST_F(LcrTest, ConformanceCheckGlobalLcrMaxInterop) {
   pbi_->xlayer_id_map[0] = 1;
   pbi_->mlayer_id_map[0][0] = 1;
   pbi_->lcr_list[GLOBAL_XLAYER_ID][1].valid = 1;
@@ -848,7 +849,26 @@ TEST_F(LcrTest, ConformanceCheckGlobalLcrConfigurable) {
   pbi_->lcr_list[GLOBAL_XLAYER_ID][1]
       .global_lcr.lcr_aggregate_info_present_flag = 1;
   pbi_->lcr_list[GLOBAL_XLAYER_ID][1].global_lcr.aggregate_ptl.lcr_max_interop =
-      CONFIGURABLE;
+      INTEROP_MAX;
+  EXPECT_TRUE(conformance_check_msdo_lcr(pbi_, true, false));
+}
+
+// A global LCR without an aggregate PTL falls back to the seq PTL, which
+// signals a profile_idc; CONFIGURABLE has no interoperability point.
+TEST_F(LcrTest, ConformanceCheckGlobalLcrConfigurableSeqPtl) {
+  pbi_->xlayer_id_map[0] = 1;
+  pbi_->mlayer_id_map[0][0] = 1;
+  pbi_->lcr_list[GLOBAL_XLAYER_ID][1].valid = 1;
+  pbi_->lcr_list[GLOBAL_XLAYER_ID][1].is_global = true;
+  pbi_->lcr_list[GLOBAL_XLAYER_ID][1]
+      .global_lcr.lcr_aggregate_info_present_flag = 0;
+  pbi_->lcr_list[GLOBAL_XLAYER_ID][1]
+      .global_lcr.lcr_seq_profile_tier_level_info_present_flag = 1;
+  pbi_->lcr_list[GLOBAL_XLAYER_ID][1].global_lcr.LcrMaxNumXLayerCount = 1;
+  pbi_->lcr_list[GLOBAL_XLAYER_ID][1].global_lcr.LcrXLayerID[0] = 0;
+  pbi_->lcr_list[GLOBAL_XLAYER_ID][1]
+      .global_lcr.seq_ptl[0]
+      .lcr_seq_profile_idc = CONFIGURABLE;
   EXPECT_TRUE(conformance_check_msdo_lcr(pbi_, true, false));
 }
 
@@ -880,6 +900,79 @@ TEST_F(LcrTest, ConformanceCheckMultiMlayerLocalLcr) {
   pbi_->lcr_list[0][1].local_lcr.lcr_profile_tier_level_info_present_flag = 1;
   pbi_->lcr_list[0][1].local_lcr.seq_ptl.lcr_seq_profile_idc = MAIN_420_10_IP1;
   EXPECT_TRUE(conformance_check_msdo_lcr(pbi_, false, true));
+}
+
+// Profiles are checked via their interoperability point, so any profile sharing
+// an IOP with an already-allowed profile must also be allowed.
+TEST(AnnexATest, InteropFromProfile) {
+  EXPECT_EQ(av2_get_interop_from_profile(MAIN_420_10_IP0), INTEROP_0);
+  EXPECT_EQ(av2_get_interop_from_profile(MAIN_420_10_IP1), INTEROP_1);
+  EXPECT_EQ(av2_get_interop_from_profile(MAIN_420_10_IP2), INTEROP_2);
+  EXPECT_EQ(av2_get_interop_from_profile(MAIN_422_10_IP1), INTEROP_1);
+  EXPECT_EQ(av2_get_interop_from_profile(MAIN_444_10_IP1), INTEROP_1);
+#if CONFIG_12BIT_PROFILE
+  EXPECT_EQ(av2_get_interop_from_profile(MAIN_444C_12_IP2), INTEROP_2);
+#endif  // CONFIG_12BIT_PROFILE
+  EXPECT_EQ(av2_get_interop_from_profile(CONFIGURABLE), INTEROP_NONE);
+  EXPECT_EQ(av2_get_interop_from_profile(RESERVED_PROFILES_START),
+            INTEROP_INVALID);
+  EXPECT_EQ(av2_get_interop_from_profile(CONFIGURABLE - 1), INTEROP_INVALID);
+  EXPECT_EQ(av2_get_interop_from_profile(-1), INTEROP_INVALID);
+  EXPECT_EQ(av2_get_interop_from_profile(MAX_PROFILES), INTEROP_INVALID);
+}
+
+#if CONFIG_12BIT_PROFILE
+// MAIN_444C_12_IP2 has the same interoperability point (2) as MAIN_420_10_IP2,
+// so it must permit the same multistream configurations. Before these checks
+// were expressed in terms of interoperability points, no legal multistream was
+// possible with the 12-bit profile.
+TEST_F(LcrTest, ConformanceCheckMultiXlayerMsdo12Bit) {
+  pbi_->multistream_decoder_mode = 1;
+  pbi_->common.msdo_params.multistream_profile_idc = MAIN_444C_12_IP2;
+  pbi_->xlayer_id_map[0] = 1;
+  pbi_->xlayer_id_map[1] = 1;
+  pbi_->mlayer_id_map[0][0] = 1;
+  EXPECT_TRUE(conformance_check_msdo_lcr(pbi_, false, false));
+}
+
+TEST_F(LcrTest, ConformanceCheckMultiMlayerLocalLcr12Bit) {
+  pbi_->xlayer_id_map[0] = 1;
+  pbi_->mlayer_id_map[0][0] = 1;
+  pbi_->mlayer_id_map[0][1] = 1;
+  pbi_->lcr_list[0][1].valid = 1;
+  pbi_->lcr_list[0][1].is_global = false;
+  pbi_->lcr_list[0][1].local_lcr.lcr_profile_tier_level_info_present_flag = 1;
+  pbi_->lcr_list[0][1].local_lcr.seq_ptl.lcr_seq_profile_idc = MAIN_444C_12_IP2;
+  EXPECT_TRUE(conformance_check_msdo_lcr(pbi_, false, true));
+}
+
+// Multiple extended layers combined with multiple embedded layers requires
+// IOP 2, which MAIN_444C_12_IP2 satisfies.
+TEST_F(LcrTest, ConformanceCheckMultiXlayerMultiMlayerMsdo12Bit) {
+  pbi_->multistream_decoder_mode = 1;
+  pbi_->common.msdo_params.multistream_profile_idc = MAIN_444C_12_IP2;
+  pbi_->xlayer_id_map[0] = 1;
+  pbi_->xlayer_id_map[1] = 1;
+  pbi_->mlayer_id_map[0][0] = 1;
+  pbi_->mlayer_id_map[0][1] = 1;
+  pbi_->lcr_list[0][1].valid = 1;
+  pbi_->lcr_list[0][1].is_global = false;
+  pbi_->lcr_list[0][1].local_lcr.lcr_profile_tier_level_info_present_flag = 1;
+  pbi_->lcr_list[0][1].local_lcr.seq_ptl.lcr_seq_profile_idc = MAIN_444C_12_IP2;
+  EXPECT_TRUE(conformance_check_msdo_lcr(pbi_, false, true));
+}
+#endif  // CONFIG_12BIT_PROFILE
+
+// IOP 0 does not permit multiple embedded layers, so this must still fail.
+TEST_F(LcrTest, ConformanceCheckMultiMlayerLocalLcrIop0Fails) {
+  pbi_->xlayer_id_map[0] = 1;
+  pbi_->mlayer_id_map[0][0] = 1;
+  pbi_->mlayer_id_map[0][1] = 1;
+  pbi_->lcr_list[0][1].valid = 1;
+  pbi_->lcr_list[0][1].is_global = false;
+  pbi_->lcr_list[0][1].local_lcr.lcr_profile_tier_level_info_present_flag = 1;
+  pbi_->lcr_list[0][1].local_lcr.seq_ptl.lcr_seq_profile_idc = MAIN_420_10_IP0;
+  EXPECT_FALSE(conformance_check_msdo_lcr(pbi_, false, true));
 }
 
 TEST_F(LcrTest, LcrIdBoundarySweep) {


### PR DESCRIPTION
conformance_check_msdo_lcr() compared against enumerated profile labels, which were never updated for MAIN_444C_12_IP2, so no legal multistream was possible with the 12-bit profile. Add av2_get_interop_from_profile() and express the checks in terms of interoperability points instead.

Also fixes two related defects: get_lcr_global_interop() returned a profile_idc where lcr_max_interop is an IOP, and the single-xlayer/multi-mlayer check OR'd the LCR presence flags, letting the absent-LCR fallback admit an IOP 0 stream.

Fix issue #5234. 