### PR TITLE
Mark temporal point info metadata as suffix metadata

### DIFF
--- a/av2/encoder/bitstream.c
+++ b/av2/encoder/bitstream.c
@@ -6667,7 +6667,7 @@ static size_t write_temporal_point_info_metadata(AV2_COMP *const cpi,
   }
 
   // Set up metadata fields for individual OBU_METADATA
-  metadata->is_suffix = 0;
+  metadata->is_suffix = 1;
   metadata->cancel_flag = 0;
   metadata->persistence_idc = AVM_NO_PERSISTENCE;
   metadata->layer_idc = AVM_LAYER_CURRENT;


### PR DESCRIPTION
Temporal point info is prefix metadata (is_suffix == 0), but it was written after the tile group OBUs. The decoder treats a prefix metadata OBU that follows a coded frame as the start of the next frame unit, so --timing-info=model produced a stream that failed to decode with "Unspecified internal error" on a nonexistent trailing frame.

Fix (Encoder only): Set is_suffix = 1 to match where the OBU is written.