### PR TITLE
Fix film grain OBU desync when denoising a monochrome sequence

### DIFF
--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -5313,6 +5313,12 @@ static int apply_denoise_2d(AV2_COMP *cpi, YV12_BUFFER_CONFIG *sd,
     if (cm->film_grain_params.apply_grain) {
       cm->film_grain_params.block_size =
           cpi->oxcf.tune_cfg.film_grain_block_size;
+      // For monochrome sequence, drop the chroma estimates
+      // here so the model that gets written matches what the decoder parses;
+      // otherwise the chroma AR coefficients are written but never read and
+      // the bitstream desynchronises.
+      if (cm->seq_params.monochrome)
+        reset_film_grain_chroma_params(&cm->film_grain_params);
       avm_film_grain_table_append(cpi->film_grain_table, time_stamp, end_time,
                                   &cm->film_grain_params);
     }

--- a/av2/encoder/encoder_utils.c
+++ b/av2/encoder/encoder_utils.c
@@ -379,7 +379,7 @@ void av2_set_size_dependent_vars(AV2_COMP *cpi, int *q, int *bottom_index,
                                   cpi->gf_group.index, bottom_index, top_index);
 }
 
-static void reset_film_grain_chroma_params(avm_film_grain_t *pars) {
+void reset_film_grain_chroma_params(avm_film_grain_t *pars) {
   pars->fgm_points[2] = 0;
   pars->cr_mult = 0;
   pars->cr_luma_mult = 0;

--- a/av2/encoder/encoder_utils.h
+++ b/av2/encoder/encoder_utils.h
@@ -945,6 +945,8 @@ static AVM_INLINE void update_subgop_ref_stats(
 void av2_update_film_grain_parameters(struct AV2_COMP *cpi,
                                       const AV2EncoderConfig *oxcf);
 
+void reset_film_grain_chroma_params(avm_film_grain_t *pars);
+
 void av2_scale_references(AV2_COMP *cpi, const InterpFilter filter,
                           const int phase, const int use_optimized_scaler);
 


### PR DESCRIPTION
apply_denoise_2d() stored the noise model's grain parameters verbatim, but the model always estimates all three planes while write_fgm_obu() signals only luma when seq_params->monochrome is set. The chroma scaling points and AR coefficients were therefore written but never read back, leaving the bit reader offset so the following frame header parsed as garbage and the decoder reported "Corrupt frame detected".

Fix issue #5316.