### PR TITLE
Shift saved_wb_first_tg.bit_buffer only for the first tile group

### DIFF
--- a/av2/encoder/bitstream.c
+++ b/av2/encoder/bitstream.c
@@ -7319,7 +7319,7 @@ static int av2_pack_bitstream_internal(AV2_COMP *const cpi, uint8_t *dst,
       return AVM_CODEC_ERROR;
     }
 
-    if (saved_wb_first_tg.bit_buffer)
+    if (saved_wb_first_tg.bit_buffer && tg_idx == 0)
       saved_wb_first_tg.bit_buffer += length_field_size;
     data += obu_header_size + obu_payload_size + length_field_size;
 


### PR DESCRIPTION
context_update_tile_id is only signalled in the first tile group, so saved_wb_first_tg.bit_buffer must keep pointing at it, but it was shifted by += length_field_size for every tile group. Only the first tile group's length field is inserted in front of the field and moves it; the issue happens when there are more than two tile groups in one frame.

Fixes issue #5325.