### PR TITLE
Disable two simple motion related features at speed 2

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -455,11 +455,6 @@ static void set_good_speed_features_framesize_independent(
     sf->lpf_sf.early_terminate_ccso_search_by_cost = 1;
     sf->part_sf.partition_pruning_with_mlp_none_thresh = 2.5f;
     sf->part_sf.intra_cnn_split = 0;
-    sf->part_sf.simple_motion_search_early_term_none = 1;
-    // TODO(Venkat): Clean-up frame type dependency for
-    // simple_motion_search_split in partition search function and set the
-    // speed feature accordingly
-    sf->part_sf.simple_motion_search_split = allow_screen_content_tools ? 1 : 2;
 
     sf->part_sf.disable_uneven_4way_partitions = true;
     sf->part_sf.disable_ext_partitions = true;
@@ -523,6 +518,11 @@ static void set_good_speed_features_framesize_independent(
     sf->part_sf.allow_partition_search_skip = 1;
     sf->part_sf.less_rectangular_check_level = 2;
     sf->part_sf.simple_motion_search_prune_agg = 1;
+    sf->part_sf.simple_motion_search_early_term_none = 1;
+    // TODO(Venkat): Clean-up frame type dependency for
+    // simple_motion_search_split in partition search function and set the
+    // speed feature accordingly
+    sf->part_sf.simple_motion_search_split = allow_screen_content_tools ? 1 : 2;
 
     sf->rd_sf.perform_coeff_opt = is_boosted_arf2_bwd_type ? 3 : 4;
 
@@ -1146,7 +1146,7 @@ static AVM_INLINE void set_erp_speed_features_framesize_dependent(
     }
   }
 
-  if (cpi->speed >= 2) {
+  if (cpi->speed >= 3) {
     sf->part_sf.simple_motion_search_early_term_none = 1;
   }
 }
@@ -1255,6 +1255,8 @@ static AVM_INLINE void set_erp_speed_features(AV2_COMP *cpi) {
 
   if (cpi->speed >= 2) {
     sf->part_sf.ext_recur_depth_level = 2;
+  }
+  if (cpi->speed >= 3) {
     sf->part_sf.simple_motion_search_split = 1;
     sf->part_sf.simple_motion_search_early_term_none = 1;
   }


### PR DESCRIPTION
The speed feature's performance at different speeds are shown below: (base commit: b8f07955a48dad6b927b93e5b2134d6be32cbe8f)


```
Speed     Set   BD-YUV    EncTime (% Base)    Speedup	Ratio
Speed_2	  A1    -0.22%     106.02% 	        +5.68%	    25.8
Speed_2	  A2    -0.99%     122.19% 	       +18.16%  	18.3
Speed_3	  A1    -0.20%     104.29% 	        +4.11%  	20.6
Speed_3	  A2    -0.18%     107.92% 	        +7.34%  	40.8
Speed_4	  A1    -0.32%     106.05% 	        +5.70%  	17.8
Speed_4	  A2    -0.24%     107.78% 	        +7.22%  	30.1
```

The breakdown of the two features is: (on an older commit cc53250a1cbe8219400461ee0e40fc84992d6df6)
```
+----------+---------------------------------------------+-----------------------------+------------------------------------+--------------------------------------+
| Test     | Feature Disabled                            | State of Other SMS Feature  | Set A1 (4K, 17f) BD-YUV / EncTime  | Set A2 (1080p, 33f) BD-YUV / EncTime |
+----------+---------------------------------------------+-----------------------------+------------------------------------+--------------------------------------+
| Test A   | simple_motion_search_split OFF              | early_term_none ON          | -0.34% / 102.19%                   | -0.45% / 103.93%                     |
| Test B   | simple_motion_search_early_term_none OFF     | sms_split ON                | -1.22% / 111.83%                   | -0.66% / 115.25%                     |
| Both OFF | Both SMS Features OFF                       | Both OFF                    | -1.58% / 113.85%                   | -1.11% / 119.93%                     |
+----------+---------------------------------------------+-----------------------------+------------------------------------+--------------------------------------+
```

We turn these features off for speed 2 since they are below the bar.

With this change, we recover -0.22% (A1), -0.99% (A2) coding gains, with 6% (A1), 22% (A2) encoder slowdown.

The current encoder performance before and after the change is:
```
Configuration	  Set  BD-YUV   EncTime (% Spd 0)
Speed 1 Base	  A1   +1.70%   31.67%
Speed 1 Base	  A2   +2.80%   22.22%
Speed 2 Before	  A1   +5.33%   11.06%
Speed 2 Before	  A2   +5.62%    9.63%
Speed 2 After	  A1   +5.10%   11.73%
Speed 2 After	  A2   +4.57%   11.77%
```

STATS_CHANGED for speed 2.