### PR TITLE
Fix NULL dereference in global motion setup with frame resize

### DIFF
--- a/av2/encoder/global_motion_facade.c
+++ b/av2/encoder/global_motion_facade.c
@@ -285,11 +285,15 @@ static AVM_INLINE void update_valid_ref_frames_for_gm(
         (ref_disabled && cpi->sf.hl_sf.recode_loop != DISALLOW_RECODE)) {
       continue;
     } else {
-      // Get the scaled buffer
-      if (av2_is_scaled(get_ref_scale_factors(cm, frame)))
+      // Get the scaled buffer. av2_scale_references() leaves scaled_ref_buf[]
+      // NULL for a disabled reference, which the check above can let through,
+      // so skip rather than dereference NULL.
+      if (av2_is_scaled(get_ref_scale_factors(cm, frame))) {
+        if (cpi->scaled_ref_buf[frame] == NULL) continue;
         ref_buf[frame] = &cpi->scaled_ref_buf[frame]->buf;
-      else
+      } else {
         ref_buf[frame] = &buf->buf;
+      }
     }
 
     int prune_ref_frames =


### PR DESCRIPTION
update_valid_ref_frames_for_gm() dereferenced cpi->scaled_ref_buf[frame] without checking it, but av2_scale_references() leaves that entry NULL for a disabled reference, and the skip-invalid-refs check only skips disabled references when recode is allowed. Under frame resize at speed >= 6 that combination occurs and the encoder segfaults on the first inter frame. Add the missing NULL check.

Fix issue #5348.