### PR TITLE
Skip unit size search for Loop Restoration based on pyramid level for speed 4

### DIFF
--- a/av2/encoder/pickrst.c
+++ b/av2/encoder/pickrst.c
@@ -3871,10 +3871,26 @@ void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
             ? 0
             : 1;
     RestorationInfo *rsi = &cm->rst_info[plane];
-    const int max_unit_size = rsi->max_restoration_unit_size;
-    const int min_unit_size = rsi->min_restoration_unit_size;
+    int max_unit_size = rsi->max_restoration_unit_size;
+    int min_unit_size = rsi->min_restoration_unit_size;
 
     int best_unit_size = min_unit_size;
+
+    if (cpi->sf.lpf_sf.reduce_lr_unit_size_by_pyr) {
+      // Trim the RU-size search window by pyramid level: drop the largest at
+      // level>=3, and also drop the smallest at level>=5 when drop_low is set.
+      const int pyr_level = cm->current_frame.pyramid_level;
+      const int drop_high = (pyr_level >= 3);
+      const int drop_low =
+          (cpi->sf.lpf_sf.reduce_lr_unit_size_by_pyr_drop_low &&
+           pyr_level >= 5);
+      int hi_unit_size = max_unit_size >> drop_high;
+      int lo_unit_size = min_unit_size << drop_low;
+      if (hi_unit_size < min_unit_size) hi_unit_size = min_unit_size;
+      if (lo_unit_size > hi_unit_size) lo_unit_size = min_unit_size;
+      min_unit_size = lo_unit_size;
+      max_unit_size = hi_unit_size;
+    }
 
     for (int unit_size = min_unit_size; unit_size <= max_unit_size;
          unit_size <<= 1) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -229,6 +229,12 @@ static void set_good_speed_feature_framesize_dependent(
     if (is_480p_or_larger) {
       sf->tx_sf.tx_type_search.prune_tx_type_using_stats = 1;
     }
+
+    // On small resolutions (<=360p), keep the smallest RU size available at
+    // deep pyramid levels by disabling drop_low.
+    if (AVMMIN(cm->width, cm->height) <= 360) {
+      sf->lpf_sf.reduce_lr_unit_size_by_pyr_drop_low = 0;
+    }
   }
 
   if (speed >= 5) {
@@ -621,6 +627,11 @@ static void set_good_speed_features_framesize_independent(
     sf->winner_mode_sf.enable_winner_mode_for_tx_size_srch = 0;
 
     sf->lpf_sf.lpf_pick = LPF_PICK_FROM_FULL_IMAGE_NON_DUAL;
+    // Trim the RU-size candidate set by pyramid level (policy in pickrst.c).
+    // drop_low is disabled later for small resolutions.
+    sf->lpf_sf.reduce_lr_unit_size_by_pyr = 1;
+    sf->lpf_sf.reduce_lr_unit_size_by_pyr_drop_low = 1;
+
     sf->mv_sf.reduce_search_range = 1;
     sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
     sf->mv_sf.newmv_drl_search_limit = 1;
@@ -1002,6 +1013,8 @@ static AVM_INLINE void init_lpf_sf(LOOP_FILTER_SPEED_FEATURES *lpf_sf) {
   lpf_sf->wienerns_refine_iters = 2;
   lpf_sf->enable_deblock_for_partition_search = 0;
   lpf_sf->early_terminate_ccso_search_by_cost = 0;
+  // Off by default: keep full RU-size search for all pyramid levels.
+  lpf_sf->reduce_lr_unit_size_by_pyr = 0;
   lpf_sf->ccso_chroma_dep = 0;
 }
 

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -1049,6 +1049,14 @@ typedef struct LOOP_FILTER_SPEED_FEATURES {
   // early terminate ccso search by cost threshold
   int early_terminate_ccso_search_by_cost;
 
+  // If set, trim the RU-size candidate set by pyramid_level in
+  // av2_pick_filter_restoration() (see pickrst.c). Default 0 = full search.
+  int reduce_lr_unit_size_by_pyr;
+
+  // Sub-flag of reduce_lr_unit_size_by_pyr. If set, also drop the smallest RU
+  // size at deep pyramid levels. Default 0 keeps the smallest size available.
+  int reduce_lr_unit_size_by_pyr_drop_low;
+
   // bypass ccso luma plane check
   int ccso_chroma_dep;
 } LOOP_FILTER_SPEED_FEATURES;


### PR DESCRIPTION
Skip unit size search for Loop Restoration based on pyramid level for speed >= 4.

Anchor: e96e164934 
Tests: RA, A1 17 frames, others 33 frames

cpu-used=4:
+----------+--------+-------+--------+--------+-------------+----------+
| Summary |     Y     |     U      |     V      |   YUV   |   Enc-time   | Dec-time |
+----------+--------+-------+--------+--------+-------------+----------+
| A1            |  0.00% | -0.02% |  0.12% |  0.00%  |   95.621%   |   99%       |
| A2            |  0.00% | -0.11% |  0.02% |  0.00%  |   97.579%   | 100%       |
| A3            | -0.03% |  0.02% |  0.02% | -0.03%  |   97.019%   | 100%       |
| A4            |  0.03% |  0.10% | -0.04% |  0.03%  |   97.039%   |  100%      |
| A5            | -0.04% |  0.20% | -0.09% | -0.03% |   97.165%   |  99%        |
+----------+--------+--------+--------+--------+------------+----------+