### PR TITLE
Optimize SSE2 temporal-filter invariant calculations

### DIFF
--- a/av2/encoder/temporal_filter.c
+++ b/av2/encoder/temporal_filter.c
@@ -1008,7 +1008,7 @@ static FRAME_DIFF tf_do_filtering(AV2_COMP *cpi, YV12_BUFFER_CONFIG **frames,
           // only supports 32x32 block size, 5x5 filtering window, 8-bit
           // encoding, and the case when the video is not with `YUV 4:2:2`
           // format.
-          if (!is_yuv422_format && TF_BLOCK_SIZE == BLOCK_32X32 &&
+          if (!is_yuv422_format && TF_BLOCK_SIZE == BLOCK_64X64 &&
               TF_WINDOW_LENGTH == 5) {
             av2_highbd_apply_temporal_filter(
                 frame_to_filter, mbd, block_size, mb_row, mb_col, num_planes,

--- a/av2/encoder/temporal_filter.h
+++ b/av2/encoder/temporal_filter.h
@@ -21,8 +21,8 @@ extern "C" {
 // TODO(any): These two variables are only used in avx2, sse2, sse4
 // implementations, where the block size is still hard coded. This should be
 // fixed to align with the c implementation.
-#define BH 32
-#define BW 32
+#define BH 64
+#define BW 64
 
 // Block size used in temporal filtering.
 #define TF_BLOCK_SIZE BLOCK_64X64

--- a/av2/encoder/x86/highbd_temporal_filter_sse2.c
+++ b/av2/encoder/x86/highbd_temporal_filter_sse2.c
@@ -93,16 +93,17 @@ static int32_t xx_mask_and_hadd(__m128i vsum1, __m128i vsum2, int i) {
 static void highbd_apply_temporal_filter(
     const uint16_t *frame1, const unsigned int stride, const uint16_t *frame2,
     const unsigned int stride2, const int block_width, const int block_height,
-    const int min_frame_size, const double sigma, const MV *subblock_mvs,
-    const int *subblock_mses, const int q_factor, const int filter_strength,
-    unsigned int *accumulator, uint16_t *count, uint32_t *luma_sq_error,
-    uint32_t *chroma_sq_error, int plane, int ss_x_shift, int ss_y_shift,
-    int bd) {
-  assert(((block_width == 32) && (block_height == 32)) ||
-         ((block_width == 16) && (block_height == 16)));
+    const double inv_factor, const double weight_factor,
+    const double decay_factor, const double *d_factor,
+    const double *block_error, unsigned int *accumulator, uint16_t *count,
+    uint32_t *luma_sq_error, uint32_t *chroma_sq_error, int plane,
+    int ss_x_shift, int ss_y_shift, int bd) {
+  assert(block_width <= BW && block_height <= BH);
+  assert((block_width % 4) == 0);
+  assert(block_width >= 8 && block_height >= 8);
   if (plane > PLANE_TYPE_Y) assert(chroma_sq_error != NULL);
 
-  uint32_t acc_5x5_sse[BH][BW];
+  uint32_t acc_5x5_sse[BH][BW] = { 0 };
   uint32_t *frame_sse =
       (plane == PLANE_TYPE_Y) ? luma_sq_error : chroma_sq_error;
 
@@ -110,12 +111,6 @@ static void highbd_apply_temporal_filter(
                     frame_sse, SSE_STRIDE);
 
   __m128i vsrc[5][2];
-
-  const double n_decay = 0.5 + log(2 * sigma + 5.0);
-  const double q_decay =
-      CLIP(pow((double)q_factor / TF_Q_DECAY_THRESHOLD, 2), 1e-5, 1);
-  const double s_decay =
-      CLIP(pow((double)filter_strength / TF_STRENGTH_THRESHOLD, 2), 1e-5, 1);
 
   // Traverse 4 columns at a time
   // First and last columns will require padding
@@ -216,21 +211,16 @@ static void highbd_apply_temporal_filter(
       diff_sse >>= ((bd - 8) * 2);
 
       const double window_error = (double)(diff_sse) / num_ref_pixels;
-      const int subblock_idx =
-          (i >= block_height / 2) * 2 + (j >= block_width / 2);
-      const double block_error = (double)subblock_mses[subblock_idx];
+      const int y32 = i / (block_height / 2);
+      const int x32 = j / (block_width / 2);
+      const int y16 = (i % (block_height / 2)) / (block_height / 4);
+      const int x16 = (j % (block_width / 2)) / (block_width / 4);
+      const int subblock_idx = (y32 * 2 + x32) * 4 + (y16 * 2 + x16);
       const double combined_error =
-          (TF_WINDOW_BLOCK_BALANCE_WEIGHT * window_error + block_error) /
-          (TF_WINDOW_BLOCK_BALANCE_WEIGHT + 1) / TF_SEARCH_ERROR_NORM_WEIGHT;
-
-      const MV mv = subblock_mvs[subblock_idx];
-      const double distance = sqrt(pow(mv.row, 2) + pow(mv.col, 2));
-      const double distance_threshold =
-          (double)AVMMAX(min_frame_size * TF_SEARCH_DISTANCE_THRESHOLD, 1);
-      const double d_factor = AVMMAX(distance / distance_threshold, 1);
+          weight_factor * window_error + block_error[subblock_idx] * inv_factor;
 
       const double scaled_error =
-          AVMMIN(combined_error * d_factor / n_decay / q_decay / s_decay, 7);
+          AVMMIN(combined_error * d_factor[subblock_idx] * decay_factor, 7);
       const int weight = (int)(exp(-scaled_error) * TF_WEIGHT_SCALE);
 
       count[k] += weight;
@@ -245,8 +235,8 @@ void av2_highbd_apply_temporal_filter_sse2(
     const int num_planes, const double *noise_levels, const MV *subblock_mvs,
     const int *subblock_mses, const int q_factor, const int filter_strength,
     const uint16_t *pred, uint32_t *accum, uint16_t *count) {
-  assert(block_size == BLOCK_32X32 && "Only support 32x32 block with avx2!");
-  assert(TF_WINDOW_LENGTH == 5 && "Only support window length 5 with avx2!");
+  assert(block_size == BLOCK_64X64 && "Only support 64x64 block with sse2!");
+  assert(TF_WINDOW_LENGTH == 5 && "Only support window length 5 with sse2!");
   assert(num_planes >= 1 && num_planes <= MAX_MB_PLANE);
 
   const int mb_height = block_size_high[block_size];
@@ -255,6 +245,33 @@ void av2_highbd_apply_temporal_filter_sse2(
   const int frame_height = frame_to_filter->y_crop_height;
   const int frame_width = frame_to_filter->y_crop_width;
   const int min_frame_size = AVMMIN(frame_height, frame_width);
+
+  const double inv_factor = 1.0 / ((TF_WINDOW_BLOCK_BALANCE_WEIGHT + 1) *
+                                   TF_SEARCH_ERROR_NORM_WEIGHT);
+  const double weight_factor =
+      (double)TF_WINDOW_BLOCK_BALANCE_WEIGHT * inv_factor;
+  const double q_decay =
+      CLIP(pow((double)q_factor / TF_Q_DECAY_THRESHOLD, 2), 1e-5, 1);
+  const double s_decay =
+      CLIP(pow((double)filter_strength / TF_STRENGTH_THRESHOLD, 2), 1e-5, 1);
+
+  double decay_factor[MAX_MB_PLANE];
+  for (int plane = 0; plane < num_planes; ++plane) {
+    const double n_decay = 0.5 + log(2 * noise_levels[plane] + 5.0);
+    decay_factor[plane] = 1.0 / (n_decay * q_decay * s_decay);
+  }
+
+  const double distance_threshold =
+      (double)AVMMAX(min_frame_size * TF_SEARCH_DISTANCE_THRESHOLD, 1);
+  double d_factor[16];
+  double block_error[16];
+  for (int subblock_idx = 0; subblock_idx < 16; ++subblock_idx) {
+    const MV mv = subblock_mvs[subblock_idx];
+    const double distance = sqrt(pow(mv.row, 2) + pow(mv.col, 2));
+    d_factor[subblock_idx] = AVMMAX(distance / distance_threshold, 1);
+    block_error[subblock_idx] = (double)subblock_mses[subblock_idx];
+  }
+
   uint32_t luma_sq_error[SSE_STRIDE * BH];
   uint32_t *chroma_sq_error =
       (num_planes > 0)
@@ -274,10 +291,9 @@ void av2_highbd_apply_temporal_filter_sse2(
 
     highbd_apply_temporal_filter(
         ref, frame_stride, pred + mb_pels * plane, plane_w, plane_w, plane_h,
-        min_frame_size, noise_levels[plane], subblock_mvs, subblock_mses,
-        q_factor, filter_strength, accum + mb_pels * plane,
-        count + mb_pels * plane, luma_sq_error, chroma_sq_error, plane,
-        ss_x_shift, ss_y_shift, mbd->bd);
+        inv_factor, weight_factor, decay_factor[plane], d_factor, block_error,
+        accum + mb_pels * plane, count + mb_pels * plane, luma_sq_error,
+        chroma_sq_error, plane, ss_x_shift, ss_y_shift, mbd->bd);
   }
   if (chroma_sq_error != NULL) avm_free(chroma_sq_error);
 }

--- a/test/temporal_filter_test.cc
+++ b/test/temporal_filter_test.cc
@@ -55,8 +55,10 @@ class HBDTemporalFilterTest
   virtual void SetUp() {
     params_ = GET_PARAM(0);
     rnd_.Reset(ACMRandom::DeterministicSeed());
-    src1_ = reinterpret_cast<uint16_t *>(avm_memalign(16, 256 * 256));
-    src2_ = reinterpret_cast<uint16_t *>(avm_memalign(16, 256 * 256));
+    src1_ = reinterpret_cast<uint16_t *>(
+        avm_memalign(16, 256 * 256 * sizeof(uint16_t)));
+    src2_ = reinterpret_cast<uint16_t *>(
+        avm_memalign(16, 256 * 256 * sizeof(uint16_t)));
 
     ASSERT_TRUE(src1_ != NULL);
     ASSERT_TRUE(src2_ != NULL);
@@ -69,40 +71,20 @@ class HBDTemporalFilterTest
   }
   void RunTest(int isRandom, int width, int height, int run_times, int bd);
 
-  void GenRandomData(int width, int height, int stride, int stride2, int bd) {
-    if (bd == 10) {
-      for (int ii = 0; ii < height; ii++) {
-        for (int jj = 0; jj < width; jj++) {
-          src1_[ii * stride + jj] = rnd_.Rand16() & 0x3FF;
-          src2_[ii * stride2 + jj] = rnd_.Rand16() & 0x3FF;
-        }
-      }
-    } else {
-      for (int ii = 0; ii < height; ii++) {
-        for (int jj = 0; jj < width; jj++) {
-          src1_[ii * stride + jj] = rnd_.Rand16() & 0xFFF;
-          src2_[ii * stride2 + jj] = rnd_.Rand16() & 0xFFF;
-        }
-      }
+  void GenRandomData(int num_samples, int bd) {
+    const uint16_t mask = (bd == 10) ? 0x3FF : 0xFFF;
+    for (int ii = 0; ii < num_samples; ii++) {
+      src1_[ii] = rnd_.Rand16() & mask;
+      src2_[ii] = rnd_.Rand16() & mask;
     }
   }
 
-  void GenExtremeData(int width, int height, int stride, uint16_t *data,
-                      int stride2, uint16_t *data2, uint16_t val, int bd) {
-    if (bd == 10) {
-      for (int ii = 0; ii < height; ii++) {
-        for (int jj = 0; jj < width; jj++) {
-          data[ii * stride + jj] = val;
-          data2[ii * stride2 + jj] = (1023 - val);
-        }
-      }
-    } else {
-      for (int ii = 0; ii < height; ii++) {
-        for (int jj = 0; jj < width; jj++) {
-          data[ii * stride + jj] = val;
-          data2[ii * stride2 + jj] = (4095 - val);
-        }
-      }
+  void GenExtremeData(int num_samples, uint16_t *data, uint16_t *data2,
+                      uint16_t val, int bd) {
+    const uint16_t max_val = (bd == 10) ? 1023 : 4095;
+    for (int ii = 0; ii < num_samples; ii++) {
+      data[ii] = val;
+      data2[ii] = (max_val - val);
     }
   }
 
@@ -119,52 +101,67 @@ void HBDTemporalFilterTest::RunTest(int isRandom, int width, int height,
                                     int run_times, int BD) {
   avm_usec_timer ref_timer, test_timer;
   for (int k = 0; k < 3; k++) {
-    const int stride = width;
-    const int stride2 = width;
+    const int total_samples = 4096 * 3;
     if (isRandom) {
-      GenRandomData(width, height, stride, stride2, BD);
+      GenRandomData(total_samples, BD);
     } else {
       const int msb = BD;
       const uint16_t limit = (1 << msb) - 1;
       if (k == 0) {
-        GenExtremeData(width, height, stride, src1_, stride2, src2_, limit, BD);
+        GenExtremeData(total_samples, src1_, src2_, limit, BD);
       } else {
-        GenExtremeData(width, height, stride, src1_, stride2, src2_, 0, BD);
+        GenExtremeData(total_samples, src1_, src2_, 0, BD);
       }
     }
-    double sigma[1] = { 2.1002103677063437 };
-    DECLARE_ALIGNED(16, unsigned int, accumulator_ref[1024 * 3]);
-    DECLARE_ALIGNED(16, uint16_t, count_ref[1024 * 3]);
-    memset(accumulator_ref, 0, 1024 * 3 * sizeof(accumulator_ref[0]));
-    memset(count_ref, 0, 1024 * 3 * sizeof(count_ref[0]));
-    DECLARE_ALIGNED(16, unsigned int, accumulator_mod[1024 * 3]);
-    DECLARE_ALIGNED(16, uint16_t, count_mod[1024 * 3]);
-    memset(accumulator_mod, 0, 1024 * 3 * sizeof(accumulator_mod[0]));
-    memset(count_mod, 0, 1024 * 3 * sizeof(count_mod[0]));
+    double sigma[3] = { 2.1002103677063437, 2.1002103677063437,
+                        2.1002103677063437 };
+    DECLARE_ALIGNED(16, unsigned int, accumulator_ref[4096 * 3]);
+    DECLARE_ALIGNED(16, uint16_t, count_ref[4096 * 3]);
+    memset(accumulator_ref, 0, 4096 * 3 * sizeof(accumulator_ref[0]));
+    memset(count_ref, 0, 4096 * 3 * sizeof(count_ref[0]));
+    DECLARE_ALIGNED(16, unsigned int, accumulator_mod[4096 * 3]);
+    DECLARE_ALIGNED(16, uint16_t, count_mod[4096 * 3]);
+    memset(accumulator_mod, 0, 4096 * 3 * sizeof(accumulator_mod[0]));
+    memset(count_mod, 0, 4096 * 3 * sizeof(count_mod[0]));
 
-    assert(width == 32 && height == 32);
-    const BLOCK_SIZE block_size = BLOCK_32X32;
-    const MV subblock_mvs[4] = { { 0, 0 }, { 5, 5 }, { 7, 8 }, { 2, 10 } };
-    const int subblock_mses[4] = { 15, 16, 17, 18 };
+    assert(width == 64 && height == 64);
+    const BLOCK_SIZE block_size = BLOCK_64X64;
+    const MV subblock_mvs[16] = {
+      { 0, 0 },   { 1, 2 },   { 2, 1 },  { 3, 3 }, { 5, 5 }, { 4, 6 },
+      { 6, 4 },   { 7, 7 },   { 7, 8 },  { 8, 7 }, { 9, 6 }, { 6, 9 },
+      { 32, 30 }, { 50, 42 }, { 11, 4 }, { 4, 11 }
+    };
+    const int subblock_mses[16] = { 15, 16, 17, 18, 19, 20, 21, 22,
+                                    23, 24, 25, 26, 27, 28, 29, 30 };
     const int q_factor = 12;
     const int filter_strength = 5;
     const int mb_row = 0;
     const int mb_col = 0;
-    const int num_planes = 1;
+    const int num_planes = 3;
     YV12_BUFFER_CONFIG *ref_frame =
         (YV12_BUFFER_CONFIG *)malloc(sizeof(YV12_BUFFER_CONFIG));
+    memset(ref_frame, 0, sizeof(YV12_BUFFER_CONFIG));
     ref_frame->y_crop_height = 360;
     ref_frame->y_crop_width = 540;
-    ref_frame->heights[0] = height;
-    ref_frame->strides[0] = stride;
-    DECLARE_ALIGNED(16, uint16_t, src[1024 * 3]);
+    ref_frame->heights[0] = 64;
+    ref_frame->strides[0] = 64;
+    ref_frame->heights[1] = 32;
+    ref_frame->strides[1] = 32;
+    DECLARE_ALIGNED(16, uint16_t, src[4096 * 3]);
     ref_frame->buffer_alloc = (uint8_t *)src;
     ref_frame->buffers[0] = src;
-    memcpy(src, src1_, 1024 * 3 * sizeof(uint16_t));
+    ref_frame->buffers[1] = src + 4096;
+    ref_frame->buffers[2] = src + 4096 + 1024;
+    memcpy(src, src1_, 4096 * 3 * sizeof(uint16_t));
 
     MACROBLOCKD *mbd = (MACROBLOCKD *)malloc(sizeof(MACROBLOCKD));
+    memset(mbd, 0, sizeof(MACROBLOCKD));
     mbd->plane[0].subsampling_y = 0;
     mbd->plane[0].subsampling_x = 0;
+    mbd->plane[1].subsampling_y = 1;
+    mbd->plane[1].subsampling_x = 1;
+    mbd->plane[2].subsampling_y = 1;
+    mbd->plane[2].subsampling_x = 1;
     mbd->bd = BD;
 
     params_.ref_func(ref_frame, mbd, block_size, mb_row, mb_col, num_planes,
@@ -182,7 +179,7 @@ void HBDTemporalFilterTest::RunTest(int isRandom, int width, int height,
                          filter_strength, src2_, accumulator_ref, count_ref);
       }
       avm_usec_timer_mark(&ref_timer);
-      const int elapsed_time_c =
+      const int elapsed_time_ref =
           static_cast<int>(avm_usec_timer_elapsed(&ref_timer));
 
       avm_usec_timer_start(&test_timer);
@@ -192,26 +189,50 @@ void HBDTemporalFilterTest::RunTest(int isRandom, int width, int height,
                          filter_strength, src2_, accumulator_mod, count_mod);
       }
       avm_usec_timer_mark(&test_timer);
-      const int elapsed_time_simd =
+      const int elapsed_time_tst =
           static_cast<int>(avm_usec_timer_elapsed(&test_timer));
 
       printf(
-          "c_time=%d \t simd_time=%d \t "
-          "gain=%f\t width=%d\t height=%d \n",
-          elapsed_time_c, elapsed_time_simd,
-          (float)((float)elapsed_time_c / (float)elapsed_time_simd), width,
-          height);
+          "ref_time=%d us \t tst_time=%d us \t "
+          "gain=%.2fx (%.1f%% reduction)\t width=%d\t height=%d \n",
+          elapsed_time_ref, elapsed_time_tst,
+          (float)elapsed_time_ref / (float)elapsed_time_tst,
+          (1.0f - (float)elapsed_time_tst / (float)elapsed_time_ref) * 100.0f,
+          width, height);
 
     } else {
-      for (int i = 0, l = 0; i < height; i++) {
-        for (int j = 0; j < width; j++, l++) {
-          EXPECT_EQ(accumulator_ref[l], accumulator_mod[l])
-              << "Error:" << k << " SSE Sum Test [" << width << "x" << height
-              << "] C accumulator does not match optimized accumulator.";
-          EXPECT_EQ(count_ref[l], count_mod[l])
-              << "Error:" << k << " SSE Sum Test [" << width << "x" << height
-              << "] C count does not match optimized count.";
-        }
+      // Check Plane 0 (Y: 64x64 = 4096 pixels)
+      for (int l = 0; l < 4096; l++) {
+        EXPECT_EQ(accumulator_ref[l], accumulator_mod[l])
+            << "Error:" << k << " SSE Sum Test [" << width << "x" << height
+            << "] Ref accumulator does not match Test accumulator at plane 0 "
+               "index "
+            << l;
+        EXPECT_EQ(count_ref[l], count_mod[l])
+            << "Error:" << k << " SSE Sum Test [" << width << "x" << height
+            << "] Ref count does not match Test count at plane 0 index " << l;
+      }
+      // Check Plane 1 (U: 32x32 = 1024 pixels)
+      for (int l = 4096; l < 4096 + 1024; l++) {
+        EXPECT_EQ(accumulator_ref[l], accumulator_mod[l])
+            << "Error:" << k << " SSE Sum Test [" << width << "x" << height
+            << "] Ref accumulator does not match Test accumulator at plane 1 "
+               "index "
+            << l;
+        EXPECT_EQ(count_ref[l], count_mod[l])
+            << "Error:" << k << " SSE Sum Test [" << width << "x" << height
+            << "] Ref count does not match Test count at plane 1 index " << l;
+      }
+      // Check Plane 2 (V: 32x32 = 1024 pixels)
+      for (int l = 8192; l < 8192 + 1024; l++) {
+        EXPECT_EQ(accumulator_ref[l], accumulator_mod[l])
+            << "Error:" << k << " SSE Sum Test [" << width << "x" << height
+            << "] Ref accumulator does not match Test accumulator at plane 2 "
+               "index "
+            << l;
+        EXPECT_EQ(count_ref[l], count_mod[l])
+            << "Error:" << k << " SSE Sum Test [" << width << "x" << height
+            << "] Ref count does not match Test count at plane 2 index " << l;
       }
     }
 
@@ -221,20 +242,20 @@ void HBDTemporalFilterTest::RunTest(int isRandom, int width, int height,
 }
 
 TEST_P(HBDTemporalFilterTest, OperationCheck) {
-  for (int height = 32; height <= 32; height = height * 2) {
-    RunTest(1, height, height, 1, 10);  // GenRandomData
-  }
+  RunTest(1, 64, 64, 1, 10);  // GenRandomData
 }
 
-TEST_P(HBDTemporalFilterTest, ExtremeValues) {
-  for (int height = 32; height <= 32; height = height * 2) {
-    RunTest(0, height, height, 1, 10);
-  }
-}
+TEST_P(HBDTemporalFilterTest, ExtremeValues) { RunTest(0, 64, 64, 1, 10); }
 
-TEST_P(HBDTemporalFilterTest, DISABLED_Speed) {
-  for (int height = 32; height <= 32; height = height * 2) {
-    RunTest(1, height, height, 100000, 10);
-  }
-}
+TEST_P(HBDTemporalFilterTest, DISABLED_Speed) { RunTest(1, 64, 64, 10000, 10); }
+
+#if HAVE_SSE2
+INSTANTIATE_TEST_SUITE_P(
+    SSE2, HBDTemporalFilterTest,
+    ::testing::Values(HBDTemporalFilterWithParam(
+        HBDTemporalFilterFuncParam(&av2_highbd_apply_temporal_filter_c,
+                                   &av2_highbd_apply_temporal_filter_sse2),
+        10)));
+#endif  // HAVE_SSE2
+
 }  // namespace


### PR DESCRIPTION
Precompute decay, normalization, motion-distance, and block-error
factors outside the per-pixel loops.

Align SSE2 implementation with C function to support 64x64 blocks
(TF_BLOCK_SIZE = BLOCK_64X64, 16 subblocks), enabling SSE2 SIMD
dispatch in the temporal filter.

Instantiate HBDTemporalFilterTest for C vs SSE2 in test/temporal_filter_test.cc.

Unit tests show that SSE2 is ~2.6x faster than C (61-62% reduction),
1.5-2x faster than the original SSE2.

[ RUN      ] SSE2/HBDTemporalFilterTest.DISABLED_Speed/0
ref_time=2562927 us | tst_time=1012646 us | gain=2.53x (60.5% reduction) width=64 height=64
ref_time=2317598 us | tst_time=881671 us  | gain=2.63x (62.0% reduction) width=64 height=64
ref_time=2431593 us | tst_time=954904 us  | gain=2.55x (60.7% reduction) width=64 height=64
