### PR TITLE
Promote the uneven-4-way partition disable to speed 1

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -132,6 +132,8 @@ static int frame_is_boosted(const AV2_COMP *cpi) {
 static void set_good_speed_feature_framesize_dependent(
     const AV2_COMP *const cpi, SPEED_FEATURES *const sf, int speed) {
   const AV2_COMMON *const cm = &cpi->common;
+  const int is_270p_or_lesser =
+      AVMMIN(cpi->common.width, cpi->common.height) <= 270;
   const int is_480p_or_larger = AVMMIN(cm->width, cm->height) >= 480;
   const int is_720p_or_larger = AVMMIN(cm->width, cm->height) >= 720;
   const int is_1080p_or_larger = AVMMIN(cm->width, cm->height) >= 1080;
@@ -182,6 +184,9 @@ static void set_good_speed_feature_framesize_dependent(
   if (speed >= 1) {
     if (!is_4k_or_larger) {
       sf->mv_sf.prune_mesh_search = 1;
+    }
+    if (!is_270p_or_lesser) {
+      sf->part_sf.disable_uneven_4way_partitions = true;
     }
   }
 


### PR DESCRIPTION
The speed feature was enabled at speed 2.
It turns out that its performance at speeed 1 is also good.

On speed 1, RA, the tradeoff is:

Testset 	           PSNR-Y  PSNR-U  PSNR-V  PSNR-YUV  EncTime 	Ratio
A1 (17 frames)    0.02%      0.30%      -0.05%    0.03%          93.77%    207.7
A2 (33 frames)    0.07%      -0.30%     0.30%     0.06%          93.30%    111.7
A3 (33 frames)    0.16%      0.07%      -0.47%    0.14%          89.52%     74.9
A4 (33 frames)    0.08%     -1.66%     -2.73%    -0.09%          89.29%     -----
A5 (33 frames)    0.47%     -0.88%     -0.75%    0.32%           85.27%     46.0

The speed feature is disabled for resolutions <= 270p.

STATS_CHANGED
