### PR TITLE
Check obu_type if single_picture_header_flag is 1

### DIFF
--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -8007,6 +8007,11 @@ static int read_uncompressed_header(AV2Decoder *pbi, OBU_TYPE obu_type,
     cm->implicit_output_picture = 0;
     cm->cur_frame->immediate_output_picture = 1;
     cm->cur_frame->implicit_output_picture = 0;
+    if (obu_type != OBU_CLOSED_LOOP_KEY) {
+      avm_internal_error(
+          &cm->error, AVM_CODEC_CORRUPT_FRAME,
+          "Still pictures must be coded as closed loop keyframes");
+    }
     current_frame->frame_type = KEY_FRAME;
     pbi->decoding_first_frame = 1;
     reset_frame_buffers(cm);


### PR DESCRIPTION
If single_picture_header_flag is equal to 1 in the sequence header OBU, frame_type is inferred to be KEY_FRAME and immediate_output_frame is inferred to be 1. Therefore obu_type needs to be OBU_CLOSED_LOOP_KEY, otherwise frame_type and immediate_output_frame will be inconsistent with obu_type and things will go wrong.

Fixes https://github.com/AOMediaCodec/avm/issues/5319.