### PR TITLE
Fix non-monotonic behavior for screen content

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -375,7 +375,8 @@ static void set_good_speed_features_framesize_independent(
 
     sf->inter_sf.prune_comp_search_by_single_result = boosted ? 2 : 1;
 
-    sf->winner_mode_sf.disable_multiway_tx_part_in_rough_mode = 1;
+    sf->winner_mode_sf.disable_multiway_tx_part_in_rough_mode =
+        allow_screen_content_tools ? 0 : 1;
     if (!frame_is_intra_only(cm) &&
         sf->winner_mode_sf.disable_multiway_tx_part_in_rough_mode) {
       sf->winner_mode_sf.multi_winner_mode_type = MULTI_WINNER_MODE_DEFAULT;


### PR DESCRIPTION
Fixed #5216

One speed feature added recently "disable_multiway_tx_part_in_rough_mode" caused non-monotonic behavior for screen content. This PR fixed it.

Tested the fix with a recent (Aug 17, 2026) commit ea89c21

Encoder command:
./avmenc video/av2_b2/Slides1_1920x1080_30fps_8bit_420.y4m --tile-columns=0 --threads=1 --cpu-used=0 --tune-content=screen --enable-intrabc-ext=1 --passes=1 --lag-in-frames=19 --auto-alt-ref=1 --min-gf-interval=16 --max-gf-interval=16 --gf-min-pyr-height=4 --gf-max-pyr-height=4 --kf-min-dist=65 --kf-max-dist=65 --use-fixed-qp-offsets=1 --deltaq-mode=0 --enable-tpl-model=0 --enable-keyframe-filtering=0 --obu --end-usage=q --qp=${qp} --limit=130 -o output_${qp}.bin --psnr --test-decode=warn --cpu-used=1
```
Without the fix:   // Non-monotonic behavior was seen.
For QP110:
         Bitrate(kbps)  |  PSNR(Y)  |  PSNR(U)  |  PSNR(V)  |  PSNR(Avg)  |  PSNR(Overall)  |  Encoding time (FPS)
------------------------------------------------------------------------------------------------------------
Summary:    879.334154  |  46.995655  |  57.128215  |  56.976782  |  47.502603    |  35.471795        |  13305.0s (0.0 fps)
For QP135:
         Bitrate(kbps)  |  PSNR(Y)  |  PSNR(U)  |  PSNR(V)  |  PSNR(Avg)  |  PSNR(Overall)  |  Encoding time (FPS)
------------------------------------------------------------------------------------------------------------
Summary:    498.976615  |  48.933906  |  53.864854  |  53.696037  |  49.457692    |  39.826879        |  11583.3s (0.0 fps)

With the fix:      // Non-monotonic behavior was fixed.
For QP110:
         Bitrate(kbps)  |  PSNR(Y)  |  PSNR(U)  |  PSNR(V)  |  PSNR(Avg)  |  PSNR(Overall)  |  Encoding time (FPS)
------------------------------------------------------------------------------------------------------------
Summary:    832.482462  |  55.846373  |  57.211316  |  57.175542  |  55.940801    |  55.250666        |  12483.5s (0.0 fps)
For QP135:
         Bitrate(kbps)  |  PSNR(Y)  |  PSNR(U)  |  PSNR(V)  |  PSNR(Avg)  |  PSNR(Overall)  |  Encoding time (FPS)
------------------------------------------------------------------------------------------------------------
Summary:    484.464000  |  51.602224  |  53.997568  |  53.858700  |  51.997805    |  51.192436        |  10998.2s (0.0 fps)
```

STATS_CHANGED for screen content