### PR TITLE
Avoid overwriting film_grain_params_present per frame

### DIFF
--- a/av2/encoder/encode_strategy.c
+++ b/av2/encoder/encode_strategy.c
@@ -1191,9 +1191,10 @@ int av2_encode_strategy(AV2_COMP *const cpi, size_t *const size,
     adjust_frame_rate(cpi, source->ts_start, source->ts_end);
   if (!frame_params.duplicate_existing_frame) {
     if (cpi->film_grain_table) {
-      cm->seq_params.film_grain_params_present = avm_film_grain_table_lookup(
-          cpi->film_grain_table, *time_stamp, *time_end, 0 /* =erase */,
-          &cm->film_grain_params);
+      // film_grain_params_present is sequence level and is written once in the
+      // sequence header, so it must not be re-derived per frame here.
+      avm_film_grain_table_lookup(cpi->film_grain_table, *time_stamp, *time_end,
+                                  0 /* =erase */, &cm->film_grain_params);
     }
     // only one operating point supported now
     const int64_t pts64 = ticks_to_timebase_units(timestamp_ratio, *time_stamp);


### PR DESCRIPTION
The sequence header writes this flag once, so overwriting it every frame with the per-frame grain-table lookup made later frames emit grain syntax the decoder never reads, desynchronising the bitstream.

Fix issue #5320.