### PR TITLE
Add AVX-512 enablement layer

### DIFF
--- a/av2/av2.cmake
+++ b/av2/av2.cmake
@@ -395,6 +395,8 @@ list(
 list(APPEND AVM_AV2_COMMON_INTRIN_AVX2
      "${AVM_ROOT}/av2/common/gdf_block_avx2.c")
 
+list(APPEND AVM_AV2_COMMON_INTRIN_AVX512)
+
 list(APPEND AVM_AV2_ENCODER_ASM_SSE2 "${AVM_ROOT}/av2/encoder/x86/dct_sse2.asm")
 
 list(
@@ -430,6 +432,8 @@ list(
   "${AVM_ROOT}/av2/encoder/x86/intra_mode_mlp_avx2.c"
   "${AVM_ROOT}/av2/encoder/x86/rdopt_avx2.c"
   "${AVM_ROOT}/av2/encoder/x86/pickrst_avx2.c")
+
+list(APPEND AVM_AV2_ENCODER_INTRIN_AVX512)
 
 list(
   APPEND
@@ -579,6 +583,30 @@ function(setup_av2_targets)
     if(CONFIG_AV2_ENCODER)
       add_intrinsics_object_library("-mavx2" "avx2" "avm_av2_encoder"
                                     "AVM_AV2_ENCODER_INTRIN_AVX2")
+    endif()
+  endif()
+
+  if(HAVE_AVX512)
+    set(AVM_AVX512_FLAG "-mavx512f -mavx512dq -mavx512bw -mavx512vl")
+    # Only probe/require the AVX-512 flags once there are sources to build.
+    if(AVM_AV2_COMMON_INTRIN_AVX512 OR (CONFIG_AV2_ENCODER
+                                        AND AVM_AV2_ENCODER_INTRIN_AVX512))
+      require_compiler_flag_nomsvc("-mavx512f" NO)
+      require_compiler_flag_nomsvc("-mavx512dq" NO)
+      require_compiler_flag_nomsvc("-mavx512bw" NO)
+      require_compiler_flag_nomsvc("-mavx512vl" NO)
+    endif()
+
+    if(AVM_AV2_COMMON_INTRIN_AVX512)
+      add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512"
+                                    "avm_av2_common"
+                                    "AVM_AV2_COMMON_INTRIN_AVX512")
+    endif()
+
+    if(CONFIG_AV2_ENCODER AND AVM_AV2_ENCODER_INTRIN_AVX512)
+      add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512"
+                                    "avm_av2_encoder"
+                                    "AVM_AV2_ENCODER_INTRIN_AVX512")
     endif()
   endif()
 

--- a/av2/av2.cmake
+++ b/av2/av2.cmake
@@ -598,15 +598,15 @@ function(setup_av2_targets)
     endif()
 
     if(AVM_AV2_COMMON_INTRIN_AVX512)
-      add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512"
-                                    "avm_av2_common"
-                                    "AVM_AV2_COMMON_INTRIN_AVX512")
+      add_intrinsics_object_library(
+        "${AVM_AVX512_FLAG}" "avx512" "avm_av2_common"
+        "AVM_AV2_COMMON_INTRIN_AVX512")
     endif()
 
     if(CONFIG_AV2_ENCODER AND AVM_AV2_ENCODER_INTRIN_AVX512)
-      add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512"
-                                    "avm_av2_encoder"
-                                    "AVM_AV2_ENCODER_INTRIN_AVX512")
+      add_intrinsics_object_library(
+        "${AVM_AVX512_FLAG}" "avx512" "avm_av2_encoder"
+        "AVM_AV2_ENCODER_INTRIN_AVX512")
     endif()
   endif()
 

--- a/avm_dsp/avm_dsp.cmake
+++ b/avm_dsp/avm_dsp.cmake
@@ -390,17 +390,18 @@ function(setup_avm_dsp_targets)
 
   if(HAVE_AVX512)
     set(AVM_AVX512_FLAG "-mavx512f -mavx512dq -mavx512bw -mavx512vl")
-    add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512" "avm_dsp_common"
-                                  "AVM_DSP_COMMON_INTRIN_AVX512")
+    add_intrinsics_object_library(
+      "${AVM_AVX512_FLAG}" "avx512" "avm_dsp_common"
+      "AVM_DSP_COMMON_INTRIN_AVX512")
     if(CONFIG_AV2_DECODER)
-      add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512"
-                                    "avm_dsp_decoder"
-                                    "AVM_DSP_DECODER_INTRIN_AVX512")
+      add_intrinsics_object_library(
+        "${AVM_AVX512_FLAG}" "avx512" "avm_dsp_decoder"
+        "AVM_DSP_DECODER_INTRIN_AVX512")
     endif()
     if(CONFIG_AV2_ENCODER)
-      add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512"
-                                    "avm_dsp_encoder"
-                                    "AVM_DSP_ENCODER_INTRIN_AVX512")
+      add_intrinsics_object_library(
+        "${AVM_AVX512_FLAG}" "avx512" "avm_dsp_encoder"
+        "AVM_DSP_ENCODER_INTRIN_AVX512")
     endif()
   endif()
 

--- a/avm_dsp/avm_dsp.cmake
+++ b/avm_dsp/avm_dsp.cmake
@@ -388,6 +388,22 @@ function(setup_avm_dsp_targets)
     endif()
   endif()
 
+  if(HAVE_AVX512)
+    set(AVM_AVX512_FLAG "-mavx512f -mavx512dq -mavx512bw -mavx512vl")
+    add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512" "avm_dsp_common"
+                                  "AVM_DSP_COMMON_INTRIN_AVX512")
+    if(CONFIG_AV2_DECODER)
+      add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512"
+                                    "avm_dsp_decoder"
+                                    "AVM_DSP_DECODER_INTRIN_AVX512")
+    endif()
+    if(CONFIG_AV2_ENCODER)
+      add_intrinsics_object_library("${AVM_AVX512_FLAG}" "avx512"
+                                    "avm_dsp_encoder"
+                                    "AVM_DSP_ENCODER_INTRIN_AVX512")
+    endif()
+  endif()
+
   if(HAVE_NEON)
     add_intrinsics_object_library("${AVM_NEON_INTRIN_FLAG}" "neon"
                                   "avm_dsp_common" "AVM_DSP_COMMON_INTRIN_NEON")

--- a/avm_ports/x86.h
+++ b/avm_ports/x86.h
@@ -164,8 +164,10 @@ static INLINE uint64_t xgetbv(void) {
 #define HAS_AVX 0x40
 #define HAS_AVX2 0x80
 #define HAS_SSE4_2 0x100
+#define HAS_AVX512 0x200
+#define HAS_AVX512_VNNI 0x400
 #ifndef BIT
-#define BIT(n) (1 << n)
+#define BIT(n) (1u << (n))
 #endif
 
 static INLINE int x86_simd_caps(void) {
@@ -215,6 +217,16 @@ static INLINE int x86_simd_caps(void) {
         cpuid(7, 0, reg_eax, reg_ebx, reg_ecx, reg_edx);
 
         if (reg_ebx & BIT(5)) flags |= HAS_AVX2;
+
+        /* AVX-512 needs OS opmask/ZMM state saved: XCR0 bits 1,2,5,6,7. */
+        if ((xgetbv() & 0xe6) == 0xe6) {
+          const unsigned int avx512_mask =
+              BIT(16) | BIT(17) | BIT(30) | BIT(31);
+          if ((reg_ebx & avx512_mask) == avx512_mask) {
+            flags |= HAS_AVX512;
+            if (reg_ecx & BIT(11)) flags |= HAS_AVX512_VNNI;
+          }
+        }
       }
     }
   }

--- a/cmake/avm_config_defaults.cmake
+++ b/cmake/avm_config_defaults.cmake
@@ -45,6 +45,8 @@ set_avm_detect_var(HAVE_VSX 0 "Enables VSX optimizations.")
 # x86 / x86_64 feature flags.
 set_avm_detect_var(HAVE_AVX 0 "Enables AVX optimizations.")
 set_avm_detect_var(HAVE_AVX2 0 "Enables AVX2 optimizations.")
+set_avm_detect_var(HAVE_AVX512 0
+                   "Enables AVX-512 (F/DQ/BW/VL) optimizations.")
 set_avm_detect_var(HAVE_MMX 0 "Enables MMX optimizations. ")
 set_avm_detect_var(HAVE_SSE 0 "Enables SSE optimizations.")
 set_avm_detect_var(HAVE_SSE2 0 "Enables SSE2 optimizations.")
@@ -207,3 +209,5 @@ set_avm_option_var(ENABLE_AVX
                    "Enables AVX optimizations on x86/x86_64 targets." ON)
 set_avm_option_var(ENABLE_AVX2
                    "Enables AVX2 optimizations on x86/x86_64 targets." ON)
+set_avm_option_var(ENABLE_AVX512
+                   "Enables AVX-512 optimizations on x86_64 targets." ON)

--- a/cmake/avm_config_defaults.cmake
+++ b/cmake/avm_config_defaults.cmake
@@ -45,8 +45,7 @@ set_avm_detect_var(HAVE_VSX 0 "Enables VSX optimizations.")
 # x86 / x86_64 feature flags.
 set_avm_detect_var(HAVE_AVX 0 "Enables AVX optimizations.")
 set_avm_detect_var(HAVE_AVX2 0 "Enables AVX2 optimizations.")
-set_avm_detect_var(HAVE_AVX512 0
-                   "Enables AVX-512 (F/DQ/BW/VL) optimizations.")
+set_avm_detect_var(HAVE_AVX512 0 "Enables AVX-512 (F/DQ/BW/VL) optimizations.")
 set_avm_detect_var(HAVE_MMX 0 "Enables MMX optimizations. ")
 set_avm_detect_var(HAVE_SSE 0 "Enables SSE optimizations.")
 set_avm_detect_var(HAVE_SSE2 0 "Enables SSE2 optimizations.")

--- a/cmake/avm_configure.cmake
+++ b/cmake/avm_configure.cmake
@@ -355,6 +355,23 @@ else()
   add_compiler_flag_if_supported("-D_FILE_OFFSET_BITS=64")
 endif()
 
+# Optional whole-program micro-architecture target (measurement knob).
+set(AVM_TARGET_MARCH
+    ""
+    CACHE STRING "Whole-program -march=<value> target (e.g. znver5). Empty=off.")
+if(NOT "${AVM_TARGET_MARCH}" STREQUAL "")
+  if(MSVC)
+    message(
+      WARNING
+        "AVM_TARGET_MARCH=${AVM_TARGET_MARCH} ignored: use /arch: flags on MSVC."
+    )
+  else()
+    message(
+      "--- avm_configure: whole-program target: -march=${AVM_TARGET_MARCH}")
+    require_compiler_flag_nomsvc("-march=${AVM_TARGET_MARCH}" YES)
+  endif()
+endif()
+
 set(AVM_LIB_LINK_TYPE PUBLIC)
 if(EMSCRIPTEN)
 

--- a/cmake/avm_configure.cmake
+++ b/cmake/avm_configure.cmake
@@ -358,7 +358,8 @@ endif()
 # Optional whole-program micro-architecture target (measurement knob).
 set(AVM_TARGET_MARCH
     ""
-    CACHE STRING "Whole-program -march=<value> target (e.g. znver5). Empty=off.")
+    CACHE STRING
+          "Whole-program -march=<value> target (e.g. znver5). Empty=off.")
 if(NOT "${AVM_TARGET_MARCH}" STREQUAL "")
   if(MSVC)
     message(

--- a/cmake/avm_optimization.cmake
+++ b/cmake/avm_optimization.cmake
@@ -26,9 +26,13 @@ function(get_msvc_intrinsic_flag flag translated_flag)
     set(${translated_flag}
         "/arch:AVX2"
         PARENT_SCOPE)
+  elseif("${flag}" MATCHES "avx512")
+    set(${translated_flag}
+        "/arch:AVX512"
+        PARENT_SCOPE)
   else()
 
-    # MSVC does not need flags for intrinsics flavors other than AVX/AVX2.
+    # MSVC does not need flags for intrinsics flavors other than AVX/AVX2/AVX512.
     unset(${translated_flag} PARENT_SCOPE)
   endif()
 endfunction()

--- a/cmake/avm_optimization.cmake
+++ b/cmake/avm_optimization.cmake
@@ -32,7 +32,8 @@ function(get_msvc_intrinsic_flag flag translated_flag)
         PARENT_SCOPE)
   else()
 
-    # MSVC does not need flags for intrinsics flavors other than AVX/AVX2/AVX512.
+    # MSVC does not need flags for intrinsics flavors other than
+    # AVX/AVX2/AVX512.
     unset(${translated_flag} PARENT_SCOPE)
   endif()
 endfunction()

--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -130,6 +130,13 @@ elseif("${AVM_TARGET_CPU}" MATCHES "^x86")
   endif()
 
   set(X86_FLAVORS "MMX;SSE;SSE2;SSE3;SSSE3;SSE4_1;SSE4_2;AVX;AVX2")
+  # AVX-512 is x86_64 only; append after AVX2 to inherit the disable cascade.
+  if("${AVM_TARGET_CPU}" STREQUAL "x86_64")
+    list(APPEND X86_FLAVORS "AVX512")
+  else()
+    set(HAVE_AVX512 0)
+    set(AVM_RTCD_FLAGS ${AVM_RTCD_FLAGS} --disable-avx512)
+  endif()
   foreach(flavor ${X86_FLAVORS})
     if(ENABLE_${flavor} AND NOT disable_remaining_flavors)
       set(HAVE_${flavor} 1)

--- a/cmake/rtcd.pl
+++ b/cmake/rtcd.pl
@@ -409,7 +409,7 @@ EOF
 # List of architectures in low-to-high preference order.
 my @PRIORITY_ARCH = qw/
   c
-  mmx sse sse2 sse3 ssse3 sse4_1 sse4_2 avx avx2
+  mmx sse sse2 sse3 ssse3 sse4_1 sse4_2 avx avx2 avx512
   arm_crc32 neon neon_dotprod neon_i8mm sve sve2
   rvv
   vsx
@@ -430,7 +430,8 @@ if ($opts{arch} eq 'x86') {
   @ALL_ARCHS = filter(qw/mmx sse sse2 sse3 ssse3 sse4_1 sse4_2 avx avx2/);
   x86;
 } elsif ($opts{arch} eq 'x86_64') {
-  @ALL_ARCHS = filter(qw/mmx sse sse2 sse3 ssse3 sse4_1 sse4_2 avx avx2/);
+  @ALL_ARCHS =
+    filter(qw/mmx sse sse2 sse3 ssse3 sse4_1 sse4_2 avx avx2 avx512/);
   if (keys %required == 0) {
     @REQUIRES = filter(qw/mmx sse sse2/);
     &require(@REQUIRES);

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -398,6 +398,11 @@ function(setup_avm_test_targets)
     add_intrinsics_source_to_target("-mavx2" "test_libavm"
                                     "AVM_UNIT_TEST_COMMON_INTRIN_AVX2")
   endif()
+  if(HAVE_AVX512 AND AVM_UNIT_TEST_COMMON_INTRIN_AVX512)
+    add_intrinsics_source_to_target(
+      "-mavx512f -mavx512dq -mavx512bw -mavx512vl" "test_libavm"
+      "AVM_UNIT_TEST_COMMON_INTRIN_AVX512")
+  endif()
   if(HAVE_NEON)
     add_intrinsics_source_to_target("${AVM_NEON_INTRIN_FLAG}" "test_libavm"
                                     "AVM_UNIT_TEST_COMMON_INTRIN_NEON")

--- a/test/test_libavm.cc
+++ b/test/test_libavm.cc
@@ -61,6 +61,7 @@ int main(int argc, char **argv) {
   if (!(simd_caps & HAS_SSE4_2)) append_negative_gtest_filter("SSE4_2");
   if (!(simd_caps & HAS_AVX)) append_negative_gtest_filter("AVX");
   if (!(simd_caps & HAS_AVX2)) append_negative_gtest_filter("AVX2");
+  if (!(simd_caps & HAS_AVX512)) append_negative_gtest_filter("AVX512");
 #endif  // ARCH_X86 || ARCH_X86_64
 
 // Shared library builds don't support whitebox tests that exercise internal


### PR DESCRIPTION
Adds the build-system, RTCD, and runtime-dispatch plumbing to host AVX-512 kernels in libavm. Infrastructure only — no kernels are added and nothing is `specialize`d to `avx512`, so this is a runtime no-op till follow-up kernel PRs land.

Includes: runtime detection in `x86.h` (XGETBV opmask/ZMM state + CPUID F/DQ/BW/VL), RTCD `avx512` arch (x86_64 only), CMake object-library hooks and MSVC `/arch:AVX512` mapping, `HAVE_AVX512`/`ENABLE_AVX512` (default ON, inherits the disable cascade), and a gtest CPU gate.

Reversible via `-DENABLE_AVX512=OFF`.