### PR TITLE
Enable Intra DIP at all speeds

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -515,7 +515,6 @@ static void set_good_speed_features_framesize_independent(
     // --- Start ---
     sf->interp_sf.use_interp_filter = 1;
     sf->tx_sf.tx_type_search.skip_tx_search = 1;
-    sf->intra_sf.skip_intra_dip_search = true;
     sf->rd_sf.disable_tcq = 0;
     // --- End ---
 


### PR DESCRIPTION
A speed feature `include_dip_for_top_n_model_rd_pruning` was recently added to speed up DIP for for speed >= 1.

Because of this, there is a very small slowdown when using DIP, with a good coding gain at speed >= 3  (where DIP was disabled before).

Anchor commit: 44be072d0b  (Aug 25, 2026)

### Speed 4 CTC 33 frames RA:

```
+---------+--------+-------------+
| Summary |  YUV   |   Enc-time  |
+---------+--------+-------------+
|   A1    | -0.85% |   101.79%   |
|   A2    | -0.53% |   102.00%   |
|Avg wo B2| -0.46% |   102.56%   |
+---------+--------+-------------+
```

### Speed 3 CTC 33 frames RA:

```
+---------+--------+-------------+
| Summary |  YUV   |   Enc-time  |
+---------+--------+-------------+
|   A1    | -0.76% |   102.47%   |
|   A2    | -0.46% |   103.18%   |
|Avg wo B2| -0.43% |   103.75%   |
+---------+--------+-------------+
```

STATS_CHANGED for speed >= 3