### PR TITLE
Promote WienerNS zero-refine to speed 1

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -347,6 +347,8 @@ static void set_good_speed_features_framesize_independent(
   sf->rd_sf.perform_coeff_opt = 1;
 
   if (speed >= 1) {
+    sf->lpf_sf.wienerns_refine_iters = 0;
+
     sf->flexmv_sf.prune_non_one_pel_mv_using_best_mv_prec = 1;
     sf->inter_sf.selective_ref_frame = 2;
     sf->inter_sf.prune_newmv_modes_using_prior_rd = 1;
@@ -480,7 +482,6 @@ static void set_good_speed_features_framesize_independent(
     sf->rd_sf.tx_domain_dist_thres_level = 1;
 
     sf->lpf_sf.cdef_pick_method = CDEF_FAST_SEARCH_LVL1;
-    sf->lpf_sf.wienerns_refine_iters = 0;
 
     // TODO(any, yunqing): move this feature to speed 0.
     sf->tpl_sf.skip_alike_starting_mv = 1;


### PR DESCRIPTION
The speed feature wienerns_refine_iters was in speed 2.

Enabling it in speed 1 shows speedup with minor quality loss.

Testset          PSNR-YUV   EncTime
A1 (17 frames)    0.02%      95.58%
A2 (33 frames)    0.03%      99.08%

STATS_CHANGED

Change-Id: I91fd3184f45190347c19b49eaf7bf1934238e5ea