### PR TITLE
Set default configuration for realtime usage (--rt)

### DIFF
--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -577,6 +577,207 @@ static struct av2_extracfg default_extra_cfg = {
   0,      // force_deferred_frames_for_ras_test
   0,      // enable_low_complexity_decode
 };
+
+static struct av2_extracfg default_extra_cfg_rt = {
+  .cpu_used = 6,
+  .enable_auto_alt_ref = 0,
+  .enable_auto_bwd_ref = 0,
+  .noise_sensitivity = 0,
+  .sharpness = 0,
+  .static_thresh = 0,
+  .row_mt = 0,
+  .tile_columns = 0,
+  .tile_rows = 0,
+  .enable_tpl_model = 0,
+  .enable_keyframe_filtering = 0,
+  .arnr_max_frames = 7,
+  .arnr_strength = 5,
+  .min_gf_interval = 8,
+  .max_gf_interval = 8,
+  .gf_min_pyr_height = 0,
+  .gf_max_pyr_height = 0,
+  .tuning = AVM_TUNE_PSNR,
+  .subgop_config_str = NULL,
+  .subgop_config_path = NULL,
+  .qp = 40,
+  .rc_max_intra_bitrate_pct = 0,
+  .rc_max_inter_bitrate_pct = 0,
+  .gf_cbr_boost_pct = 0,
+  .lossless = 0,
+  .enable_deblocking = 1,
+  .enable_cdef = 1,
+  .enable_gdf = 0,
+  .gdf_unit_matches_sb = 0,
+  .enable_restoration = 0,
+  .enable_pc_wiener = 0,
+  .enable_wiener_nonsep = 0,
+  .enable_ccso = 0,
+  .ccso_unit_matches_sb = 0,
+  .enable_band_metadata = 0,
+  .enable_lf_sub_pu = 0,
+  .force_video_mode = 1,
+  .enable_trellis_quant = 0,
+  .enable_qm = 0,
+  .qm_y = DEFAULT_QM_Y,
+  .qm_u = DEFAULT_QM_U,
+  .qm_v = DEFAULT_QM_V,
+  .qm_min = DEFAULT_QM_FIRST,
+  .qm_max = DEFAULT_QM_LAST,
+  .user_defined_qmatrix = 0,
+  .frame_multi_qmatrix_unit_test = 0,
+  .sef_with_order_hint_test = 0,
+  .multi_seq_header_test = 0,
+  .num_tg = 1,
+  .mtu_size = 0,
+  .timing_info_type = AVM_TIMING_UNSPECIFIED,
+  .frame_parallel_decoding_mode = 0,
+  .enable_chroma_deltaq = 0,
+  .aq_mode = NO_AQ,
+  .deltaq_mode = DELTA_Q_OBJECTIVE,
+  .frame_periodic_boost = 0,
+  .bit_depth = AVM_BITS_8,
+  .content = AVM_CONTENT_DEFAULT,
+  .color_primaries = AVM_CICP_CP_UNSPECIFIED,
+  .transfer_characteristics = AVM_CICP_TC_UNSPECIFIED,
+  .matrix_coefficients = AVM_CICP_MC_UNSPECIFIED,
+  .chroma_sample_position = AVM_CSP_UNSPECIFIED,
+  .color_range = 0,
+  .render_width = 0,
+  .render_height = 0,
+  .superblock_size = AVM_SUPERBLOCK_SIZE_DYNAMIC,
+  .enable_sframe = 0,
+  .film_grain_test_vector = 0,
+  .film_grain_table_filename = 0,
+  .film_grain_block_size = 0,
+  .motion_vector_unit_test = 0,
+  .cdf_update_mode = 1,
+  .disable_ml_partition_speed_features = 1,
+  .erp_pruning_level = 0,
+  .use_ml_erp_pruning = 0,
+  .enable_ext_partitions = 0,
+  .enable_tx_partition = 1,
+  .enable_rect_partitions = 1,
+  .enable_uneven_4way_partitions = 1,
+  .max_partition_aspect_ratio = 8,
+  .disable_ml_transform_speed_features = 0,
+  .enable_sdp = 0,
+  .enable_extended_sdp = 0,
+  .enable_mrls = 0,
+  .enable_tip = 0,
+  .enable_tip_refinemv = 0,
+  .enable_mv_traj = 0,
+  .enable_high_motion = 0,
+  .enable_bawp = 0,
+  .enable_cwp = 0,
+  .enable_imp_msk_bld = 0,
+  .enable_fsc = 1,
+  .enable_idtx_intra = 1,
+  .enable_ist = 0,
+  .enable_inter_ist = 0,
+  .enable_chroma_dctonly = 0,
+  .enable_inter_ddt = 0,
+  .enable_cctx = 0,
+  .enable_ibp = 0,
+  .enable_adaptive_mvd = 0,
+  .enable_flex_mvres = 0,
+  .select_cfl_ds_filter = 3,
+  .enable_joint_mvd = 0,
+  .enable_refinemv = 0,
+  .enable_mvd_sign_derive = 0,
+  .min_partition_size = 4,
+  .max_partition_size = 256,
+  .enable_intra_edge_filter = 0,
+  .reduced_tx_part_set = 0,
+  .enable_flip_idtx = 1,
+  .max_reference_frames = 3,
+  .enable_reduced_reference_set = 1,
+  .explicit_ref_frame_map = 1,
+  .add_sef_for_hidden_frames = 0,
+  .monotonic_output_order = 0,
+  .enable_ref_frame_mvs = 0,
+  .reduced_ref_frame_mvs_mode = 0,
+  .allow_ref_frame_mvs = 0,
+  .enable_masked_comp = 0,
+  .enable_onesided_comp = 0,
+  .enable_interintra_comp = 0,
+  .enable_smooth_interintra = 0,
+  .enable_diff_wtd_comp = 0,
+  .enable_interinter_wedge = 0,
+  .enable_interintra_wedge = 0,
+  .enable_global_motion = 0,
+  .enable_skip_mode = 0,
+  .enable_warped_motion = 0,
+  .enable_warp_causal = 0,
+  .enable_warp_delta = 0,
+  .enable_six_param_warp_delta = 0,
+  .enable_warp_extend = 0,
+  .enable_intra_dip = 0,
+  .enable_smooth_intra = 0,
+  .enable_paeth_intra = 0,
+  .enable_cfl_intra = 0,
+  .enable_mhccp = 0,
+  .enable_overlay = 0,
+  .enable_palette = 1,
+  .enable_intrabc = !CONFIG_SHARP_SETTINGS,
+  .enable_intrabc_ext = 0,
+  .enable_angle_delta = 0,
+  .enable_opfl_refine = AVM_OPFL_REFINE_NONE,
+#if CONFIG_DENOISE
+  .noise_level = 0,
+  .noise_block_size = 32,
+#endif
+  .chroma_subsampling_x = 0,
+  .chroma_subsampling_y = 0,
+  .reduced_tx_type_set = 0,
+  .use_intra_dct_only = 1,
+  .use_inter_dct_only = 0,
+  .use_intra_default_tx_only = 0,
+  .quant_b_adapt = 0,
+  .vbr_corpus_complexity_lap = 0,
+  .target_seq_level_idx = {
+      SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX,
+      SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX,
+      SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX,
+      SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX,
+      SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX,
+      SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX, SEQ_LEVEL_MAX,
+      SEQ_LEVEL_MAX, SEQ_LEVEL_MAX,
+  },
+  .tier_mask = 0,
+  .min_cr = 0,
+  .coeff_cost_upd_freq = (COST_UPDATE_TYPE)2,
+  .mode_cost_upd_freq = (COST_UPDATE_TYPE)2,
+  .mv_cost_upd_freq = (COST_UPDATE_TYPE)3,
+  .sb_multipass_unit_test = 0,
+  .enable_subgop_stats = 0,
+  .max_drl_refmvs = 0,
+  .max_drl_refbvs = 0,
+  .enable_refmvbank = 0,
+  .enable_drl_reorder = 0,
+  .enable_cdef_on_skip_txfm = 0,
+  .enable_avg_cdf = 1,
+  .avg_cdf_type = 1,
+  .enable_parity_hiding = 0,
+  .enable_short_refresh_frame_flags = 1,
+  .enable_ext_seg = 0,
+  .dpb_size = 8,
+  .enable_bru = 0,
+  .disable_loopfilters_across_tiles = 0,
+  .enable_cropping_window = 0,
+  .crop_win_left_offset = 0,
+  .crop_win_right_offset = 0,
+  .crop_win_top_offset = 0,
+  .crop_win_bottom_offset = 0,
+  .scan_type_info_present_flag = 0,
+  .enable_mfh_obu_signaling = 0,
+  .operating_points_count = 1,
+  .cross_frame_cdf_init_mode = 1,
+  .use_buffer_refresh_multi_layers_test = 0,
+  .buffer_refresh_multi_layers_test = { 0 },
+  .multi_layers_lag_test = 0,
+  .force_deferred_frames_for_ras_test = 0,
+  .enable_low_complexity_decode = 0,
+};
 // clang-format on
 
 struct avm_codec_alg_priv {
@@ -2848,7 +3049,11 @@ static avm_codec_err_t encoder_init(avm_codec_ctx_t *ctx) {
       ctx->config.enc = &priv->cfg;
     }
 
-    priv->extra_cfg = default_extra_cfg;
+    if (priv->cfg.g_usage == AVM_USAGE_REALTIME) {
+      priv->extra_cfg = default_extra_cfg_rt;
+    } else {
+      priv->extra_cfg = default_extra_cfg;
+    }
     avm_once(av2_initialize_enc);
 
     res = validate_config(priv, &priv->cfg, &priv->extra_cfg);
@@ -4928,7 +5133,7 @@ static const avm_codec_enc_cfg_t encoder_usage_cfg[] = {
       SCALE_NUMERATOR,  // rc_resize_denominator
       SCALE_NUMERATOR,  // rc_resize_kf_denominator
 
-      AVM_VBR,      // rc_end_usage
+      AVM_CBR,      // rc_end_usage
       { NULL, 0 },  // rc_firstpass_mb_stats_in
       256,          // rc_target_bandwidth
       0,            // rc_min_quantizer
@@ -4969,73 +5174,114 @@ static const avm_codec_enc_cfg_t encoder_usage_cfg[] = {
       0,                           // frame_hash_per_plane;
       0,                           // use_short_metadata;
       {
-          0,    // init_by_cfg_file
-          128,  // superblock_size
-          128,  // max_partition_size
-          4,    // min_partition_size
-          1,    // enable_rect_partitions
-          1,    // enable_uneven_4way_partitions
-          1,    // disable_ml_partition_speed_features
-          5,    // erp_pruning_level
-          0,    // use_ml_erp_pruning
-          1,    // enable_ext_partitions
-          1,    // enable_tx_partition
-          8,    // max_partition_aspect_ratio
-          0,    1, 1, /*extended sdp*/ 1,
-          1,
-          1,  // enable RefineMv and OPFL for TIP
-          1,  // MV traj
-          0,  // enable_high_motion
-          1,    1, 1, 1,
-          1,  // enable idtx intra for fsc is disabled case
-          1,
-          1,  // IST
-          1,  // inter IST
-          0,  // chroma DCT only
-          1,  // inter DDT
-          1,  // enable_cctx
-          1,    1, 1,
-          3,  // select_cfl_ds
-          1,    1, 1, 1,
-          1,    1, 1, 0,
-          1,    1, 1, 1,
-          0,    1, 1, 1,
-          1,    1, 1, 1,
-          1,    1, 1, 1,
-          0,    0, 1, 1,
-          1,    1, 1, 1,
-          1,    1, 1,
-          0,  // reduced_tx_part_set
-          1,    1, 1, 1,
-          3,    1,
-          0,  // reduced_ref_frame_mvs_mode
-          1,  // enable_reduced_reference_set
-          0,  // explicit_ref_frame_map
-          0,  // add_sef_for_hidden_frames
-          0,  // monotonic_output_order
-          0,  // reduced_tx_type_set
-          0,  // max_drl_refmvs
-
-          0,  // max_drl_refbvs
-          1,    1, 1,
-          1,  // enable_avg_cdf
-          1,  // avg_cdf_type
-          1,
-          1,  // enable_short_refresh_frame_flags
-          0,  // enable_ext_seg
-          8,  // dpb_size
-          0,  // enable_bru
-          0,  // disable_loopfilters_across_tiles
-          0,  // enable cropping window
-          0,  // crop_win_left_offset
-          0,  // crop_win_right_offset
-          0,  // crop_win_top_offset
-          0,  // crop_win_bottom_offset
-          NULL, 0, 0,
-          0,  // enable_mfh_obu_signaling
-          1,
-          0,  // enable_low_complexity_decode
-      },      // cfg
+          .init_by_cfg_file = 0,
+          .superblock_size = 128,
+          .max_partition_size = 128,
+          .min_partition_size = 4,
+          .enable_rect_partitions = 1,
+          .enable_uneven_4way_partitions = 1,
+          .disable_ml_partition_speed_features = 1,
+          .erp_pruning_level = 0,
+          .use_ml_erp_pruning = 0,
+          .enable_ext_partitions = 0,
+          .enable_tx_partition = 1,
+          .max_partition_aspect_ratio = 8,
+          .disable_ml_transform_speed_features = 0,
+          .enable_sdp = 0,
+          .enable_extended_sdp = 0,
+          .enable_mrls = 0,
+          .enable_tip = 0,
+          .enable_tip_refinemv = 0,
+          .enable_mv_traj = 0,
+          .enable_high_motion = 0,
+          .enable_bawp = 0,
+          .enable_cwp = 0,
+          .enable_imp_msk_bld = 0,
+          .enable_fsc = 1,
+          .enable_idtx_intra = 1,
+          .enable_ist = 0,
+          .enable_inter_ist = 0,
+          .enable_chroma_dctonly = 0,
+          .enable_inter_ddt = 0,
+          .enable_cctx = 0,
+          .enable_ibp = 0,
+          .enable_adaptive_mvd = 0,
+          .enable_flex_mvres = 0,
+          .select_cfl_ds_filter = 3,
+          .enable_joint_mvd = 0,
+          .enable_refinemv = 0,
+          .enable_mvd_sign_derive = 0,
+          .enable_flip_idtx = 1,
+          .enable_deblocking = 1,
+          .enable_cdef = 1,
+          .enable_gdf = 0,
+          .gdf_unit_matches_sb = 0,
+          .enable_restoration = 0,
+          .enable_pc_wiener = 0,
+          .enable_wiener_nonsep = 0,
+          .enable_ccso = 0,
+          .ccso_unit_matches_sb = 0,
+          .enable_band_metadata = 0,
+          .enable_lf_sub_pu = 0,
+          .enable_warped_motion = 0,
+          .enable_warp_causal = 0,
+          .enable_warp_delta = 0,
+          .enable_six_param_warp_delta = 0,
+          .enable_warp_extend = 0,
+          .enable_global_motion = 0,
+          .enable_skip_mode = 0,
+          .enable_diff_wtd_comp = 0,
+          .enable_interintra_comp = 0,
+          .enable_masked_comp = 0,
+          .enable_onesided_comp = 0,
+          .enable_palette = 1,
+          .enable_intrabc = 1,
+          .enable_intrabc_ext = 0,
+          .enable_cfl_intra = 0,
+          .enable_mhccp = 0,
+          .enable_smooth_intra = 0,
+          .enable_intra_dip = 0,
+          .enable_angle_delta = 0,
+          .enable_opfl_refine = AVM_OPFL_REFINE_NONE,
+          .enable_intra_edge_filter = 0,
+          .reduced_tx_part_set = 0,
+          .enable_smooth_interintra = 0,
+          .enable_interinter_wedge = 0,
+          .enable_interintra_wedge = 0,
+          .enable_paeth_intra = 0,
+          .enable_trellis_quant = 0,
+          .enable_ref_frame_mvs = 0,
+          .reduced_ref_frame_mvs_mode = 0,
+          .enable_reduced_reference_set = 1,
+          .explicit_ref_frame_map = 1,
+          .add_sef_for_hidden_frames = 0,
+          .monotonic_output_order = 0,
+          .reduced_tx_type_set = 0,
+          .max_drl_refmvs = 0,
+          .max_drl_refbvs = 0,
+          .enable_refmvbank = 0,
+          .enable_drl_reorder = 0,
+          .enable_cdef_on_skip_txfm = 0,
+          .enable_avg_cdf = 1,
+          .avg_cdf_type = 1,
+          .enable_parity_hiding = 0,
+          .enable_short_refresh_frame_flags = 1,
+          .enable_ext_seg = 0,
+          .dpb_size = 8,
+          .enable_bru = 0,
+          .disable_loopfilters_across_tiles = 0,
+          .enable_cropping_window = 0,
+          .crop_win_left_offset = 0,
+          .crop_win_right_offset = 0,
+          .crop_win_top_offset = 0,
+          .crop_win_bottom_offset = 0,
+          .icc_data = NULL,
+          .icc_size = 0,
+          .scan_type_info_present_flag = 0,
+          .enable_mfh_obu_signaling = 0,
+          .operating_points_count = 1,
+          .enable_low_complexity_decode = 0,
+      },  // cfg
   },
 };
 

--- a/test/rtc_test.cc
+++ b/test/rtc_test.cc
@@ -50,77 +50,7 @@ class RtcTest : public ::libavm_test::CodecTestWithParam<int>,
     if (video->frame() == 0) {
       encoder->Control(AV2E_SET_TUNE_CONTENT, tune_content_);
       encoder->Control(AVME_SET_CPUUSED, 6);
-      // Other RTC settings, to be updated.
-      encoder->Control(AVME_SET_ENABLEAUTOALTREF, 0);
-      encoder->Control(AV2E_SET_ENABLE_KEYFRAME_FILTERING, 0);
-      encoder->Control(AV2E_SET_ENABLE_RECT_PARTITIONS, 0);
-      encoder->Control(AV2E_SET_ENABLE_INTRA_EDGE_FILTER, 0);
-      encoder->Control(AV2E_SET_ENABLE_MASKED_COMP, 0);
-      encoder->Control(AV2E_SET_ENABLE_ONESIDED_COMP, 0);
-      encoder->Control(AV2E_SET_ENABLE_INTERINTRA_COMP, 0);
-      encoder->Control(AV2E_SET_ENABLE_SMOOTH_INTERINTRA, 0);
-      encoder->Control(AV2E_SET_ENABLE_DIFF_WTD_COMP, 0);
-      encoder->Control(AV2E_SET_ENABLE_INTERINTER_WEDGE, 0);
-      encoder->Control(AV2E_SET_ENABLE_INTERINTRA_WEDGE, 0);
-      encoder->Control(AV2E_SET_ENABLE_GLOBAL_MOTION, 0);
-      encoder->Control(AV2E_SET_ENABLE_WARPED_MOTION, 0);
-      encoder->Control(AV2E_SET_ENABLE_SMOOTH_INTRA, 0);
-      encoder->Control(AV2E_SET_ENABLE_PAETH_INTRA, 0);
-      encoder->Control(AV2E_SET_ENABLE_CFL_INTRA, 0);
-      encoder->Control(AV2E_SET_ENABLE_OVERLAY, 0);
-      encoder->Control(AV2E_SET_QUANT_B_ADAPT, 0);
-      encoder->Control(AV2E_SET_ENABLE_TPL_MODEL, 0);
-      encoder->Control(AV2E_SET_FRAME_PERIODIC_BOOST, 0);
       encoder->Control(AV2E_SET_MAX_REFERENCE_FRAMES, 1);
-      encoder->Control(AV2E_SET_REDUCED_REFERENCE_SET, 1);
-      encoder->Control(AV2E_SET_ENABLE_REF_FRAME_MVS, 0);
-      encoder->Control(AV2E_SET_ENABLE_QM, 0);
-      encoder->Control(AV2E_SET_ENABLE_ANGLE_DELTA, 0);
-      encoder->Control(AV2E_SET_ENABLE_RESTORATION, 0);
-      encoder->Control(AV2E_SET_ENABLE_BRU, 0);
-      encoder->Control(AV2E_SET_AQ_MODE, 0);
-      encoder->Control(AV2E_SET_CDF_UPDATE_MODE, 1);
-      encoder->Control(AV2E_SET_ENABLE_DEBLOCKING, 1);
-      encoder->Control(AV2E_SET_ENABLE_CDEF, 1);
-      encoder->Control(AV2E_SET_ENABLE_PALETTE, 1);
-      encoder->Control(AV2E_SET_ENABLE_INTRABC, 1);
-      encoder->Control(AV2E_SET_INTRA_DCT_ONLY, 1);
-      encoder->Control(AV2E_SET_INTER_DCT_ONLY, 1);
-      encoder->Control(AV2E_SET_FORCE_VIDEO_MODE, 1);
-      encoder->Control(AV2E_SET_COEFF_COST_UPD_FREQ, 2);
-      encoder->Control(AV2E_SET_MODE_COST_UPD_FREQ, 2);
-      encoder->Control(AV2E_SET_MV_COST_UPD_FREQ, 3);
-      // The following settings don't have codec control assigned yet.
-      encoder->SetOption("enable-sdp", "0");
-      encoder->SetOption("enable-extended-sdp", "0");
-      encoder->SetOption("enable-mhccp", "0");
-      encoder->SetOption("enable-mrls", "0");
-      encoder->SetOption("enable-tip", "0");
-      encoder->SetOption("enable-bawp", "0");
-      encoder->SetOption("enable-cwp", "0");
-      encoder->SetOption("enable-imp-msk-bld", "0");
-      encoder->SetOption("enable-ist", "0");
-      encoder->SetOption("enable-inter-ist", "0");
-      encoder->SetOption("enable-inter-ddt", "0");
-      encoder->SetOption("enable-cctx", "0");
-      encoder->SetOption("enable-ccso", "0");
-      encoder->SetOption("enable-ext-partitions", "0");
-      encoder->SetOption("enable-pc-wiener", "0");
-      encoder->SetOption("enable-wiener-nonsep", "0");
-      encoder->SetOption("enable-ibp", "0");
-      encoder->SetOption("enable-refmvbank", "0");
-      encoder->SetOption("enable-opfl-refine", "0");
-      encoder->SetOption("enable-lf-sub-pu", "0");
-      encoder->SetOption("enable-adaptive-mvd", "0");
-      encoder->SetOption("enable-flex-mvres", "0");
-      encoder->SetOption("enable-joint-mvd", "0");
-      encoder->SetOption("enable-refinemv", "0");
-      encoder->SetOption("enable-mvd-sign-derive", "0");
-      encoder->SetOption("enable-parity-hiding", "0");
-      encoder->SetOption("enable-warp-delta", "0");
-      encoder->SetOption("enable-warp-extend", "0");
-      encoder->SetOption("max-drl-refmvs", "0");
-      encoder->SetOption("max-drl-refbvs", "0");
     }
   }
 


### PR DESCRIPTION
Add default extra and encoder configuration options for AVM_USAGE_REALTIME in av2/av2_cx_iface.c to match standard RTC encoding defaults, and simplify test/rtc_test.cc to use the new defaults.

Setting `--rt` in the `avmenc` command line applies standard Realtime (RTC) defaults equivalent to:
  
    --bit-depth=8 --passes=1 --lag-in-frames=0 --auto-alt-ref=0 --enable-tpl-model=0 \
    --enable-keyframe-filtering=0 --enable-deblocking=1 --enable-restoration=0 \
    --enable-intra-edge-filter=0 --enable-flip-idtx=1 --enable-masked-comp=0 \
    --enable-onesided-comp=0 --enable-interintra-comp=0 --enable-smooth-interintra=0 \
    --enable-diff-wtd-comp=0 --enable-interinter-wedge=0 --enable-interintra-wedge=0 \
    --enable-global-motion=0 --enable-warped-motion=0 --enable-smooth-intra=0 \
    --enable-paeth-intra=0 --enable-cfl-intra=0 --force-video-mode=1 --enable-overlay=0 \
    --enable-angle-delta=0 --enable-trellis-quant=0 --enable-qm=0 --use-intra-dct-only=1 \
    --coeff-cost-upd-freq=2 --mode-cost-upd-freq=2 --mv-cost-upd-freq=3 --frame-parallel=0 \
    --aq-mode=0 --deltaq-mode=0 --frame-boost=0 --noise-sensitivity=0 --cdf-update-mode=1 \
    --reduced-reference-set=1 --enable-ref-frame-mvs=0 --erp-pruning-level=0 \
    --use-ml-erp-pruning=0 --enable-ext-partitions=0 --enable-mrls=0 --enable-pc-wiener=0 \
    --enable-wiener-nonsep=0 --enable-tip=0 --enable-bawp=0 --enable-cwp=0 \
    --enable-imp-msk-bld=0 --enable-ist=0 --enable-inter-ist=0 --enable-inter-ddt=0 \
    --enable-cctx=0 --enable-ibp=0 --max-drl-refmvs=0 --max-drl-refbvs=0 --enable-refmvbank=0 \
    --enable-opfl-refine=0 --enable-ccso=0 --enable-lf-sub-pu=0 --enable-adaptive-mvd=0 \
    --enable-flex-mvres=0 --enable-joint-mvd=0 --enable-refinemv=0 --enable-mvd-sign-derive=0 \
    --enable-parity-hiding=0 --enable-warp-delta=0 --enable-warp-extend=0 --tile-columns=0 \
    --gf-min-pyr-height=0 --gf-max-pyr-height=0 --enable-sdp=0 --min-gf-interval=8 \
    --max-gf-interval=8 --explicit-ref-frame-map=1 --enable-bru=0 --enable-ext-seg=0 \
    --enable-six-param-warp-delta=0 --enable-cdef=1 --enable-cdef-on-skip-txfm=0 \
    --dpb-size=8 --use-inter-dct-only=0 --enable-fsc=1 --enable-idtx-intra=1 \
    --enable-palette=1 --enable-intrabc-ext=0 --enable-intrabc=1 --cpu-used=6 \
    --enable-gdf=0 --max-reference-frames=3
