### PR TITLE
Add range check min_gf_interval in validate_config

### DIFF
--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -696,9 +696,14 @@ static avm_codec_err_t validate_config(avm_codec_alg_priv_t *ctx,
   RANGE_CHECK_HI(cfg, g_lag_in_frames, MAX_TOTAL_BUFFERS);
   RANGE_CHECK_HI(extra_cfg, min_gf_interval, MAX_LAG_BUFFERS - 1);
   RANGE_CHECK_HI(extra_cfg, max_gf_interval, MAX_LAG_BUFFERS - 1);
+  if (extra_cfg->min_gf_interval > 0) {
+    RANGE_CHECK(extra_cfg, min_gf_interval, MIN_GF_INTERVAL,
+                (MAX_LAG_BUFFERS - 1));
+  }
   if (extra_cfg->max_gf_interval > 0) {
     RANGE_CHECK(extra_cfg, max_gf_interval,
-                AVMMAX(2, extra_cfg->min_gf_interval), (MAX_LAG_BUFFERS - 1));
+                AVMMAX(MIN_GF_INTERVAL, extra_cfg->min_gf_interval),
+                (MAX_LAG_BUFFERS - 1));
   }
   RANGE_CHECK_HI(extra_cfg, gf_min_pyr_height, 5);
   RANGE_CHECK_HI(extra_cfg, gf_max_pyr_height, 5);


### PR DESCRIPTION
--min-gf-interval=1..3 bypasses the clamp the auto path applies, which defeats the baseline_gf_interval < min_gf_interval guard in define_gf_group(). A degenerate end-of-sequence group then builds an ARF whose temporal filter reads past the end of the lookahead and segfaults.

Valid configurations are bit-identical; 1..3 now match min=4.

This resolves issue #5297.