### PR TITLE
Add early termination in warp delta refinement

### DIFF
--- a/av2/encoder/mcomp.c
+++ b/av2/encoder/mcomp.c
@@ -5202,13 +5202,11 @@ static AVM_INLINE void search_warp_delta_params(
 // search functions, due to the way that it alternates MV and warp parameter
 // refinement. Need to revisit this function in phase 2 and revisit whether
 // there is a good way to do something similar.
-int av2_pick_warp_delta(const AV2_COMMON *const cm, MACROBLOCKD *xd,
-                        MB_MODE_INFO *mbmi,
-                        const SUBPEL_MOTION_SEARCH_PARAMS *ms_params,
-                        const ModeCosts *mode_costs,
-                        warp_mode_info_array *prev_best_models,
-                        WARP_CANDIDATE *warp_param_stack,
-                        const int fast_decoupled_search) {
+int av2_pick_warp_delta(
+    const AV2_COMMON *const cm, MACROBLOCKD *xd, MB_MODE_INFO *mbmi,
+    const SUBPEL_MOTION_SEARCH_PARAMS *ms_params, const ModeCosts *mode_costs,
+    warp_mode_info_array *prev_best_models, WARP_CANDIDATE *warp_param_stack,
+    const int fast_decoupled_search, bool early_term_warp_delta_refine) {
   WarpedMotionParams *params = &mbmi->wm_params[0];
   const BLOCK_SIZE bsize = mbmi->sb_type[PLANE_TYPE_Y];
   int mi_row = xd->mi_row;
@@ -5356,6 +5354,7 @@ int av2_pick_warp_delta(const AV2_COMMON *const cm, MACROBLOCKD *xd,
   // Refine model, by making a few passes through the available
   // parameters and trying to increase/decrease them
   if (!fast_decoupled_search) {
+    uint64_t best_rd_prev = best_rd;
     for (int iter = 0; iter < number_of_iterations; iter++) {
       int center_best_so_far = 1;
 
@@ -5459,9 +5458,15 @@ int av2_pick_warp_delta(const AV2_COMMON *const cm, MACROBLOCKD *xd,
         }
       }
 
-      if (center_best_so_far) {
+      const int early_terminate_refine =
+          center_best_so_far ||
+          (early_term_warp_delta_refine && best_rd > 0.95 * best_rd_prev);
+
+      if (early_terminate_refine) {
         break;
       }
+
+      best_rd_prev = best_rd;
     }
   } else {
     search_warp_translational_params(

--- a/av2/encoder/mcomp.h
+++ b/av2/encoder/mcomp.h
@@ -571,13 +571,11 @@ uint8_t need_mv_adjustment(MACROBLOCKD *xd, const AV2_COMMON *const cm,
                            int *num_nonzero_mvd);
 
 // Returns 1 if able to select a good model, 0 if not
-int av2_pick_warp_delta(const AV2_COMMON *const cm, MACROBLOCKD *xd,
-                        MB_MODE_INFO *mbmi,
-                        const SUBPEL_MOTION_SEARCH_PARAMS *ms_params,
-                        const ModeCosts *mode_costs,
-                        warp_mode_info_array *prev_best_models,
-                        WARP_CANDIDATE *warp_param_stack,
-                        const int fast_decoupled_search);
+int av2_pick_warp_delta(
+    const AV2_COMMON *const cm, MACROBLOCKD *xd, MB_MODE_INFO *mbmi,
+    const SUBPEL_MOTION_SEARCH_PARAMS *ms_params, const ModeCosts *mode_costs,
+    warp_mode_info_array *prev_best_models, WARP_CANDIDATE *warp_param_stack,
+    const int fast_decoupled_search, bool early_term_warp_delta_refine);
 
 int av2_refine_mv_for_base_param_warp_model(
     const AV2_COMMON *const cm, MACROBLOCKD *xd, MB_MODE_INFO *mbmi,

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -2654,7 +2654,8 @@ static AVM_INLINE int handle_warp_delta_mode(
       valid = av2_pick_warp_delta(
           cm, xd, mbmi, &ms_params, &x->mode_costs, prev_best_models,
           mbmi_ext->warp_param_stack[av2_ref_frame_type(mbmi->ref_frame)],
-          cpi->sf.inter_sf.fast_warp_delta_decoupled_search);
+          cpi->sf.inter_sf.fast_warp_delta_decoupled_search,
+          cpi->sf.inter_sf.early_term_warp_delta_refine);
     }
   }
 

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -378,6 +378,7 @@ static void set_good_speed_features_framesize_independent(
     sf->intra_sf.intra_mode_prune_top = 4;
     sf->inter_sf.prune_comp_mode_eval_using_est_rd = true;
     sf->inter_sf.prune_warp_newmv_ref_mv_idx = true;
+    sf->inter_sf.early_term_warp_delta_refine = true;
 
     sf->intra_sf.include_dip_for_top_n_model_rd_pruning = true;
 
@@ -874,6 +875,7 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->enable_six_param_warp_in_winner_mode = 0;
   inter_sf->enable_six_param_warp_in_winner_mode_by_tid = 0;
   inter_sf->fast_warp_delta_decoupled_search = 0;
+  inter_sf->early_term_warp_delta_refine = false;
   inter_sf->comp_inter_joint_search_thresh = BLOCK_4X4;
   inter_sf->adaptive_rd_thresh = 0;
   inter_sf->model_based_post_interp_filter_breakout = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -621,6 +621,9 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // Enable fast warp delta search for 4 param and 6 param models
   int fast_warp_delta_decoupled_search;
 
+  // Early terminate warp delta refinement when RD cost improvements diminish.
+  bool early_term_warp_delta_refine;
+
   // When 1, prune single-ref NEWMV / WARP_NEWMV for a given ref frame
   // when the best RD seen so far for that ref (taken from a prior mode
   // such as NEARMV, NEWMV[amvd=0], or WARPMV) is far from the best RD


### PR DESCRIPTION
Added a speed feature to early terminate the warp
delta refinement loop if the rate-distortion cost
improvement in a pass drops below 5%.

Results for RA CTC, A1 17 frames, A2 33 frames,
speed 1: (Anchor: 7c9dfbaa287ab6df4613f746bbab4b410853fced)

```
+-----+-------+-------+-------+-------+---------------+
|Class|   Y   |   Cb  |   Cr  | wAvg  |EncInstCount(%)|
+-----+-------+-------+-------+-------+---------------+
| A2  |-0.0004|-0.0367|-0.2123|-0.0103| 98.93         |
| A1  |-0.0649| 0.1274| 0.0844|-0.0513| 98.89         |
+-----+-------+-------+-------+-------+---------------+
```
STATS_CHANGED for speed >= 1