### PR TITLE
Bound the two-pass wet-pass mode search with the dry pass's rd

### DIFF
--- a/av2/encoder/block.h
+++ b/av2/encoder/block.h
@@ -30,6 +30,19 @@
 extern "C" {
 #endif
 
+/*! \brief Granularity of the dry-pass rd grid, in mi units (log2): 16x16 px. */
+#define TWO_PASS_DRY_RD_UNIT_LOG2 2
+/*! \brief Side of the dry-pass rd grid, in units. */
+#define TWO_PASS_DRY_RD_SIDE (MAX_MIB_SIZE >> TWO_PASS_DRY_RD_UNIT_LOG2)
+/*! \brief Number of positions in the dry-pass rd grid. */
+#define TWO_PASS_DRY_RD_GRID (TWO_PASS_DRY_RD_SIDE * TWO_PASS_DRY_RD_SIDE)
+/*! \brief Smallest side, in pixels, the dry pass can produce. */
+#define TWO_PASS_DRY_RD_MIN_1D 16
+/*! \brief Number of block sizes the dry pass can record. */
+#define TWO_PASS_DRY_RD_BSIZES 15
+/*! \brief Number of slots in the dry-pass rd grid. */
+#define TWO_PASS_DRY_RD_SLOTS (TWO_PASS_DRY_RD_GRID * TWO_PASS_DRY_RD_BSIZES)
+
 //! Minimum linear dimension of a tpl block
 #define MIN_TPL_BSIZE_1D 16
 //! Maximum number of tpl block in a super block
@@ -1659,6 +1672,14 @@ typedef struct macroblock {
   /*! \brief True during the dry pass of the SB-level two-pass partition
    * search; gates the block-level dry-pass shortcuts. */
   bool apply_dry_pass_shortcuts;
+
+  /*! \brief The dry pass's best rdcost per block, or 0 when absent. Indexed by
+   * dry_pass_rd_slot(). Reset per superblock. */
+  int64_t unit_dry_rd[TWO_PASS_DRY_RD_SLOTS];
+
+  /*! \brief True during the wet pass of the SB-level two-pass partition
+   * search; gates consumption of any dry-pass side information. */
+  bool consume_dry_pass_info;
 
   /*! \brief Cap on top intra Y candidates for full RD. */
   int intra_mode_prune_top;

--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -679,6 +679,9 @@ static AVM_INLINE void perform_two_pass_partition_search(
   // The dry pass does not go below 16x16: it only needs a rough shape, and it
   // scores blocks with a reduced set of tools.
   x->sb_enc.min_partition_size = BLOCK_16X16;
+  // Drop the previous superblock's dry-pass rd records. The recorded rdcosts
+  // are in the dry pass's rdmult units, which the wet pass must not recompute.
+  if (fast_two_pass) av2_zero(x->unit_dry_rd);
   perform_one_partition_pass(cpi, td, tile_data, tp, tp_chroma, mi_row, mi_col,
                              SB_DRY_PASS, NULL);
   PARTITION_TREE *part_ref = xd->sbi->ptree_root[0];

--- a/av2/encoder/encodeframe_utils.h
+++ b/av2/encoder/encodeframe_utils.h
@@ -185,6 +185,7 @@ static AVM_INLINE void av2_set_two_pass_flags(
   const bool fast_two_pass = av2_two_pass_part_is_fast(&cpi->sf.part_sf);
   x->apply_dry_pass_shortcuts =
       fast_two_pass && (multi_pass_mode == SB_DRY_PASS);
+  x->consume_dry_pass_info = fast_two_pass && (multi_pass_mode == SB_WET_PASS);
   const bool is_wet_pass_reuse =
       (fast_two_pass && multi_pass_mode == SB_WET_PASS && part_search_state &&
        part_search_state->forced_partition != PARTITION_INVALID);

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -479,6 +479,69 @@ void av2_set_offsets(const AV2_COMP *const cpi, const TileInfo *const tile,
   }
 }
 
+// Percent the dry-pass rdcost is inflated by before the wet pass uses it as an
+// initial rd limit, to absorb the context drift between the passes.
+#define TWO_PASS_WARMSTART_MARGIN_PCT 4
+
+// Dense index into unit_dry_rd's size dimension, biased by 1 so 0 means "no
+// slot". Only sizes with both sides >= TWO_PASS_DRY_RD_MIN_1D are listed; the
+// dry pass cannot produce the rest.
+static const int8_t dry_rd_bsize_idx[BLOCK_SIZES_ALL] = {
+  [BLOCK_16X16] = 1,    [BLOCK_16X32] = 2,    [BLOCK_32X16] = 3,
+  [BLOCK_32X32] = 4,    [BLOCK_32X64] = 5,    [BLOCK_64X32] = 6,
+  [BLOCK_64X64] = 7,    [BLOCK_64X128] = 8,   [BLOCK_128X64] = 9,
+  [BLOCK_128X128] = 10, [BLOCK_16X64] = 11,   [BLOCK_64X16] = 12,
+  [BLOCK_128X256] = 13, [BLOCK_256X128] = 14, [BLOCK_256X256] = 15,
+};
+
+// Slot for a block in the dry-pass rd grid, or -1 if the dry pass cannot have
+// recorded it. The size is checked first, so blocks below the floor cost one
+// table lookup.
+static AVM_INLINE int dry_pass_rd_slot(BLOCK_SIZE sb_size, int mi_row,
+                                       int mi_col, BLOCK_SIZE bsize) {
+  if (bsize >= BLOCK_SIZES_ALL) return -1;
+  const int size_idx = dry_rd_bsize_idx[bsize] - 1;
+  // The table must agree with the real block dimensions.
+  assert((size_idx >= 0) == (block_size_wide[bsize] >= TWO_PASS_DRY_RD_MIN_1D &&
+                             block_size_high[bsize] >= TWO_PASS_DRY_RD_MIN_1D));
+  assert(size_idx < TWO_PASS_DRY_RD_BSIZES);
+  if (size_idx < 0) return -1;
+  const int gr =
+      (mi_row & (mi_size_high[sb_size] - 1)) >> TWO_PASS_DRY_RD_UNIT_LOG2;
+  const int gc =
+      (mi_col & (mi_size_wide[sb_size] - 1)) >> TWO_PASS_DRY_RD_UNIT_LOG2;
+  if (gr >= TWO_PASS_DRY_RD_SIDE || gc >= TWO_PASS_DRY_RD_SIDE) return -1;
+  return (gr * TWO_PASS_DRY_RD_SIDE + gc) * TWO_PASS_DRY_RD_BSIZES + size_idx;
+}
+
+// Record the dry pass's best rdcost for this block. Keyed by position and by
+// exact block size: rd cost scales with block area, so a smaller block's rdcost
+// is not a valid bound for a larger one.
+static AVM_INLINE void record_dry_pass_rd(MACROBLOCK *x, BLOCK_SIZE sb_size,
+                                          int mi_row, int mi_col,
+                                          BLOCK_SIZE bsize, int64_t rdcost) {
+  if (rdcost <= 0 || rdcost == INT64_MAX) return;
+  const int slot_idx = dry_pass_rd_slot(sb_size, mi_row, mi_col, bsize);
+  if (slot_idx < 0) return;
+  int64_t *const slot = &x->unit_dry_rd[slot_idx];
+  if (*slot == 0 || rdcost < *slot) *slot = rdcost;
+}
+
+// The wet pass's initial rd limit for this block: the dry pass's rdcost plus a
+// margin, or 0 when the dry pass has no record for it.
+static AVM_INLINE int64_t dry_pass_rd_bound(const MACROBLOCK *x,
+                                            BLOCK_SIZE sb_size, int mi_row,
+                                            int mi_col, BLOCK_SIZE bsize) {
+  if (!x->consume_dry_pass_info) return 0;
+  const int slot_idx = dry_pass_rd_slot(sb_size, mi_row, mi_col, bsize);
+  if (slot_idx < 0) return 0;
+  const int64_t rd = x->unit_dry_rd[slot_idx];
+  if (rd <= 0) return 0;
+  // Guard the multiply against overflow on very large rd values.
+  if (rd > INT64_MAX / (100 + TWO_PASS_WARMSTART_MARGIN_PCT)) return 0;
+  return rd * (100 + TWO_PASS_WARMSTART_MARGIN_PCT) / 100;
+}
+
 /*!\brief Interface for AV2 mode search for an individual coding block
  *
  * \ingroup partition_search
@@ -665,8 +728,27 @@ static void pick_sb_modes(AV2_COMP *const cpi, ThreadData *td,
       av2_rd_pick_inter_mode_sb_seg_skip(cpi, tile_data, x, mi_row, mi_col,
                                          rd_cost, bsize, ctx, best_rd.rdcost);
     } else {
-      av2_rd_pick_inter_mode_sb(cpi, tile_data, x, rd_cost, bsize, ctx,
-                                best_rd.rdcost);
+      // Wet pass: start from the dry pass's rd for this block plus a margin, so
+      // pruning bites from the first candidate. The bound can be violated
+      // because the two passes see different contexts, so if it leaves the
+      // block with no valid mode the search is re-run once with the original
+      // limit.
+      const int64_t warmstart_bound =
+          dry_pass_rd_bound(x, cm->sb_size, mi_row, mi_col, bsize);
+      const bool warmstart_applied =
+          warmstart_bound > 0 && warmstart_bound < best_rd.rdcost;
+      av2_rd_pick_inter_mode_sb(
+          cpi, tile_data, x, rd_cost, bsize, ctx,
+          warmstart_applied ? warmstart_bound : best_rd.rdcost);
+      if (warmstart_applied && rd_cost->rate == INT_MAX) {
+        av2_rd_pick_inter_mode_sb(cpi, tile_data, x, rd_cost, bsize, ctx,
+                                  best_rd.rdcost);
+      }
+    }
+    // Dry pass: record the rd it achieved, to bound the wet pass on this block.
+    if (x->apply_dry_pass_shortcuts && rd_cost->rate != INT_MAX) {
+      record_dry_pass_rd(x, cm->sb_size, mi_row, mi_col, bsize,
+                         rd_cost->rdcost);
     }
 #if CONFIG_COLLECT_COMPONENT_TIMING
     end_timing(cpi, av2_rd_pick_inter_mode_sb_time);


### PR DESCRIPTION
The wet pass starts mode search from an unbounded rd limit, so its pruning cannot bite until it finds a good candidate on its own. Start it instead from the dry pass's rd for the same block and size, plus a margin.

The two passes see different contexts, so the bound can be violated. A block left with no valid mode is re-searched once with the original limit.

Anchor: commit c77f169
Speed 4 (cpu-used=4): FG16 CTC (33 frames, class A1 and A2, RA)

```
  +------------+-------+-------+-------+-------+------+------+
  | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
  +------------+-------+-------+-------+-------+------+------+
  | A1         | -0.30 | -0.29 | -0.38 | -0.30 |  100 |  100 |
  | A2         | -0.17 |  0.07 |  0.31 | -0.15 |  101 |  100 |
  | Avg w/o B2 | -0.21 | -0.04 |  0.11 | -0.19 |  100 |  100 |
  +------------+-------+-------+-------+-------+------+------+
```

STATS_CHANGED