### PR TITLE
Do not enable simple_motion_search_prune_rect

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -296,7 +296,9 @@ static void set_good_speed_features_framesize_independent(
   sf->gm_sf.disable_gm_search_based_on_stats = 1;
 
   sf->part_sf.less_rectangular_check_level = 1;
-  sf->part_sf.simple_motion_search_prune_rect = 1;
+  // This speed feature is currently not implemented. See comment in
+  // av2_simple_motion_search_prune_rect() function.
+  sf->part_sf.simple_motion_search_prune_rect = 0;
 
   sf->inter_sf.disable_wedge_search_var_thresh = 0;
   // TODO(debargha): Test, tweak and turn on either 1 or 2


### PR DESCRIPTION
av2_simple_motion_search_prune_rect() is not implemented for the AV2 partition set and asserts "Not implemented" since e2d056635. With --disable-ml-partition-speed-features=0 the speed feature turned on, the assert was compiled out under NDEBUG, and the encoder segfaulted: av2_prune_partitions_before_search() calls the function for rectangular block sizes, where convert_bsize_to_idx() returns -1 and sms_tree is NULL because fill_sms_buf() only populates square sizes.

This fixes #5310.