### PR TITLE
Fix inferred frame size when an MFH OBU and frame resize are both in use

### DIFF
--- a/av2/encoder/bitstream.c
+++ b/av2/encoder/bitstream.c
@@ -5296,10 +5296,19 @@ static AVM_INLINE void write_uncompressed_header(
             "Bridge frame frame_number is not equal to ref_buf order_hint");
       }
     } else {
+      // The size the decoder infers when frame_size_override_flag is 0. Must
+      // stay in sync with decodeframe.c:setup_frame_size().
+      int inferred_width = seq_params->max_frame_width;
+      int inferred_height = seq_params->max_frame_height;
+      if (cm->cur_mfh_id != 0 &&
+          cm->mfh_params[cm->cur_mfh_id].mfh_frame_size_present_flag) {
+        inferred_width = cm->mfh_params[cm->cur_mfh_id].mfh_frame_width;
+        inferred_height = cm->mfh_params[cm->cur_mfh_id].mfh_frame_height;
+      }
       frame_size_override_flag =
-          frame_is_sframe(cm) ? 1
-                              : (cm->width != seq_params->max_frame_width ||
-                                 cm->height != seq_params->max_frame_height);
+          frame_is_sframe(cm)
+              ? 1
+              : (cm->width != inferred_width || cm->height != inferred_height);
       if (!frame_is_sframe(cm)) avm_wb_write_bit(wb, frame_size_override_flag);
       avm_wb_write_literal(
           wb, current_frame->order_hint,


### PR DESCRIPTION
This commit fixes a mismatch between encoder and decoder for inferring the frame size when both an MFH OBU and frame resize are in use.

When an MFH OBU is present and frame_size_override_flag is 0, the decoder infers the MFH frame size, instead of using max_frame_width/max_frame_height in sequence header. The encoder compared only against max_frame_\*, so under RPR a frame that matched max_frame_\* but differed from the MFH size was written with no size and decoded at the wrong dimensions, desyncing the parse. This commit adds comparison against the size the decoder actually infers.

Fix issue #5347.