### PR TITLE
Correct the assertions added in commit 4831498

### DIFF
--- a/av2/encoder/encoder_utils.h
+++ b/av2/encoder/encoder_utils.h
@@ -1007,7 +1007,7 @@ static AVM_INLINE void av2_set_seq_tile_info(SequenceHeader *const seq_params,
       if (j >= tile_cfg->tile_width_count) j = 0;
       start_sb += AVMMIN(size_sb, tiles->max_width_sb);
     }
-    assert(start_sb == sb_cols);
+    assert(start_sb >= sb_cols);
     tiles->cols = i;
     tiles->col_start_sb[i] = sb_cols;
   }
@@ -1026,7 +1026,7 @@ static AVM_INLINE void av2_set_seq_tile_info(SequenceHeader *const seq_params,
       if (j >= tile_cfg->tile_height_count) j = 0;
       start_sb += AVMMIN(size_sb, tiles->max_height_sb);
     }
-    assert(start_sb == sb_rows);
+    assert(start_sb >= sb_rows);
     tiles->rows = i;
     tiles->row_start_sb[i] = sb_rows;
   }
@@ -1075,7 +1075,7 @@ static AVM_INLINE void av2_set_tile_info(AV2_COMMON *const cm,
       if (j >= tile_cfg->tile_width_count) j = 0;
       start_sb += AVMMIN(size_sb, tiles->max_width_sb);
     }
-    assert(start_sb == sb_cols);
+    assert(start_sb >= sb_cols);
     tiles->cols = i;
     tiles->col_start_sb[i] = sb_cols;
   }
@@ -1097,7 +1097,7 @@ static AVM_INLINE void av2_set_tile_info(AV2_COMMON *const cm,
       if (j >= tile_cfg->tile_height_count) j = 0;
       start_sb += AVMMIN(size_sb, tiles->max_height_sb);
     }
-    assert(start_sb == sb_rows);
+    assert(start_sb >= sb_rows);
     tiles->rows = i;
     tiles->row_start_sb[i] = sb_rows;
   }


### PR DESCRIPTION
The assertions are intended to verify that sb_cols and sb_rows are fully consumed by av2_set_seq_tile_info() or av2_set_tile_info(). It is fine for sb_start to exceed sb_cols or sb_rows after exiting the for loop, because we will cap tiles->col_start_sb[i] and tiles->row_start_sb[i] to sb_cols and sb_rows, respectively, so we won't consume more than sb_cols and sb_rows.

Fixes https://github.com/AOMediaCodec/avm/issues/5332.