### PR TITLE
AVX-512 implementation of av2_highbd_convolve_x_sr

### DIFF
--- a/av2/common/av2_rtcd_defs.pl
+++ b/av2/common/av2_rtcd_defs.pl
@@ -448,7 +448,7 @@ specialize qw/av2_highbd_cwp_convolve_x sse4_1 avx2/;
 specialize qw/av2_highbd_cwp_convolve_y sse4_1 avx2/;
 specialize qw/av2_highbd_cwp_convolve_2d_copy sse4_1 avx2/;
 specialize qw/av2_highbd_convolve_2d_sr ssse3 avx2 neon/;
-specialize qw/av2_highbd_convolve_x_sr ssse3 avx2 neon/;
+specialize qw/av2_highbd_convolve_x_sr ssse3 avx2 avx512 neon/;
 specialize qw/av2_highbd_convolve_y_sr ssse3 avx2 neon/;
 specialize qw/av2_highbd_convolve_2d_scale sse4_1/;
 

--- a/av2/common/convolve.h
+++ b/av2/common/convolve.h
@@ -13,6 +13,8 @@
 #ifndef AVM_AV2_COMMON_CONVOLVE_H_
 #define AVM_AV2_COMMON_CONVOLVE_H_
 #include "av2/common/filter.h"
+#include "avm_dsp/avm_dsp_common.h"
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/avm_dsp/avm_dsp.cmake
+++ b/avm_dsp/avm_dsp.cmake
@@ -51,6 +51,8 @@ list(
   "${AVM_ROOT}/avm_dsp/subtract.c"
   "${AVM_ROOT}/avm_dsp/txfm_common.h"
   "${AVM_ROOT}/avm_dsp/x86/convolve_common_intrin.h"
+  "${AVM_ROOT}/avm_dsp/x86/highbd_convolve_x_sr.h"
+  "${AVM_ROOT}/avm_dsp/x86/highbd_convolve_x_sr_avx512_dispatch.c"
   "${AVM_ROOT}/avm_dsp/avg.c")
 
 list(

--- a/avm_dsp/avm_dsp.cmake
+++ b/avm_dsp/avm_dsp.cmake
@@ -114,6 +114,7 @@ list(
   "${AVM_ROOT}/avm_dsp/x86/bitdepth_conversion_avx2.h")
 
 list(APPEND AVM_DSP_COMMON_INTRIN_AVX512
+     "${AVM_ROOT}/avm_dsp/x86/convolve_avx512.h"
      "${AVM_ROOT}/avm_dsp/x86/highbd_convolve_avx512.c")
 
 list(APPEND AVM_DSP_DECODER_INTRIN_AVX2 "${AVM_ROOT}/avm_dsp/x86/entdec_avx2.c")

--- a/avm_dsp/avm_dsp.cmake
+++ b/avm_dsp/avm_dsp.cmake
@@ -113,6 +113,9 @@ list(
   "${AVM_ROOT}/avm_dsp/x86/avg_intrin_avx2.c"
   "${AVM_ROOT}/avm_dsp/x86/bitdepth_conversion_avx2.h")
 
+list(APPEND AVM_DSP_COMMON_INTRIN_AVX512
+     "${AVM_ROOT}/avm_dsp/x86/highbd_convolve_avx512.c")
+
 list(APPEND AVM_DSP_DECODER_INTRIN_AVX2 "${AVM_ROOT}/avm_dsp/x86/entdec_avx2.c")
 
 list(

--- a/avm_dsp/x86/convolve_avx512.h
+++ b/avm_dsp/x86/convolve_avx512.h
@@ -18,9 +18,9 @@
 #include "av2/common/filter.h"
 #include "avm_dsp/x86/synonyms.h"
 
-static INLINE void prepare_coeffs(const InterpFilterParams *const filter_params,
-                                  const int subpel_q4,
-                                  __m512i *const coeffs /* [4] */) {
+static INLINE void prepare_coeffs_avx512(
+    const InterpFilterParams *const filter_params, const int subpel_q4,
+    __m512i *const coeffs /* [4] */) {
   const int16_t *filter = av2_get_interp_filter_subpel_kernel(
       filter_params, subpel_q4 & SUBPEL_MASK);
   const __m128i coeff_8 = _mm_loadu_si128((__m128i *)filter);
@@ -31,7 +31,8 @@ static INLINE void prepare_coeffs(const InterpFilterParams *const filter_params,
   coeffs[3] = _mm512_shuffle_epi32(coeff, 0xff);  // 6 7 6 7 ...
 }
 
-static INLINE __m512i convolve(const __m512i *const s, const __m512i *const c) {
+static INLINE __m512i convolve_avx512(const __m512i *const s,
+                                      const __m512i *const c) {
   const __m512i r0 = _mm512_madd_epi16(s[0], c[0]);
   const __m512i r1 = _mm512_madd_epi16(s[1], c[1]);
   const __m512i r2 = _mm512_madd_epi16(s[2], c[2]);

--- a/avm_dsp/x86/convolve_avx512.h
+++ b/avm_dsp/x86/convolve_avx512.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+#ifndef AVM_AVM_DSP_X86_CONVOLVE_AVX512_H_
+#define AVM_AVM_DSP_X86_CONVOLVE_AVX512_H_
+
+#include <immintrin.h>
+
+#include "av2/common/filter.h"
+#include "avm_dsp/x86/synonyms.h"
+
+static INLINE void prepare_coeffs(const InterpFilterParams *const filter_params,
+                                  const int subpel_q4,
+                                  __m512i *const coeffs /* [4] */) {
+  const int16_t *filter = av2_get_interp_filter_subpel_kernel(
+      filter_params, subpel_q4 & SUBPEL_MASK);
+  const __m128i coeff_8 = _mm_loadu_si128((__m128i *)filter);
+  const __m512i coeff = _mm512_broadcast_i32x4(coeff_8);
+  coeffs[0] = _mm512_shuffle_epi32(coeff, 0x00);  // 0 1 0 1 ...
+  coeffs[1] = _mm512_shuffle_epi32(coeff, 0x55);  // 2 3 2 3 ...
+  coeffs[2] = _mm512_shuffle_epi32(coeff, 0xaa);  // 4 5 4 5 ...
+  coeffs[3] = _mm512_shuffle_epi32(coeff, 0xff);  // 6 7 6 7 ...
+}
+
+static INLINE __m512i convolve(const __m512i *const s, const __m512i *const c) {
+  const __m512i r0 = _mm512_madd_epi16(s[0], c[0]);
+  const __m512i r1 = _mm512_madd_epi16(s[1], c[1]);
+  const __m512i r2 = _mm512_madd_epi16(s[2], c[2]);
+  const __m512i r3 = _mm512_madd_epi16(s[3], c[3]);
+  return _mm512_add_epi32(_mm512_add_epi32(r0, r1), _mm512_add_epi32(r2, r3));
+}
+
+static INLINE void load_4rows(const uint16_t *src_ptr, int src_stride, int off,
+                              __m512i *r0, __m512i *r1) {
+  const __m128i a0 = _mm_loadu_si128((__m128i *)&src_ptr[0 * src_stride + off]);
+  const __m128i b0 = _mm_loadu_si128((__m128i *)&src_ptr[1 * src_stride + off]);
+  const __m128i c0 = _mm_loadu_si128((__m128i *)&src_ptr[2 * src_stride + off]);
+  const __m128i d0 = _mm_loadu_si128((__m128i *)&src_ptr[3 * src_stride + off]);
+  const __m128i a1 =
+      _mm_loadu_si128((__m128i *)&src_ptr[0 * src_stride + off + 8]);
+  const __m128i b1 =
+      _mm_loadu_si128((__m128i *)&src_ptr[1 * src_stride + off + 8]);
+  const __m128i c1 =
+      _mm_loadu_si128((__m128i *)&src_ptr[2 * src_stride + off + 8]);
+  const __m128i d1 =
+      _mm_loadu_si128((__m128i *)&src_ptr[3 * src_stride + off + 8]);
+  __m512i t0 = _mm512_castsi128_si512(a0);
+  t0 = _mm512_inserti32x4(t0, b0, 1);
+  t0 = _mm512_inserti32x4(t0, c0, 2);
+  t0 = _mm512_inserti32x4(t0, d0, 3);
+  __m512i t1 = _mm512_castsi128_si512(a1);
+  t1 = _mm512_inserti32x4(t1, b1, 1);
+  t1 = _mm512_inserti32x4(t1, c1, 2);
+  t1 = _mm512_inserti32x4(t1, d1, 3);
+  *r0 = t0;
+  *r1 = t1;
+}
+
+#endif  // AVM_AVM_DSP_X86_CONVOLVE_AVX512_H_

--- a/avm_dsp/x86/highbd_convolve_avx2.c
+++ b/avm_dsp/x86/highbd_convolve_avx2.c
@@ -212,7 +212,7 @@ static void highbd_convolve_x_sr_avx2_shuffle(
       const __m256i r1 = _mm256_permute2x128_si256(row0, row1, 0x31);
 
       // even pixels
-      s[0] = _mm256_alignr_epi8(r1, r0, 0);
+      s[0] = r0;
       s[1] = _mm256_alignr_epi8(r1, r0, 4);
       s[2] = _mm256_alignr_epi8(r1, r0, 8);
       s[3] = _mm256_alignr_epi8(r1, r0, 12);

--- a/avm_dsp/x86/highbd_convolve_avx2.c
+++ b/avm_dsp/x86/highbd_convolve_avx2.c
@@ -16,6 +16,7 @@
 
 #include "avm_dsp/x86/convolve.h"
 #include "avm_dsp/x86/convolve_avx2.h"
+#include "avm_dsp/x86/highbd_convolve_x_sr.h"
 #include "avm_dsp/x86/synonyms.h"
 
 // -----------------------------------------------------------------------------
@@ -169,7 +170,7 @@ void av2_highbd_convolve_y_sr_avx2(const uint16_t *src, int src_stride,
   }
 }
 
-static void highbd_convolve_x_sr_avx2_shuffle(
+void highbd_convolve_x_sr_avx2_shuffle(
     const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
     int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
     ConvolveParams *conv_params, int bd) {
@@ -263,7 +264,7 @@ static void highbd_convolve_x_sr_avx2_shuffle(
   }
 }
 
-static void highbd_convolve_x_sr_avx2_loadonly(
+void highbd_convolve_x_sr_avx2_loadonly(
     const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
     int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
     ConvolveParams *conv_params, int bd) {

--- a/avm_dsp/x86/highbd_convolve_avx2.c
+++ b/avm_dsp/x86/highbd_convolve_avx2.c
@@ -169,11 +169,10 @@ void av2_highbd_convolve_y_sr_avx2(const uint16_t *src, int src_stride,
   }
 }
 
-void av2_highbd_convolve_x_sr_avx2(const uint16_t *src, int src_stride,
-                                   uint16_t *dst, int dst_stride, int w, int h,
-                                   const InterpFilterParams *filter_params_x,
-                                   const int subpel_x_qn,
-                                   ConvolveParams *conv_params, int bd) {
+static void highbd_convolve_x_sr_avx2_shuffle(
+    const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
+    int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
+    ConvolveParams *conv_params, int bd) {
   int i, j;
   const int fo_horiz = filter_params_x->taps / 2 - 1;
   const uint16_t *const src_ptr = src - fo_horiz;
@@ -262,6 +261,87 @@ void av2_highbd_convolve_x_sr_avx2(const uint16_t *src, int src_stride,
       }
     }
   }
+}
+
+static void highbd_convolve_x_sr_avx2_loadonly(
+    const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
+    int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
+    ConvolveParams *conv_params, int bd) {
+  const int fo_horiz = filter_params_x->taps / 2 - 1;
+  const uint16_t *const src_ptr = src - fo_horiz;
+
+  assert(bd + FILTER_BITS + 2 - conv_params->round_0 <= 16);
+
+  __m256i s[4], coeffs_x[4];
+
+  const __m256i round_const_x =
+      _mm256_set1_epi32(((1 << conv_params->round_0) >> 1));
+  const __m128i round_shift_x = _mm_cvtsi32_si128(conv_params->round_0);
+
+  const int bits = FILTER_BITS - conv_params->round_0;
+  const __m128i round_shift_bits = _mm_cvtsi32_si128(bits);
+  const __m256i round_const_bits = _mm256_set1_epi32((1 << bits) >> 1);
+  const __m256i clip_pixel =
+      _mm256_set1_epi16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+
+  assert(bits >= 0);
+  assert((FILTER_BITS - conv_params->round_1) >= 0 ||
+         ((conv_params->round_0 + conv_params->round_1) == 2 * FILTER_BITS));
+
+  prepare_coeffs(filter_params_x, subpel_x_qn, coeffs_x);
+
+  for (int i = 0; i < h; ++i) {
+    for (int jc = 0; jc < w; jc += 16) {
+      const int j = (jc + 16 <= w) ? jc : (w - 16);
+      const uint16_t *const p = &src_ptr[i * src_stride + j];
+
+      // Even pixels
+      s[0] = _mm256_loadu_si256((const __m256i *)(p + 0));
+      s[1] = _mm256_loadu_si256((const __m256i *)(p + 2));
+      s[2] = _mm256_loadu_si256((const __m256i *)(p + 4));
+      s[3] = _mm256_loadu_si256((const __m256i *)(p + 6));
+      __m256i res_even = convolve(s, coeffs_x);
+      res_even = _mm256_sra_epi32(_mm256_add_epi32(res_even, round_const_x),
+                                  round_shift_x);
+      // Odd pixels
+      s[0] = _mm256_loadu_si256((const __m256i *)(p + 1));
+      s[1] = _mm256_loadu_si256((const __m256i *)(p + 3));
+      s[2] = _mm256_loadu_si256((const __m256i *)(p + 5));
+      s[3] = _mm256_loadu_si256((const __m256i *)(p + 7));
+      __m256i res_odd = convolve(s, coeffs_x);
+      res_odd = _mm256_sra_epi32(_mm256_add_epi32(res_odd, round_const_x),
+                                 round_shift_x);
+
+      res_even = _mm256_sra_epi32(_mm256_add_epi32(res_even, round_const_bits),
+                                  round_shift_bits);
+      res_odd = _mm256_sra_epi32(_mm256_add_epi32(res_odd, round_const_bits),
+                                 round_shift_bits);
+
+      const __m256i res_even1 = _mm256_packus_epi32(res_even, res_even);
+      const __m256i res_odd1 = _mm256_packus_epi32(res_odd, res_odd);
+      __m256i res = _mm256_unpacklo_epi16(res_even1, res_odd1);
+      res = _mm256_min_epi16(res, clip_pixel);
+
+      uint16_t *const d = &dst[i * dst_stride + j];
+      _mm_storeu_si128((__m128i *)d, _mm256_castsi256_si128(res));
+      _mm_storeu_si128((__m128i *)(d + 8), _mm256_extracti128_si256(res, 1));
+    }
+  }
+}
+
+void av2_highbd_convolve_x_sr_avx2(const uint16_t *src, int src_stride,
+                                   uint16_t *dst, int dst_stride, int w, int h,
+                                   const InterpFilterParams *filter_params_x,
+                                   const int subpel_x_qn,
+                                   ConvolveParams *conv_params, int bd) {
+  if (w >= 16)
+    highbd_convolve_x_sr_avx2_loadonly(src, src_stride, dst, dst_stride, w, h,
+                                       filter_params_x, subpel_x_qn,
+                                       conv_params, bd);
+  else
+    highbd_convolve_x_sr_avx2_shuffle(src, src_stride, dst, dst_stride, w, h,
+                                      filter_params_x, subpel_x_qn, conv_params,
+                                      bd);
 }
 
 #define CONV8_ROUNDING_BITS (7)

--- a/avm_dsp/x86/highbd_convolve_avx512.c
+++ b/avm_dsp/x86/highbd_convolve_avx512.c
@@ -44,7 +44,7 @@ static void highbd_convolve_x_sr_avx512_shuffle(
 
   assert(bits >= 0);
 
-  prepare_coeffs(filter_params_x, subpel_x_qn, coeffs_x);
+  prepare_coeffs_avx512(filter_params_x, subpel_x_qn, coeffs_x);
 
   for (; i + 4 <= h; i += 4) {
     for (int j = 0; j < w; j += 8) {
@@ -52,12 +52,12 @@ static void highbd_convolve_x_sr_avx512_shuffle(
       load_4rows(&src_ptr[i * src_stride], src_stride, j, &r0, &r1);
 
       // Even output pixels.
-      s[0] = _mm512_alignr_epi8(r1, r0, 0);
+      s[0] = r0;
       s[1] = _mm512_alignr_epi8(r1, r0, 4);
       s[2] = _mm512_alignr_epi8(r1, r0, 8);
       s[3] = _mm512_alignr_epi8(r1, r0, 12);
 
-      __m512i res_even = convolve(s, coeffs_x);
+      __m512i res_even = convolve_avx512(s, coeffs_x);
       res_even = _mm512_sra_epi32(_mm512_add_epi32(res_even, round_const_x),
                                   round_shift_x);
 
@@ -67,7 +67,7 @@ static void highbd_convolve_x_sr_avx512_shuffle(
       s[2] = _mm512_alignr_epi8(r1, r0, 10);
       s[3] = _mm512_alignr_epi8(r1, r0, 14);
 
-      __m512i res_odd = convolve(s, coeffs_x);
+      __m512i res_odd = convolve_avx512(s, coeffs_x);
       res_odd = _mm512_sra_epi32(_mm512_add_epi32(res_odd, round_const_x),
                                  round_shift_x);
 
@@ -140,7 +140,7 @@ static void highbd_convolve_x_sr_avx512_loadonly(
   assert((FILTER_BITS - conv_params->round_1) >= 0 ||
          ((conv_params->round_0 + conv_params->round_1) == 2 * FILTER_BITS));
 
-  prepare_coeffs(filter_params_x, subpel_x_qn, coeffs_x);
+  prepare_coeffs_avx512(filter_params_x, subpel_x_qn, coeffs_x);
 
   for (int i = 0; i < h; ++i) {
     for (int jc = 0; jc < w; jc += 32) {
@@ -152,7 +152,7 @@ static void highbd_convolve_x_sr_avx512_loadonly(
       s[1] = _mm512_loadu_si512((const __m512i *)(p + 2));
       s[2] = _mm512_loadu_si512((const __m512i *)(p + 4));
       s[3] = _mm512_loadu_si512((const __m512i *)(p + 6));
-      __m512i res_even = convolve(s, coeffs_x);
+      __m512i res_even = convolve_avx512(s, coeffs_x);
       res_even = _mm512_sra_epi32(_mm512_add_epi32(res_even, round_const_x),
                                   round_shift_x);
 
@@ -161,7 +161,7 @@ static void highbd_convolve_x_sr_avx512_loadonly(
       s[1] = _mm512_loadu_si512((const __m512i *)(p + 3));
       s[2] = _mm512_loadu_si512((const __m512i *)(p + 5));
       s[3] = _mm512_loadu_si512((const __m512i *)(p + 7));
-      __m512i res_odd = convolve(s, coeffs_x);
+      __m512i res_odd = convolve_avx512(s, coeffs_x);
       res_odd = _mm512_sra_epi32(_mm512_add_epi32(res_odd, round_const_x),
                                  round_shift_x);
 
@@ -193,7 +193,13 @@ void av2_highbd_convolve_x_sr_avx512(const uint16_t *src, int src_stride,
                                          conv_params, bd);
     return;
   }
-  if (w > 8 && w <= 16) {
+  if (w <= 8 && h <= 4) {
+    av2_highbd_convolve_x_sr_avx2(src, src_stride, dst, dst_stride, w, h,
+                                  filter_params_x, subpel_x_qn, conv_params,
+                                  bd);
+    return;
+  }
+  if (w == 16) {
     av2_highbd_convolve_x_sr_avx2(src, src_stride, dst, dst_stride, w, h,
                                   filter_params_x, subpel_x_qn, conv_params,
                                   bd);

--- a/avm_dsp/x86/highbd_convolve_avx512.c
+++ b/avm_dsp/x86/highbd_convolve_avx512.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+#include <immintrin.h>
+#include <string.h>
+
+#include "config/av2_rtcd.h"
+#include "config/avm_dsp_rtcd.h"
+
+#include "avm_dsp/x86/convolve.h"
+#include "avm_dsp/x86/convolve_avx512.h"
+#include "avm_dsp/x86/synonyms.h"
+
+static void highbd_convolve_x_sr_avx512_shuffle(
+    const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
+    int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
+    ConvolveParams *conv_params, int bd) {
+  int i = 0;
+  const int fo_horiz = filter_params_x->taps / 2 - 1;
+  const uint16_t *const src_ptr = src - fo_horiz;
+
+  assert(bd + FILTER_BITS + 2 - conv_params->round_0 <= 16);
+
+  __m512i s[4], coeffs_x[4];
+
+  const __m512i round_const_x =
+      _mm512_set1_epi32(((1 << conv_params->round_0) >> 1));
+  const __m128i round_shift_x = _mm_cvtsi32_si128(conv_params->round_0);
+
+  const int bits = FILTER_BITS - conv_params->round_0;
+  const __m128i round_shift_bits = _mm_cvtsi32_si128(bits);
+  const __m512i round_const_bits = _mm512_set1_epi32((1 << bits) >> 1);
+  const __m512i clip_pixel =
+      _mm512_set1_epi16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+  const __m512i zero = _mm512_setzero_si512();
+
+  assert(bits >= 0);
+
+  prepare_coeffs(filter_params_x, subpel_x_qn, coeffs_x);
+
+  for (; i + 4 <= h; i += 4) {
+    for (int j = 0; j < w; j += 8) {
+      __m512i r0, r1;
+      load_4rows(&src_ptr[i * src_stride], src_stride, j, &r0, &r1);
+
+      // Even output pixels.
+      s[0] = _mm512_alignr_epi8(r1, r0, 0);
+      s[1] = _mm512_alignr_epi8(r1, r0, 4);
+      s[2] = _mm512_alignr_epi8(r1, r0, 8);
+      s[3] = _mm512_alignr_epi8(r1, r0, 12);
+
+      __m512i res_even = convolve(s, coeffs_x);
+      res_even = _mm512_sra_epi32(_mm512_add_epi32(res_even, round_const_x),
+                                  round_shift_x);
+
+      // Odd output pixels.
+      s[0] = _mm512_alignr_epi8(r1, r0, 2);
+      s[1] = _mm512_alignr_epi8(r1, r0, 6);
+      s[2] = _mm512_alignr_epi8(r1, r0, 10);
+      s[3] = _mm512_alignr_epi8(r1, r0, 14);
+
+      __m512i res_odd = convolve(s, coeffs_x);
+      res_odd = _mm512_sra_epi32(_mm512_add_epi32(res_odd, round_const_x),
+                                 round_shift_x);
+
+      res_even = _mm512_sra_epi32(_mm512_add_epi32(res_even, round_const_bits),
+                                  round_shift_bits);
+      res_odd = _mm512_sra_epi32(_mm512_add_epi32(res_odd, round_const_bits),
+                                 round_shift_bits);
+
+      const __m512i res_even1 = _mm512_packs_epi32(res_even, res_even);
+      const __m512i res_odd1 = _mm512_packs_epi32(res_odd, res_odd);
+
+      __m512i res = _mm512_unpacklo_epi16(res_even1, res_odd1);
+      res = _mm512_min_epi16(res, clip_pixel);
+      res = _mm512_max_epi16(res, zero);
+
+      const __m128i out0 = _mm512_extracti32x4_epi32(res, 0);
+      const __m128i out1 = _mm512_extracti32x4_epi32(res, 1);
+      const __m128i out2 = _mm512_extracti32x4_epi32(res, 2);
+      const __m128i out3 = _mm512_extracti32x4_epi32(res, 3);
+      if (w - j > 4) {
+        _mm_storeu_si128((__m128i *)&dst[(i + 0) * dst_stride + j], out0);
+        _mm_storeu_si128((__m128i *)&dst[(i + 1) * dst_stride + j], out1);
+        _mm_storeu_si128((__m128i *)&dst[(i + 2) * dst_stride + j], out2);
+        _mm_storeu_si128((__m128i *)&dst[(i + 3) * dst_stride + j], out3);
+      } else if (w - j == 4) {
+        _mm_storel_epi64((__m128i *)&dst[(i + 0) * dst_stride + j], out0);
+        _mm_storel_epi64((__m128i *)&dst[(i + 1) * dst_stride + j], out1);
+        _mm_storel_epi64((__m128i *)&dst[(i + 2) * dst_stride + j], out2);
+        _mm_storel_epi64((__m128i *)&dst[(i + 3) * dst_stride + j], out3);
+      } else {
+        xx_storel_32((__m128i *)&dst[(i + 0) * dst_stride + j], out0);
+        xx_storel_32((__m128i *)&dst[(i + 1) * dst_stride + j], out1);
+        xx_storel_32((__m128i *)&dst[(i + 2) * dst_stride + j], out2);
+        xx_storel_32((__m128i *)&dst[(i + 3) * dst_stride + j], out3);
+      }
+    }
+  }
+
+  // Handle the tail rows.
+  if (i < h) {
+    av2_highbd_convolve_x_sr_avx2(
+        src + i * src_stride, src_stride, dst + i * dst_stride, dst_stride, w,
+        h - i, filter_params_x, subpel_x_qn, conv_params, bd);
+  }
+}
+
+static void highbd_convolve_x_sr_avx512_loadonly(
+    const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
+    int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
+    ConvolveParams *conv_params, int bd) {
+  const int fo_horiz = filter_params_x->taps / 2 - 1;
+  const uint16_t *const src_ptr = src - fo_horiz;
+
+  assert(bd + FILTER_BITS + 2 - conv_params->round_0 <= 16);
+
+  __m512i s[4], coeffs_x[4];
+
+  const __m512i round_const_x =
+      _mm512_set1_epi32(((1 << conv_params->round_0) >> 1));
+  const __m128i round_shift_x = _mm_cvtsi32_si128(conv_params->round_0);
+
+  const int bits = FILTER_BITS - conv_params->round_0;
+  const __m128i round_shift_bits = _mm_cvtsi32_si128(bits);
+  const __m512i round_const_bits = _mm512_set1_epi32((1 << bits) >> 1);
+  const __m512i clip_pixel =
+      _mm512_set1_epi16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+  const __m512i zero = _mm512_setzero_si512();
+
+  assert(bits >= 0);
+  assert((FILTER_BITS - conv_params->round_1) >= 0 ||
+         ((conv_params->round_0 + conv_params->round_1) == 2 * FILTER_BITS));
+
+  prepare_coeffs(filter_params_x, subpel_x_qn, coeffs_x);
+
+  for (int i = 0; i < h; ++i) {
+    for (int jc = 0; jc < w; jc += 32) {
+      const int j = (jc + 32 <= w) ? jc : (w - 32);
+      const uint16_t *const p = &src_ptr[i * src_stride + j];
+
+      // Even output pixels: windows at pixel offsets 0, 2, 4, 6.
+      s[0] = _mm512_loadu_si512((const __m512i *)(p + 0));
+      s[1] = _mm512_loadu_si512((const __m512i *)(p + 2));
+      s[2] = _mm512_loadu_si512((const __m512i *)(p + 4));
+      s[3] = _mm512_loadu_si512((const __m512i *)(p + 6));
+      __m512i res_even = convolve(s, coeffs_x);
+      res_even = _mm512_sra_epi32(_mm512_add_epi32(res_even, round_const_x),
+                                  round_shift_x);
+
+      // Odd output pixels: windows at pixel offsets 1, 3, 5, 7.
+      s[0] = _mm512_loadu_si512((const __m512i *)(p + 1));
+      s[1] = _mm512_loadu_si512((const __m512i *)(p + 3));
+      s[2] = _mm512_loadu_si512((const __m512i *)(p + 5));
+      s[3] = _mm512_loadu_si512((const __m512i *)(p + 7));
+      __m512i res_odd = convolve(s, coeffs_x);
+      res_odd = _mm512_sra_epi32(_mm512_add_epi32(res_odd, round_const_x),
+                                 round_shift_x);
+
+      res_even = _mm512_sra_epi32(_mm512_add_epi32(res_even, round_const_bits),
+                                  round_shift_bits);
+      res_odd = _mm512_sra_epi32(_mm512_add_epi32(res_odd, round_const_bits),
+                                 round_shift_bits);
+
+      const __m512i res_even1 = _mm512_packs_epi32(res_even, res_even);
+      const __m512i res_odd1 = _mm512_packs_epi32(res_odd, res_odd);
+      __m512i res = _mm512_unpacklo_epi16(res_even1, res_odd1);
+      res = _mm512_min_epi16(res, clip_pixel);
+      res = _mm512_max_epi16(res, zero);
+
+      _mm512_storeu_si512((__m512i *)&dst[i * dst_stride + j], res);
+    }
+  }
+}
+
+void av2_highbd_convolve_x_sr_avx512(const uint16_t *src, int src_stride,
+                                     uint16_t *dst, int dst_stride, int w,
+                                     int h,
+                                     const InterpFilterParams *filter_params_x,
+                                     const int subpel_x_qn,
+                                     ConvolveParams *conv_params, int bd) {
+  if (w >= 32) {
+    highbd_convolve_x_sr_avx512_loadonly(src, src_stride, dst, dst_stride, w, h,
+                                         filter_params_x, subpel_x_qn,
+                                         conv_params, bd);
+    return;
+  }
+  if (w > 8 && w <= 16) {
+    av2_highbd_convolve_x_sr_avx2(src, src_stride, dst, dst_stride, w, h,
+                                  filter_params_x, subpel_x_qn, conv_params,
+                                  bd);
+    return;
+  }
+  highbd_convolve_x_sr_avx512_shuffle(src, src_stride, dst, dst_stride, w, h,
+                                      filter_params_x, subpel_x_qn, conv_params,
+                                      bd);
+}

--- a/avm_dsp/x86/highbd_convolve_avx512.c
+++ b/avm_dsp/x86/highbd_convolve_avx512.c
@@ -17,9 +17,10 @@
 
 #include "avm_dsp/x86/convolve.h"
 #include "avm_dsp/x86/convolve_avx512.h"
+#include "avm_dsp/x86/highbd_convolve_x_sr.h"
 #include "avm_dsp/x86/synonyms.h"
 
-static void highbd_convolve_x_sr_avx512_shuffle(
+void highbd_convolve_x_sr_avx512_shuffle(
     const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
     int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
     ConvolveParams *conv_params, int bd) {
@@ -108,13 +109,21 @@ static void highbd_convolve_x_sr_avx512_shuffle(
 
   // Handle the tail rows.
   if (i < h) {
-    av2_highbd_convolve_x_sr_avx2(
-        src + i * src_stride, src_stride, dst + i * dst_stride, dst_stride, w,
-        h - i, filter_params_x, subpel_x_qn, conv_params, bd);
+    const uint16_t *const src_tail = src + i * src_stride;
+    uint16_t *const dst_tail = dst + i * dst_stride;
+    const int h_tail = h - i;
+    if (w >= 16)
+      highbd_convolve_x_sr_avx2_loadonly(src_tail, src_stride, dst_tail,
+                                         dst_stride, w, h_tail, filter_params_x,
+                                         subpel_x_qn, conv_params, bd);
+    else
+      highbd_convolve_x_sr_avx2_shuffle(src_tail, src_stride, dst_tail,
+                                        dst_stride, w, h_tail, filter_params_x,
+                                        subpel_x_qn, conv_params, bd);
   }
 }
 
-static void highbd_convolve_x_sr_avx512_loadonly(
+void highbd_convolve_x_sr_avx512_loadonly(
     const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
     int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
     ConvolveParams *conv_params, int bd) {
@@ -179,33 +188,4 @@ static void highbd_convolve_x_sr_avx512_loadonly(
       _mm512_storeu_si512((__m512i *)&dst[i * dst_stride + j], res);
     }
   }
-}
-
-void av2_highbd_convolve_x_sr_avx512(const uint16_t *src, int src_stride,
-                                     uint16_t *dst, int dst_stride, int w,
-                                     int h,
-                                     const InterpFilterParams *filter_params_x,
-                                     const int subpel_x_qn,
-                                     ConvolveParams *conv_params, int bd) {
-  if (w >= 32) {
-    highbd_convolve_x_sr_avx512_loadonly(src, src_stride, dst, dst_stride, w, h,
-                                         filter_params_x, subpel_x_qn,
-                                         conv_params, bd);
-    return;
-  }
-  if (w <= 8 && h <= 4) {
-    av2_highbd_convolve_x_sr_avx2(src, src_stride, dst, dst_stride, w, h,
-                                  filter_params_x, subpel_x_qn, conv_params,
-                                  bd);
-    return;
-  }
-  if (w == 16) {
-    av2_highbd_convolve_x_sr_avx2(src, src_stride, dst, dst_stride, w, h,
-                                  filter_params_x, subpel_x_qn, conv_params,
-                                  bd);
-    return;
-  }
-  highbd_convolve_x_sr_avx512_shuffle(src, src_stride, dst, dst_stride, w, h,
-                                      filter_params_x, subpel_x_qn, conv_params,
-                                      bd);
 }

--- a/avm_dsp/x86/highbd_convolve_x_sr.h
+++ b/avm_dsp/x86/highbd_convolve_x_sr.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+#ifndef AVM_AVM_DSP_X86_HIGHBD_CONVOLVE_X_SR_H_
+#define AVM_AVM_DSP_X86_HIGHBD_CONVOLVE_X_SR_H_
+
+#include "av2/common/convolve.h"
+
+void highbd_convolve_x_sr_avx2_shuffle(
+    const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
+    int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
+    ConvolveParams *conv_params, int bd);
+
+void highbd_convolve_x_sr_avx2_loadonly(
+    const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
+    int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
+    ConvolveParams *conv_params, int bd);
+
+void highbd_convolve_x_sr_avx512_shuffle(
+    const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
+    int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
+    ConvolveParams *conv_params, int bd);
+
+void highbd_convolve_x_sr_avx512_loadonly(
+    const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
+    int h, const InterpFilterParams *filter_params_x, const int subpel_x_qn,
+    ConvolveParams *conv_params, int bd);
+
+#endif  // AVM_AVM_DSP_X86_HIGHBD_CONVOLVE_X_SR_H_

--- a/avm_dsp/x86/highbd_convolve_x_sr_avx512_dispatch.c
+++ b/avm_dsp/x86/highbd_convolve_x_sr_avx512_dispatch.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+/* This selector has no ISA-specific instructions and is compiled without
+ * AVX2/AVX512 flags. Kernels stay in their respective ISA-specific files. */
+#include "config/avm_config.h"
+
+#if HAVE_AVX512
+
+#include "avm_dsp/x86/highbd_convolve_x_sr.h"
+
+void av2_highbd_convolve_x_sr_avx512(const uint16_t *src, int src_stride,
+                                     uint16_t *dst, int dst_stride, int w,
+                                     int h,
+                                     const InterpFilterParams *filter_params_x,
+                                     const int subpel_x_qn,
+                                     ConvolveParams *conv_params, int bd) {
+  /* Kernel pick (speed-test winners, not a completeness table of every (w,h)):
+   *   w <= 8 and h <= 4  -> AVX2 shuffle
+   *   w == 16            -> AVX2 load-only
+   *   w >= 32            -> AVX-512 load-only
+   *   everything else    -> AVX-512 shuffle
+   *     (w <= 8 and h > 4; also 9 <= w <= 31 except 16)
+   */
+  if (w <= 8 && h <= 4) {
+    highbd_convolve_x_sr_avx2_shuffle(src, src_stride, dst, dst_stride, w, h,
+                                      filter_params_x, subpel_x_qn, conv_params,
+                                      bd);
+  } else if (w == 16) {
+    highbd_convolve_x_sr_avx2_loadonly(src, src_stride, dst, dst_stride, w, h,
+                                       filter_params_x, subpel_x_qn,
+                                       conv_params, bd);
+  } else if (w >= 32) {
+    highbd_convolve_x_sr_avx512_loadonly(src, src_stride, dst, dst_stride, w, h,
+                                         filter_params_x, subpel_x_qn,
+                                         conv_params, bd);
+  } else {
+    highbd_convolve_x_sr_avx512_shuffle(src, src_stride, dst, dst_stride, w, h,
+                                        filter_params_x, subpel_x_qn,
+                                        conv_params, bd);
+  }
+}
+
+#endif  // HAVE_AVX512

--- a/test/av2_convolve_test.cc
+++ b/test/av2_convolve_test.cc
@@ -117,6 +117,14 @@ std::vector<TestParam<T>> GetTestParams(std::initializer_list<int> bit_depths,
     }
   }
   sizes.insert(BlockSize(24, 24));
+  // AV2 extended partition sizes seen in convolve histograms (not in BLOCK_SIZE
+  // enum).
+  sizes.insert(BlockSize(12, 12));
+  sizes.insert(BlockSize(12, 20));
+  sizes.insert(BlockSize(16, 24));
+  sizes.insert(BlockSize(20, 12));
+  sizes.insert(BlockSize(20, 20));
+  sizes.insert(BlockSize(24, 16));
   std::vector<TestParam<T>> result;
   for (const BlockSize &block : sizes) {
     for (int bd : bit_depths) {
@@ -142,7 +150,7 @@ template <typename T>
 
 TEST_F(AV2ConvolveParametersTest, GetHighbdTestParams) {
   auto v = GetHighbdTestParams(av2_highbd_convolve_x_sr_c);
-  ASSERT_EQ(74U, v.size());
+  ASSERT_EQ(86U, v.size());
   int num_10 = 0;
   int num_12 = 0;
   for (const auto &p : v) {
@@ -348,6 +356,8 @@ class AV2ConvolveXHighbdTest : public AV2ConvolveTest<highbd_convolve_x_func> {
     }
   }
 
+  void SpeedTest() { TestConvolveSpeed(EIGHTTAP_REGULAR, 8, 20000); }
+
  private:
   void TestConvolve(const int sub_x, const InterpFilter filter) {
     const int width = GetParam().Block().Width();
@@ -370,9 +380,48 @@ class AV2ConvolveXHighbdTest : public AV2ConvolveTest<highbd_convolve_x_func> {
                               filter_params_x, sub_x, &conv_params2, bit_depth);
     AssertOutputBufferEq(reference, test, width, height);
   }
+
+  void TestConvolveSpeed(const InterpFilter filter, const int sub_x,
+                         const int num_iters) {
+    const int width = GetParam().Block().Width();
+    const int height = GetParam().Block().Height();
+    const int bit_depth = GetParam().BitDepth();
+    const InterpFilterParams *filter_params_x =
+        av2_get_interp_filter_params_with_block_size(filter, width);
+    const uint16_t *input = FirstRandomInput12(GetParam());
+    DECLARE_ALIGNED(32, uint16_t, reference[MAX_SB_SQUARE]);
+    DECLARE_ALIGNED(32, uint16_t, test[MAX_SB_SQUARE]);
+
+    ConvolveParams conv_params1 =
+        get_conv_params_no_round(0, 0, nullptr, 0, 0, bit_depth);
+    avm_usec_timer timer;
+    avm_usec_timer_start(&timer);
+    for (int i = 0; i < num_iters; ++i) {
+      av2_highbd_convolve_x_sr_c(input, width, reference, kOutputStride, width,
+                                 height, filter_params_x, sub_x, &conv_params1,
+                                 bit_depth);
+    }
+    avm_usec_timer_mark(&timer);
+    const int time1 = static_cast<int>(avm_usec_timer_elapsed(&timer));
+
+    ConvolveParams conv_params2 =
+        get_conv_params_no_round(0, 0, nullptr, 0, 0, bit_depth);
+    avm_usec_timer_start(&timer);
+    for (int i = 0; i < num_iters; ++i) {
+      GetParam().TestFunction()(input, width, test, kOutputStride, width,
+                                height, filter_params_x, sub_x, &conv_params2,
+                                bit_depth);
+    }
+    avm_usec_timer_mark(&timer);
+    const int time2 = static_cast<int>(avm_usec_timer_elapsed(&timer));
+
+    printf("f%d %3dx%-3d bd: %d ref: %d mod: %d (%3.2f)\n", filter, width,
+           height, bit_depth, time1, time2, (double)time1 / time2);
+  }
 };
 
 TEST_P(AV2ConvolveXHighbdTest, RunTest) { RunTest(); }
+TEST_P(AV2ConvolveXHighbdTest, DISABLED_Speed) { SpeedTest(); }
 
 INSTANTIATE_TEST_SUITE_P(C, AV2ConvolveXHighbdTest,
                          BuildHighbdParams(av2_highbd_convolve_x_sr_c));

--- a/test/av2_convolve_test.cc
+++ b/test/av2_convolve_test.cc
@@ -440,6 +440,10 @@ INSTANTIATE_TEST_SUITE_P(AVX2, AV2ConvolveXHighbdTest,
 INSTANTIATE_TEST_SUITE_P(NEON, AV2ConvolveXHighbdTest,
                          BuildHighbdParams(av2_highbd_convolve_x_sr_neon));
 #endif
+#if HAVE_AVX512
+INSTANTIATE_TEST_SUITE_P(AVX512, AV2ConvolveXHighbdTest,
+                         BuildHighbdParams(av2_highbd_convolve_x_sr_avx512));
+#endif
 
 /////////////////////////////////////////////////////////
 // Single reference convolve-y functions (high bit-depth)


### PR DESCRIPTION
1. Optimized AVX2 load-only path for wide blocks.
2.  AVX-512 shuffle path for narrow blocks and load-only path for w >= 32.
3. Falls back to AVX2 for unsupported block shapes/tail rows.
4. Extends correctness coverage with AV2 partition sizes.
5. Adds disabled convolution microbenchmark.
6. Extended microbenchmark with AVX512 benchmark


Baseline Commit : 2128e7e90
Benchmark environment: AMD Turin, fixed core.
 Geomean speedup vs prior AVX2, by width and bit depth (>1 = faster):

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/chrjacob/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/chrjacob/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{vertical-align:middle;
	white-space:normal;}
.xl64
	{mso-number-format:0;
	text-align:right;
	vertical-align:middle;}
.xl65
	{mso-number-format:"0\.000\0022x\0022";
	text-align:right;
	vertical-align:middle;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


Width | Bit depth | Geomean speedup | Number of samples
-- | -- | -- | --
2 | 10 | 1.011x | 4
2 | 12 | 1.026x | 4
4 | 10 | 1.112x | 5
4 | 12 | 1.113x | 5
8 | 10 | 1.171x | 6
8 | 12 | 1.179x | 6
12 | 10 | 1.478x | 2
12 | 12 | 1.485x | 2
16 | 10 | 1.362x | 7
16 | 12 | 1.362x | 7
20 | 10 | 1.476x | 2
20 | 12 | 1.474x | 2
24 | 10 | 1.472x | 2
24 | 12 | 1.476x | 2
32 | 10 | 2.125x | 5
32 | 12 | 2.131x | 5
64 | 10 | 2.544x | 5
64 | 12 | 2.522x | 5
128 | 10 | 2.511x | 3
128 | 12 | 2.504x | 3
256 | 10 | 2.556x | 2
256 | 12 | 2.559x | 2



</body>

</html>

** CTC Run **
---------
 A4/A5 33f RA CTC cpu-used=1
On turin dense, machine with aocc-5.2
Benchmarking commit (baseline): https://github.com/AOMediaCodec/avm/commit/2128e7e902de7748c0ff8390f08a6b33a0940f1a
A5 -- 0.5% gain
A4 -- no impact

