### PR TITLE
Skip pixel-domain distortion using tx-domain RD estimate

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -383,6 +383,7 @@ static void set_good_speed_features_framesize_independent(
     sf->intra_sf.include_dip_for_top_n_model_rd_pruning = true;
 
     sf->tx_sf.adaptive_tx_type_search_idx = 4;
+    sf->tx_sf.skip_pixel_dist_calc_using_tx_dist = true;
     sf->tx_sf.adaptive_tx_partition_type_search_idx = 4;
     sf->tx_sf.enable_adaptive_tx_search_level = true;
 
@@ -971,6 +972,7 @@ static AVM_INLINE void init_tx_sf(TX_SPEED_FEATURES *tx_sf) {
   tx_sf->tx_type_search.prune_tx_type_est_rd = 0;
   tx_sf->tx_type_search.winner_mode_tx_type_pruning = 0;
   tx_sf->txb_split_cap = 1;
+  tx_sf->skip_pixel_dist_calc_using_tx_dist = false;
   tx_sf->adaptive_tx_type_search_idx = 0;
   tx_sf->adaptive_tx_partition_type_search_idx = 0;
   tx_sf->use_inter_txb_hash = 1;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -958,6 +958,13 @@ typedef struct TX_SPEED_FEATURES {
 
   // Enable txfm partition search
   bool enable_tx_partition;
+
+  // Skip the full pixel-domain distortion calculation for a tx candidate when
+  // a lightweight transform-domain RD estimate is already worse than best_rd
+  // and ref_best_rd. Avoids the more expensive pixel-domain reconstruction path
+  // for candidates that are unlikely to improve the best RD.
+  bool skip_pixel_dist_calc_using_tx_dist;
+
   // Enable adaptive tx search level
   bool enable_adaptive_tx_search_level;
   // Enable adaptive TCQ threshold:

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -2309,6 +2309,50 @@ static AVM_INLINE RD_STATS get_tx_blk_distortion(
   return this_rd_stats;
 }
 
+// Lightweight pre-distortion RD gate used inside search_tx_type's inner loop.
+// Computes an approximate RD cost using transform-domain distortion and returns
+// true when the candidate should be skipped (pruned).
+static INLINE bool prune_tx_type_rd_calc_using_tx_domain_dist(
+    MACROBLOCK *x, const uint16_t *eobs_ptr, int64_t block_sse,
+    int64_t sec_tx_sse_to_be_coded, int64_t best_rd, int64_t ref_best_rd,
+    int plane, int block, int stx, int rate_cost,
+    int use_transform_domain_distortion, TX_SIZE tx_size,
+    bool skip_pixel_dist_calc_using_tx_dist) {
+  if (!skip_pixel_dist_calc_using_tx_dist || eobs_ptr[block] == 0 ||
+      best_rd == INT64_MAX || use_transform_domain_distortion)
+    return false;
+
+  // sec_tx_sse_to_be_coded is the residual SSE after the forward
+  // secondary transform, set by the prune_tx_rd_eval_sec_tx_sse filter earlier
+  // in the loop. When available, block_sse - sec_tx_sse_to_be_coded is the
+  // minimum distortion. If even this optimistic estimate exceeds best_rd or
+  // ref_best_rd, there is no need to run the more expensive
+  // dist_block_tx_domain() call below.
+  if (sec_tx_sse_to_be_coded != INT64_MAX) {
+    int64_t tmp_rd = RDCOST(x->rdmult, rate_cost,
+                            AVMMAX((block_sse - sec_tx_sse_to_be_coded), 0));
+    if (tmp_rd > AVMMIN(best_rd, ref_best_rd)) return true;
+  }
+
+  // Compute the tx-domain distortion. For 64x64 blocks or when a secondary
+  // transform (stx) is applied, the coded coefficients cover only part of the
+  // transform domain, so the residual energy (block_sse - coded_sse) is added
+  // as a correction. Prune if the resulting RD exceeds the threshold.
+  RD_STATS this_rd_stats;
+  dist_block_tx_domain(x, plane, block, tx_size, &this_rd_stats.dist,
+                       &this_rd_stats.sse);
+  int64_t tx_domain_dist;
+  if (stx != 0 || txsize_sqr_up_map[tx_size] == TX_64X64)
+    tx_domain_dist =
+        this_rd_stats.dist + AVMMAX((block_sse - this_rd_stats.sse), 0);
+  else
+    tx_domain_dist = this_rd_stats.dist;
+  const int64_t tx_domain_rd = RDCOST(x->rdmult, rate_cost, tx_domain_dist);
+  if (tx_domain_rd > AVMMIN(best_rd, ref_best_rd)) return true;
+
+  return false;
+}
+
 // Search for the best transform type for a given transform block.
 // This function can be used for both inter and intra, both luma and chroma.
 static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
@@ -2658,6 +2702,13 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
         // terminate early.
         if (RDCOST(x->rdmult, rate_cost, 0) > best_rd) continue;
 
+        if (prune_tx_type_rd_calc_using_tx_domain_dist(
+                x, eobs_ptr, block_sse, sec_tx_sse_to_be_coded, best_rd,
+                ref_best_rd, plane, block, stx, rate_cost,
+                use_transform_domain_distortion, tx_size,
+                tx_sf->skip_pixel_dist_calc_using_tx_dist)) {
+          continue;
+        }
         RD_STATS this_rd_stats = get_tx_blk_distortion(
             cpi, x, plane, block, blk_row, blk_col, tx_size, block_sse,
             eobs_ptr[block], dc_only_blk, fsc_mode_in,


### PR DESCRIPTION
  The expensive pixel-domain distortion path in search_tx_type()
  is skipped if the lightweight transform-domain RD estimate
  already exceeds best_rd or ref_best_rd. This is controlled by
  a new speed feature flag skip_pixel_dist_calc_using_tx_dist,
  enabled for speed >= 1.

  STATS_CHANGED for speed >= 1

 
  Test results (RA) for Speed 1
  Anchor: commit 5d628d8
  A1 - 17 frames
  A2 - 33 frames
    
  ```
  +------------+-------+-------+-------+-------+-------------+
  | Class      |     Y |    Cb |    Cr |  YUV  |EncInstCount%|
  +------------+-------+-------+-------+-------+-------------+
  | A1         | -0.03 |  0.43 | -0.06 |  0.00 |    95.84    |
  | A2         |  0.04 |  0.46 | -0.15 |  0.05 |    97.35    |
  +------------+-------+-------+-------+-------+-------------+
  ```