### PR TITLE
Fix encoder segfault when a GF group is truncated to one frame

### DIFF
--- a/av2/encoder/pass2_strategy.c
+++ b/av2/encoder/pass2_strategy.c
@@ -1817,6 +1817,8 @@ static void define_gf_group(AV2_COMP *cpi, FIRSTPASS_STATS *this_frame,
     set_baseline_gf_interval(cpi, (i - 1), active_max_gf_interval, use_alt_ref,
                              frame_params->frame_type);
 
+    if (rc->baseline_gf_interval < 2) gf_group->max_layer_depth_allowed = 0;
+
     const int forward_frames = (rc->frames_to_key - i + 1 >= (i - 1))
                                    ? (i - 1)
                                    : AVMMAX(0, rc->frames_to_key - i + 1);


### PR DESCRIPTION
define_gf_group() sets max_layer_depth_allowed from gf_max_pyr_height, then set_baseline_gf_interval() can shorten baseline_gf_interval to 1. Nothing rechecks the pyramid height afterwards, so an ARF is scheduled for a group with no room for one and av2_lookahead_peek() returns NULL in the temporal filter.

Reproduces with --kf-max-dist=1 --gf-min-pyr-height=2 --enable-fwd-kf=1 on any input. define_gf_group_pass0() already has this guard.

Bounded at 2 rather than min_gf_interval so that only the degenerate 1-frame group is affected; all non-crashing streams stay bit-exact.

Fix #5301.