### PR TITLE
Picklpf: Fix chroma cost computation in search_filter_offsets

### DIFF
--- a/av2/encoder/picklpf.c
+++ b/av2/encoder/picklpf.c
@@ -327,7 +327,6 @@ void av2_pick_filter_level(const YV12_BUFFER_CONFIG *sd, AV2_COMP *cpi,
         lf->delta_side_v = 0;
     int last_frame_offsets[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
-    int dir = 0;
     double best_single_cost = DBL_MAX;
     double best_dual_cost = DBL_MAX;
     int best_single_offsets[4] = { 0, 0, 0, 0 };
@@ -367,6 +366,7 @@ void av2_pick_filter_level(const YV12_BUFFER_CONFIG *sd, AV2_COMP *cpi,
     }
 
     if (num_planes > 1) {
+      const int dir = 2;
       double best_cost_u = DBL_MAX;
       double best_cost_v = DBL_MAX;
       // Cb


### PR DESCRIPTION
As chroma has no separate q/side offsets for different edge directions, the rate has to be measured relative to zero.

In search_filter_offsets() the dir parameter determines rate for signalling offsets. The rate selection part is indicated below for reference.

```c
if (dir == 2) {                       // single offset — cost measured against zero
  start_bits = offsets[off_ind] ? df_par_bits : 0;
  best_bits  = offset_best      ? df_par_bits : 0;
} else if (dir == 0) {                // vertical — cost joint with the horizontal offset
  int hor_offset = last_frame_offsets[(hor_q_ind + 1) + off_ind];
  ...
} else {               // dir == 1
  ...
} 
```
The if branch is for luma (when both edges have same offsets). Here the rate cost is measured by comparing offset against zero. The else if and else branch is for luma, where VERT_EDGE and HORZ_EDGE are separately signalled and the cost model checks whether they match. Chroma has no separate offsets for different edge directions. During search_filter_offsets, all four chroma call sites pass dir = 0, so chroma goes through the luma branch. Hence chroma's rate is based on luma HORZ value instead of zero. Passing dir = 2 fixes it. Chroma gets the "cost vs. zero" branch as expected for a single independently-signalled offset.

```
| Speed | Num frames | Class | avg.psnr | ovr.psnr |
|-------|-----------|-------|----------|----------|
| 1     | 17        | A1    | -0.01    | -0.011   |
|       | 33        | A2    | 0.03     | 0.032    |
| 2     | 17        | A1    | -0.026   | -0.023   |
|       | 33        | A2    | -0.016   | -0.014   |
```