### PR TITLE
Fix out-of-range operating_points_count

### DIFF
--- a/av2/arg_defs.c
+++ b/av2/arg_defs.c
@@ -897,7 +897,7 @@ const av2_codec_arg_definitions_t g_av2_codec_arg_defs = {
       ARG_DEF(NULL, "enable-mfh-obu-signaling", 1,
               "Enable MFH OBU signaling (0: false (default), 1: true)"),
   .operating_points_count = ARG_DEF(NULL, "operating-points-count", 1,
-                                    "Number of operating points (1-31)."),
+                                    "Number of operating points (1-7)."),
   .cross_frame_cdf_init_mode =
       ARG_DEF(NULL, "cross-frame-cdf-init-mode", 1,
               "Cross frame CDF for context initialization "

--- a/av2/av2_cx_iface.c
+++ b/av2/av2_cx_iface.c
@@ -770,6 +770,8 @@ static avm_codec_err_t validate_config(avm_codec_alg_priv_t *ctx,
   RANGE_CHECK_HI(cfg, frame_hash_metadata, 3);
   RANGE_CHECK_HI(cfg, frame_hash_per_plane, 1);
 
+  RANGE_CHECK(extra_cfg, operating_points_count, 0, MAX_OPS_COUNT);
+
   RANGE_CHECK(extra_cfg, dpb_size, 1, 16);
   RANGE_CHECK(extra_cfg, color_primaries, AVM_CICP_CP_BT_709,
               AVM_CICP_CP_EBU_3213);  // Need to check range more precisely to

--- a/av2/encoder/encoder.h
+++ b/av2/encoder/encoder.h
@@ -1208,7 +1208,7 @@ typedef struct AV2EncoderConfig {
   // Configuration related to layering information.
   LayerCfg layer_cfg;
 
-  // 0-31 = manually set operating_points_cnt_minus_1
+  // Number of operating points per OPS, in the range 0 to MAX_OPS_COUNT (7).
   int operating_points_count;
   /*!\endcond */
 } AV2EncoderConfig;


### PR DESCRIPTION
The advertised 1-31 range is not aligned with the spec: ops_cnt is an f(3) field, so MAX_OPS_COUNT (7) is the correct upper bound.