### PR TITLE
unused var: Remove few unused fields/structs from av2 encoder

### DIFF
--- a/av2/common/blockd.h
+++ b/av2/common/blockd.h
@@ -393,7 +393,6 @@ typedef struct TXB_POS_INFO {
   int n_partitions;                   // number of txfm partitions
 } TXB_POS_INFO;
 
-#define INTER_TX_SIZE_BUF_LEN 64
 #define TXK_TYPE_BUF_LEN 64
 #define TX_PARTITION_BUF 16
 /*!\endcond */

--- a/av2/encoder/av2_quantize.h
+++ b/av2/encoder/av2_quantize.h
@@ -28,7 +28,6 @@ extern "C" {
 
 typedef struct QUANT_PARAM {
   int log_scale;
-  TX_SIZE tx_size;
   const qm_val_t *qmatrix;
   const qm_val_t *iqmatrix;
   int use_quant_b_adapt;

--- a/av2/encoder/block.h
+++ b/av2/encoder/block.h
@@ -234,28 +234,16 @@ typedef struct LV_MAP_COEFF_COST {
   //! Quick access to precomputed base costs for optimized access.
   //! Cost for encoding coeff_base Y zero coeff.
   int32_t base_cost_zero[TCQ_CTXS][SIG_COEF_CONTEXTS];
-  //! Cost for encoding coeff_base UV zero coeff.
-  int32_t base_cost_uv_zero[SIG_COEF_CONTEXTS];
   //! Cost for encoding coeff base + mid Y values.
   uint16_t base_cost_low_tbl[5][SIG_COEF_CONTEXTS][TCQ_CTXS][2];
-  //! Cost for encoding coeff base + mid UV values.
-  uint16_t base_cost_uv_low_tbl[5][SIG_COEF_CONTEXTS][2];
   //! Cost for encoding coeff_base Y zero value (LF region).
   uint16_t base_lf_cost_zero[TCQ_CTXS][LF_SIG_COEF_CONTEXTS];
-  //! Cost for encoding coeff_base UV zero value (LF region).
-  uint16_t base_lf_cost_uv_zero[LF_SIG_COEF_CONTEXTS];
   //! Cost for encoding coeff base + mid Y values (LF region).
   uint16_t base_lf_cost_low_tbl[9][LF_SIG_COEF_CONTEXTS][TCQ_CTXS][2];
-  //! Cost for encoding coeff base + mid UV values (LF region).
-  uint16_t base_lf_cost_uv_low_tbl[9][LF_SIG_COEF_CONTEXTS][2];
   //! Cost for encoding eob position.
   uint16_t base_eob_cost_tbl[5][SIG_COEF_CONTEXTS_EOB][2];
-  //! Cost for encoding eob position (UV).
-  uint16_t base_eob_cost_uv_tbl[5][SIG_COEF_CONTEXTS_EOB][2];
   //! Cost for encoding eob position (LF region).
   uint16_t base_lf_eob_cost_tbl[9][SIG_COEF_CONTEXTS_EOB][2];
-  //! Cost for encoding eob position (YV, LF region).
-  uint16_t base_lf_eob_cost_uv_tbl[9][SIG_COEF_CONTEXTS_EOB][2];
   //! Quick access to mid (br) costs for optimized access.
   uint16_t mid_cost_tbl[11][LEVEL_CONTEXTS][TCQ_CTXS][2];
   //! Quick access to mid (br) costs for optimized access (LF region).
@@ -370,16 +358,12 @@ typedef struct {
 typedef struct {
   //! Txfm size used if the current mode is intra mode.
   TX_SIZE tx_size;
-  //! Txfm sizes used if the current mode is inter mode.
-  TX_SIZE inter_tx_size[INTER_TX_SIZE_BUF_LEN];
   //! Txfm partitions used if the current mode is inter mode.
   TX_PARTITION_TYPE tx_partition_type[TX_PARTITION_BUF];
   //! Map showing which txfm block skips the txfm process.
   uint8_t blk_skip[MAX_MIB_SIZE * MAX_MIB_SIZE];
   //! Map showing the txfm types for each blcok.
   TX_TYPE tx_type_map[MAX_MIB_SIZE * MAX_MIB_SIZE];
-  //! Map showing the cctx types for each block.
-  CctxType cctx_type_map[MAX_MIB_SIZE * MAX_MIB_SIZE];
   //! Rd_stats for the whole partition block.
   RD_STATS rd_stats;
   //! Hash value of the current record.
@@ -391,53 +375,13 @@ typedef struct {
 typedef struct {
   //! Circular buffer that stores the txfm search results.
   MB_RD_INFO tx_rd_info[RD_RECORD_BUFFER_LEN];  // Circular buffer.
-  //! Index to insert the newest \ref TXB_RD_INFO.
+  //! Index to insert the newest \ref MB_RD_INFO.
   int index_start;
   //! Number of info stored in this record.
   int num;
   //! Hash function
   CRC32C crc_calculator;
 } MB_RD_RECORD;
-
-/*! \brief Txfm search results for a tx block.
- */
-typedef struct {
-  //! Distortion after the txfm process
-  int64_t dist;
-  //! SSE of the prediction before the txfm process
-  int64_t sse;
-  //! Rate used to encode the txfm.
-  int rate;
-  //! Location of the end of non-zero entries.
-  uint16_t eob;
-  //! Location of the first of non-zero entries.
-  uint16_t bob;
-  //! Transform type used on the current block.
-  TX_TYPE tx_type;
-  //! Unknown usage
-  uint16_t entropy_context;
-  //! Context used to code the coefficients.
-  uint8_t txb_entropy_ctx;
-  //! Whether the current info block contains  valid info
-  uint8_t valid;
-  //! Unused
-  uint8_t fast;
-  //! Whether trellis optimization is done.
-  uint8_t perform_block_coeff_opt;
-} TXB_RD_INFO;
-
-/*! \brief Hash records of txfm search result for each tx block.
- */
-typedef struct {
-  //! The hash values.
-  uint32_t hash_vals[TX_SIZE_RD_RECORD_BUFFER_LEN];
-  //! The txfm search results
-  TXB_RD_INFO tx_rd_info[TX_SIZE_RD_RECORD_BUFFER_LEN];
-  //! Index to insert the newest \ref TXB_RD_INFO.
-  int index_start;
-  //! Number of info stored in this record.
-  int num;
-} TXB_RD_RECORD;
 
 //! Number of compound rd stats
 #define MAX_COMP_RD_STATS 64
@@ -555,7 +499,6 @@ typedef struct {
 /*! \brief Contains data for simple motion
  */
 typedef struct SimpleMotionData {
-  MV mv_ref;                         /*!< mv reference */
   MV fullmv;                         /*!< mv full */
   MV submv;                          /*!< mv subpel */
   unsigned int sse;                  /*!< sse */
@@ -647,12 +590,6 @@ typedef struct SimpleMotionDataBufs {
   MAKE_SM_DATA_BUF(64, 8, 0);
   MAKE_SM_DATA_BUF(32, 4, 0);
 
-  // 1:16 blocks
-  MAKE_SM_DATA_BUF(4, 64, 0);
-
-  // 16:1 blocks
-  MAKE_SM_DATA_BUF(64, 4, 0);
-
   // Square blocks
   MAKE_SM_DATA_BUF(256, 256, 1);
   MAKE_SM_DATA_BUF(128, 128, 1);
@@ -695,12 +632,6 @@ typedef struct SimpleMotionDataBufs {
   // 8:1 blocks
   MAKE_SM_DATA_BUF(64, 8, 1);
   MAKE_SM_DATA_BUF(32, 4, 1);
-
-  // 1:16 blocks
-  MAKE_SM_DATA_BUF(4, 64, 1);
-
-  // 16:1 blocks
-  MAKE_SM_DATA_BUF(64, 4, 1);
   /*!\endcond */
 } SimpleMotionDataBufs;
 
@@ -723,21 +654,6 @@ typedef struct {
   float cnn_buffer[CNN_OUT_BUF_SIZE];
   //! log of the quantization parameter of the ancestor BLOCK_64X64.
   float log_q;
-
-  /*! \brief Variance of the subblocks in the superblock.
-   *
-   * This is used by rt mode for variance based partitioning.
-   * The indices corresponds to the following block sizes:
-   * -   0    - 128x128
-   * -  1-2   - 128x64
-   * -  3-4   -  64x128
-   * -  5-8   -  64x64
-   * -  9-16  -  64x32
-   * - 17-24  -  32x64
-   * - 25-40  -  32x32
-   * - 41-104 -  16x16
-   */
-  uint8_t variance_low[105];
 } PartitionSearchInfo;
 
 /*! \brief Defines the parameters used to perform txfm search.
@@ -804,13 +720,6 @@ typedef struct {
   int eval_mode_type;
 } TxfmSearchParams;
 
-/*!\cond */
-#define MAX_NUM_8X8_TXBS ((MAX_MIB_SIZE >> 1) * (MAX_MIB_SIZE >> 1))
-#define MAX_NUM_16X16_TXBS ((MAX_MIB_SIZE >> 2) * (MAX_MIB_SIZE >> 2))
-#define MAX_NUM_32X32_TXBS ((MAX_MIB_SIZE >> 3) * (MAX_MIB_SIZE >> 3))
-#define MAX_NUM_64X64_TXBS ((MAX_MIB_SIZE >> 4) * (MAX_MIB_SIZE >> 4))
-/*!\endcond */
-
 /*! \brief Stores various encoding/search decisions related to txfm search.
  *
  * This struct contains a cache of previous txfm results, and some buffers for
@@ -851,25 +760,9 @@ typedef struct {
    * - MB_RD_RECORD: records a whole *partition block*'s inter-mode txfm result.
    *   Since this operates on the partition block level, this can give us a
    *   whole txfm partition tree.
-   * - TXB_RD_RECORD: records a txfm search result within a transform blcok
-   *   itself. This operates on txb level only and onlyt appplies to square
-   *   txfms.
    */
-  /**@{*/
   //! Txfm hash record for the whole coding block.
   MB_RD_RECORD mb_rd_record;
-
-  //! Inter mode txfm hash record for TX_8X8 blocks.
-  TXB_RD_RECORD txb_rd_record_8X8[MAX_NUM_8X8_TXBS];
-  //! Inter mode txfm hash record for TX_16X16 blocks.
-  TXB_RD_RECORD txb_rd_record_16X16[MAX_NUM_16X16_TXBS];
-  //! Inter mode txfm hash record for TX_32X32 blocks.
-  TXB_RD_RECORD txb_rd_record_32X32[MAX_NUM_32X32_TXBS];
-  //! Inter mode txfm hash record for TX_64X64 blocks.
-  TXB_RD_RECORD txb_rd_record_64X64[MAX_NUM_64X64_TXBS];
-  //! Intra mode txfm hash record for square tx blocks.
-  TXB_RD_RECORD txb_rd_record_intra;
-  /**@}*/
 
   /*! \brief Number of txb splits.
    *
@@ -887,10 +780,6 @@ typedef struct {
   unsigned int tx_search_count;
 #endif  // CONFIG_SPEED_STATS
 } TxfmSearchInfo;
-#undef MAX_NUM_8X8_TXBS
-#undef MAX_NUM_16X16_TXBS
-#undef MAX_NUM_32X32_TXBS
-#undef MAX_NUM_64X64_TXBS
 
 /*! \brief Holds the entropy costs for various modes sent to the bitstream.
  *
@@ -924,15 +813,10 @@ typedef struct {
   /**@{*/
   //! Luma mode cost for inter frame.
   int mbmode_cost[BLOCK_SIZE_GROUPS][INTRA_MODES];
-  //! Luma mode cost for intra frame.
-  int y_mode_costs[INTRA_MODES][INTRA_MODES][INTRA_MODES];
   //! intra_dip_cost
   int intra_dip_cost[DIP_CTXS][2];
   //! intra_dip_mode_cost
   int intra_dip_mode_cost[16];
-  //! angle_delta_cost
-  int angle_delta_cost[PARTITION_STRUCTURE_NUM][DIRECTIONAL_MODES]
-                      [2 * MAX_ANGLE_DELTA + 1];
 
   //! mrl_index_cost
   int mrl_index_cost[MRL_INDEX_CONTEXTS][MRL_LINE_NUMBER];
@@ -944,8 +828,6 @@ typedef struct {
   int cfl_mhccp_cost[CFL_MHCCP_SWITCH_NUM];
   //! Cost of signaling the cfl mode
   int cfl_index_cost[CFL_TYPE_COUNT - 1];
-  //! Cost of signaling the cfl mode when mhccp is not applicable
-  int cfl_index_mhccp0_cost[CFL_TYPE_COUNT - 2];
   //! cost of signaling filter direction
   int filter_dir_cost[MHCCP_CONTEXT_GROUP_SIZE][MHCCP_MODE_NUM];
 
@@ -981,8 +863,6 @@ typedef struct {
   int intrabc_cost[INTRABC_CONTEXTS][2];
   //! intrabc_mode_cost
   int intrabc_mode_cost[2];
-  //! intrabc_drl_idx_cost
-  int intrabc_drl_idx_cost[MAX_REF_BV_STACK_SIZE - 1][2];
   //! intrabc_bv_precision_cost
   int intrabc_bv_precision_cost[NUM_BV_PRECISION_CONTEXTS]
                                [NUM_ALLOWED_BV_PRECISIONS];
@@ -1460,8 +1340,8 @@ typedef struct macroblock {
 
   //! The rate needed to encode a new block vector to the bitstream and some
   //! multipliers for motion search.
-
   IntraBCMvCosts dv_costs;
+
   //! The rate needed to signal the txfm coefficients to the bitstream.
   CoeffCosts coeff_costs;
   /**@}*/
@@ -1539,14 +1419,6 @@ typedef struct macroblock {
    * \name Prediction Mode Search
    ****************************************************************************/
   /**@{*/
-  /*! \brief Inter skip mode.
-   *
-   * Skip mode tries to use the closest forward and backward references for
-   * inter prediction. Skip here means to skip transmitting the reference
-   * frames, not to be confused with skip_txfm.
-   */
-  int skip_mode;
-
   /*! \brief Factors used for rd-thresholding.
    *
    * Determines a rd threshold to determine whether to continue searching the

--- a/av2/encoder/context_tree.c
+++ b/av2/encoder/context_tree.c
@@ -143,8 +143,6 @@ PICK_MODE_CONTEXT *av2_alloc_pmc(const AV2_COMMON *cm, TREE_TYPE tree_type,
 
   AVM_CHECK_MEM_ERROR(&error, ctx, avm_calloc(1, sizeof(*ctx)));
   ctx->rd_mode_is_ready = 0;
-  ctx->parent = parent;
-  ctx->index = index;
   set_chroma_ref_info(tree_type, mi_row, mi_col, index, bsize,
                       &ctx->chroma_ref_info,
                       parent ? &parent->chroma_ref_info : NULL,

--- a/av2/encoder/context_tree.h
+++ b/av2/encoder/context_tree.h
@@ -62,8 +62,6 @@ typedef struct PICK_MODE_CONTEXT {
   int rd_mode_is_ready;  // Flag to indicate whether rd pick mode decision has
                          // been made.
   CHROMA_REF_INFO chroma_ref_info;
-  struct PC_TREE *parent;
-  int index;
 } PICK_MODE_CONTEXT;
 
 typedef struct PC_TREE {

--- a/av2/encoder/encodeframe.c
+++ b/av2/encoder/encodeframe.c
@@ -465,7 +465,7 @@ static INLINE void init_encode_rd_sb(AV2_COMP *cpi, ThreadData *td,
   }
 
   // Reset hash state for transform/mode rd hash information
-  reset_hash_records(&x->txfm_search_info, cpi->sf.tx_sf.use_inter_txb_hash);
+  reset_hash_records(&x->txfm_search_info);
   av2_zero(x->picked_ref_frames_mask);
   av2_invalid_rd_stats(rd_cost);
   if (sf->part_sf.partition_search_type != VAR_BASED_PARTITION &&
@@ -546,7 +546,7 @@ static AVM_INLINE void perform_one_partition_pass(
         (intra_sdp_enabled && xd->tree_type == CHROMA_PART) ? tp_chroma : tp,
         mi_row, mi_col, sb_size, PARTITION_NONE, &dummy_rdc, dummy_rdc, pc_root,
         xd->tree_type == CHROMA_PART ? xd->sbi->ptree_root[0] : NULL,
-        template_tree, INT_MAX, sms_root, NULL, multi_pass_mode, NULL
+        template_tree, INT_MAX, sms_root, NULL, multi_pass_mode
 #if CONFIG_ML_PART_SPLIT
         ,
         force_prune_flags
@@ -1709,9 +1709,6 @@ static AVM_INLINE void set_rel_frame_dist(
     const AV2_COMMON *const cm, RefFrameDistanceInfo *const ref_frame_dist_info,
     const int ref_frame_flags) {
   MV_REFERENCE_FRAME ref_frame;
-  int min_past_dist = INT32_MAX, min_future_dist = INT32_MAX;
-  ref_frame_dist_info->nearest_past_ref = NONE_FRAME;
-  ref_frame_dist_info->nearest_future_ref = NONE_FRAME;
   for (ref_frame = 0; ref_frame < INTER_REFS_PER_FRAME; ++ref_frame) {
     ref_frame_dist_info->ref_relative_dist[ref_frame] = 0;
     if (ref_frame_flags & (1 << ref_frame)) {
@@ -1720,16 +1717,6 @@ static AVM_INLINE void set_rel_frame_dist(
           cm->cur_frame->ref_display_order_hint[ref_frame],
           cm->current_frame.display_order_hint);
       ref_frame_dist_info->ref_relative_dist[ref_frame] = dist;
-      // Get the nearest ref_frame in the past
-      if (abs(dist) < min_past_dist && dist < 0) {
-        ref_frame_dist_info->nearest_past_ref = ref_frame;
-        min_past_dist = abs(dist);
-      }
-      // Get the nearest ref_frame in the future
-      if (dist < min_future_dist && dist > 0) {
-        ref_frame_dist_info->nearest_future_ref = ref_frame;
-        min_future_dist = dist;
-      }
     }
   }
 }

--- a/av2/encoder/encodeframe_utils.h
+++ b/av2/encoder/encodeframe_utils.h
@@ -31,16 +31,6 @@ typedef struct {
   ENTROPY_CONTEXT l[MAX_MIB_SIZE * MAX_MB_PLANE];
   PARTITION_CONTEXT sa[MAX_MIB_SIZE * MAX_MB_PLANE];
   PARTITION_CONTEXT sl[MAX_MIB_SIZE * MAX_MB_PLANE];
-
-  //! The current level bank, used to restore the level bank in MACROBLOCKD.
-  REF_MV_BANK curr_level_bank;
-  //! The best level bank from the rdopt process.
-  REF_MV_BANK best_level_bank;
-  //! The current warp, level bank, used to restore the warp level bank in
-  //! MACROBLOCKD.
-  WARP_PARAM_BANK curr_level_warp_bank;
-  //! The best warp level bank from the rdopt process.
-  WARP_PARAM_BANK best_level_warp_bank;
 } RD_SEARCH_MACROBLOCK_CONTEXT;
 
 // This struct is used to store the statistics used by sb-level multi-pass
@@ -122,9 +112,6 @@ typedef struct PartitionSearchState {
 
   // Parameters related to partition block size.
   PartitionBlkParams part_blk_params;
-
-  // Win flags for HORZ and VERT partition evaluations.
-  RD_RECT_PART_WIN_INFO split_part_rect_win[SUB_PARTITIONS_SPLIT];
 
   // RD cost for the current block of given partition type.
   RD_STATS this_rdc;

--- a/av2/encoder/encodemb.c
+++ b/av2/encoder/encodemb.c
@@ -817,7 +817,6 @@ void av2_setup_xform(const AV2_COMMON *cm, MACROBLOCK *x, int plane,
 void av2_setup_quant(TX_SIZE tx_size, int use_optimize_b, int xform_quant_idx,
                      int use_quant_b_adapt, QUANT_PARAM *qparam) {
   qparam->log_scale = av2_get_tx_scale(tx_size);
-  qparam->tx_size = tx_size;
 
   qparam->use_quant_b_adapt = use_quant_b_adapt;
 
@@ -1258,8 +1257,8 @@ void av2_encode_sb(const struct AV2_COMP *cpi, MACROBLOCK *x, BLOCK_SIZE bsize,
 
   struct optimize_ctx ctx;
   struct encode_b_args arg = {
-    cpi,  x,    &ctx,    &mbmi->skip_txfm[xd->tree_type == CHROMA_PART],
-    NULL, NULL, dry_run, cpi->optimize_seg_arr[mbmi->segment_id]
+    cpi,  x,       &mbmi->skip_txfm[xd->tree_type == CHROMA_PART], NULL,
+    NULL, dry_run, cpi->optimize_seg_arr[mbmi->segment_id]
   };
 
   for (int plane = plane_start; plane < plane_end; ++plane) {
@@ -1575,8 +1574,8 @@ void av2_encode_intra_block_plane(const struct AV2_COMP *cpi, MACROBLOCK *x,
   ENTROPY_CONTEXT tl[MAX_MIB_SIZE] = { 0 };
   int8_t *skip_txfm = &(xd->mi[0]->skip_txfm[xd->tree_type == CHROMA_PART]);
 
-  struct encode_b_args arg = { cpi, x,  NULL,    skip_txfm,
-                               ta,  tl, dry_run, enable_optimize_b };
+  struct encode_b_args arg = { cpi, x,       skip_txfm,        ta,
+                               tl,  dry_run, enable_optimize_b };
   const BLOCK_SIZE plane_bsize =
       get_mb_plane_block_size(xd, xd->mi[0], plane, ss_x, ss_y);
   (void)bsize;
@@ -1851,8 +1850,13 @@ void av2_encode_intra_block_joint_uv(const struct AV2_COMP *cpi, MACROBLOCK *x,
   ENTROPY_CONTEXT ta[MAX_MIB_SIZE * 2] = { 0 };
   ENTROPY_CONTEXT tl[MAX_MIB_SIZE * 2] = { 0 };
   struct encode_b_args arg = {
-    cpi, x,  NULL,    &(xd->mi[0]->skip_txfm[xd->tree_type == CHROMA_PART]),
-    ta,  tl, dry_run, enable_optimize_b
+    cpi,
+    x,
+    &(xd->mi[0]->skip_txfm[xd->tree_type == CHROMA_PART]),
+    ta,
+    tl,
+    dry_run,
+    enable_optimize_b
   };
   const BLOCK_SIZE plane_bsize =
       get_mb_plane_block_size(xd, xd->mi[0], AVM_PLANE_U, ss_x, ss_y);

--- a/av2/encoder/encodemb.h
+++ b/av2/encoder/encodemb.h
@@ -56,7 +56,6 @@ struct optimize_ctx {
 struct encode_b_args {
   const struct AV2_COMP *cpi;
   MACROBLOCK *x;
-  struct optimize_ctx *ctx;
   int8_t *skip;
   ENTROPY_CONTEXT *ta;
   ENTROPY_CONTEXT *tl;

--- a/av2/encoder/encoder.h
+++ b/av2/encoder/encoder.h
@@ -872,8 +872,6 @@ typedef struct {
   bool enable_joint_mvd;
   // Indicates if refineMV mode should be enabled.
   bool enable_refinemv;
-  // Indicates if cfl should be enabled.
-  bool enable_cfl_intra;
   // Indicates if mvd sign derivation should be enabled.
   bool enable_mvd_sign_derive;
   // enable temporal interpolated prediction
@@ -1210,9 +1208,6 @@ typedef struct AV2EncoderConfig {
 
   // Configuration related to layering information.
   LayerCfg layer_cfg;
-
-  // Number of operating points per OPS, in the range 0 to MAX_OPS_COUNT (7).
-  int operating_points_count;
 
   // Enable the low complexity decode mode.
   unsigned int enable_low_complexity_decode;
@@ -2165,14 +2160,6 @@ typedef struct {
    * True relative distance of reference frames w.r.t. the current frame.
    */
   int ref_relative_dist[INTER_REFS_PER_FRAME];
-  /*!
-   * The nearest reference w.r.t. current frame in the past.
-   */
-  int8_t nearest_past_ref;
-  /*!
-   * The nearest reference w.r.t. current frame in the future.
-   */
-  int8_t nearest_future_ref;
 } RefFrameDistanceInfo;
 
 /*!
@@ -2271,11 +2258,6 @@ typedef struct {
   ExtRefreshFrameFlagsInfo refresh_frame;
 
   /*!
-   * Flag to enable CDF initialization with cross frame contexts at the
-   * beginning of a frame decode.
-   */
-  bool cross_frame_context;
-  /*!
    * Flag to enable temporal MV prediction.
    */
   bool use_ref_frame_mvs;
@@ -2323,15 +2305,6 @@ typedef struct {
   // Whether the current struct contains valid data
   int valid;
 } MV_STATS;
-
-typedef struct {
-  struct loopfilter lf;
-  CdefInfo cdef_info;
-  YV12_BUFFER_CONFIG copy_buffer;
-  RATE_CONTROL rc;
-  MV_STATS mv_stats;
-  FeatureFlags features;
-} CODING_CONTEXT;
 
 typedef struct {
   int frame_width;
@@ -3193,7 +3166,6 @@ typedef struct EncodeFrameParams {
   FRAME_TYPE frame_type;
 
   /*!\cond */
-  int primary_ref_frame;
   int order_offset;
 
   /*!\endcond */

--- a/av2/encoder/firstpass.h
+++ b/av2/encoder/firstpass.h
@@ -185,7 +185,6 @@ typedef struct {
   // cpi->output_pkt_list[i].data.twopass_stats.buf points to actual data stored
   // here.
   FIRSTPASS_STATS *frame_stats_arr[MAX_LAP_BUFFERS + 1];
-  int frame_stats_next_idx;  // Index to next unused element in frame_stats_arr.
   const FIRSTPASS_STATS *stats_in;
   STATS_BUFFER_CTX *stats_buf_ctx;
   int first_pass_done;

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -3396,12 +3396,6 @@ static void init_partition_search_state_params(
     part_search_state->region_type_cost = x->mode_costs.region_type_cost[ctx];
   }
 
-  // Initialize HORZ and VERT win flags as true for all split partitions.
-  for (int i = 0; i < SUB_PARTITIONS_SPLIT; i++) {
-    part_search_state->split_part_rect_win[i].rect_part_win[HORZ] = true;
-    part_search_state->split_part_rect_win[i].rect_part_win[VERT] = true;
-  }
-
   // Initialize the rd cost.
   av2_init_rd_stats(&part_search_state->this_rdc);
 
@@ -3479,8 +3473,7 @@ static AVM_INLINE int rd_try_subblock_partition(
     AV2_COMP *const cpi, ThreadData *td, TileDataEnc *tile_data,
     TokenExtra **tp, RDO_PICK_SB_ARGS *rdo_args, RD_STATS *this_rdc,
     RD_STATS *sum_rdc, RD_STATS best_rdcost, int64_t *none_rd,
-    int max_recursion_depth, SB_MULTI_PASS_MODE multi_pass_mode,
-    RD_RECT_PART_WIN_INFO *rect_part_win_info, bool *skippable
+    int max_recursion_depth, SB_MULTI_PASS_MODE multi_pass_mode, bool *skippable
 #if CONFIG_ML_PART_SPLIT
     ,
     int force_prune_flags[MAX_PRUNE_TYPES]
@@ -3503,8 +3496,7 @@ static AVM_INLINE int rd_try_subblock_partition(
                              rdo_args->parent_partition, this_rdc,
                              rdcost_remaining, rdo_args->pc_tree,
                              rdo_args->ptree_luma, rdo_args->template_tree,
-                             max_recursion_depth, NULL, none_rd,
-                             multi_pass_mode, rect_part_win_info
+                             max_recursion_depth, NULL, none_rd, multi_pass_mode
 #if CONFIG_ML_PART_SPLIT
                              ,
                              force_prune_flags
@@ -3723,8 +3715,7 @@ static void rectangular_partition_search(
     PartitionSearchState *part_search_state, RD_STATS *best_rdc,
     SB_MULTI_PASS_MODE multi_pass_mode, const PARTITION_TREE *ptree_luma,
     const PARTITION_TREE *template_tree, int max_recursion_depth,
-    RD_RECT_PART_WIN_INFO *rect_part_win_info, LevelBanksRDO *level_banks,
-    PARTITION_TYPE parent_partition
+    LevelBanksRDO *level_banks, PARTITION_TYPE parent_partition
 #if CONFIG_ML_PART_SPLIT
     ,
     int next_force_prune_flags[NUM_RECT_PARTS][MAX_PRUNE_TYPES]
@@ -3829,7 +3820,7 @@ static void rectangular_partition_search(
       RD_STATS this_rdc;
       if (!rd_try_subblock_partition(
               cpi, td, tile_data, tp, &rdo_args, &this_rdc, sum_rdc, *best_rdc,
-              NULL, max_recursion_depth, multi_pass_mode, NULL, &skippable
+              NULL, max_recursion_depth, multi_pass_mode, &skippable
 #if CONFIG_ML_PART_SPLIT
               ,
               next_force_prune_flags[rect_type]
@@ -3848,10 +3839,6 @@ static void rectangular_partition_search(
       part_search_state->found_best_partition = true;
       pc_tree->partitioning = partition_type;
       pc_tree->skippable = skippable;
-    } else {
-      // Update HORZ / VERT win flag.
-      if (rect_part_win_info != NULL)
-        rect_part_win_info->rect_part_win[rect_type] = false;
     }
 #if CONFIG_COLLECT_PARTITION_STATS
     end_partition_block_timer(part_timing_stats, partition_type,
@@ -4430,8 +4417,7 @@ static void split_partition_search(
     if (!rd_try_subblock_partition(
             cpi, td, tile_data, tp, &rdo_args, &part_search_state->this_rdc,
             &sum_rdc, *best_rdc, &part_search_state->split_rd[sub_idx],
-            max_recursion_depth, multi_pass_mode,
-            &part_search_state->split_part_rect_win[sub_idx], &skippable
+            max_recursion_depth, multi_pass_mode, &skippable
 #if CONFIG_ML_PART_SPLIT
             ,
             force_prune_flags
@@ -4852,7 +4838,7 @@ static INLINE void search_intra_region_partitioning(
     if (!rd_try_subblock_partition(cpi, td, tile_data, tp, &rdo_args,
                                    &part_search_state->this_rdc, sum_rdc,
                                    *best_rdc, NULL, max_recursion_depth,
-                                   multi_pass_mode, NULL, &skippable
+                                   multi_pass_mode, &skippable
 #if CONFIG_ML_PART_SPLIT
                                    ,
                                    force_prune_flags
@@ -5242,7 +5228,7 @@ static void search_extended_partition(
     if (!rd_try_subblock_partition(cpi, td, tile_data, tp, &rdo_args,
                                    &search_state->this_rdc, &sum_rdc, *best_rdc,
                                    NULL, max_recursion_depth, multi_pass_mode,
-                                   NULL, &skippable
+                                   &skippable
 #if CONFIG_ML_PART_SPLIT
                                    ,
                                    force_prune_flags
@@ -5577,9 +5563,6 @@ static void prune_partitions_using_ml_results(
  * \param[in,out] none_rd             Pointer to the rd cost in the case of
  *                                    not splitting the current block
  * \param[in]     multi_pass_mode     SB_SINGLE_PASS/SB_DRY_PASS/SB_WET_PASS
- * \param[in,out] rect_part_win_info  Pointer to struct storing whether
- *                                    horz/vert partition outperforms
- *                                    previously tested partitions
  * \param[in]     force_prune_flags   Prune partitions based on ML results
  *                                    [Only if CONFIG_ML_PART_SPLIT is
  *                                    defined].
@@ -5596,8 +5579,7 @@ bool av2_rd_pick_partition(
     PC_TREE *pc_tree, const PARTITION_TREE *ptree_luma,
     const PARTITION_TREE *template_tree, const int max_recursion_depth,
     SIMPLE_MOTION_DATA_TREE *sms_tree, int64_t *none_rd,
-    const SB_MULTI_PASS_MODE multi_pass_mode,
-    RD_RECT_PART_WIN_INFO *rect_part_win_info
+    const SB_MULTI_PASS_MODE multi_pass_mode
 #if CONFIG_ML_PART_SPLIT
     ,
     int force_prune_flags[MAX_PRUNE_TYPES]
@@ -5900,7 +5882,7 @@ BEGIN_PARTITION_SEARCH:
   rectangular_partition_search(
       cpi, td, tile_data, tp, pc_tree, &x_ctx, &part_search_state, &best_rdc,
       multi_pass_mode, ptree_luma, template_tree, eff_max_recursion_depth - 1,
-      rect_part_win_info, &level_banks, parent_partition
+      &level_banks, parent_partition
 #if CONFIG_ML_PART_SPLIT
       ,
       next_force_prune_flags

--- a/av2/encoder/partition_search.h
+++ b/av2/encoder/partition_search.h
@@ -44,8 +44,7 @@ bool av2_rd_pick_partition(
     PC_TREE *pc_tree, const PARTITION_TREE *ptree_luma,
     const PARTITION_TREE *template_tree, const int max_recursion_depth,
     SIMPLE_MOTION_DATA_TREE *sms_tree, int64_t *none_rd,
-    const SB_MULTI_PASS_MODE multi_pass_mode,
-    RD_RECT_PART_WIN_INFO *rect_part_win_info
+    const SB_MULTI_PASS_MODE multi_pass_mode
 #if CONFIG_ML_PART_SPLIT
     ,
     int prune_rect_flags[3]

--- a/av2/encoder/partition_strategy.h
+++ b/av2/encoder/partition_strategy.h
@@ -41,11 +41,6 @@
 // Number of sub-partitions in split partition type.
 #define SUB_PARTITIONS_SPLIT 4
 
-// Structure to keep win flags for HORZ and VERT partition evaluations.
-typedef struct {
-  int rect_part_win[NUM_RECT_PARTS];
-} RD_RECT_PART_WIN_INFO;
-
 struct PartitionSearchState;
 
 void av2_intra_mode_cnn_partition(

--- a/av2/encoder/pass2_strategy.c
+++ b/av2/encoder/pass2_strategy.c
@@ -2746,7 +2746,6 @@ static void process_first_pass_stats(AV2_COMP *cpi,
         section_target_bandwidth, DEFAULT_GRP_WEIGHT);
 
     rc->active_worst_quality = tmp_q;
-    rc->ni_av_qi = tmp_q;
     rc->last_q[INTER_FRAME] = tmp_q;
     rc->avg_q = av2_convert_qindex_to_q(tmp_q, cm->seq_params.bit_depth);
     rc->avg_frame_qindex[INTER_FRAME] = tmp_q;

--- a/av2/encoder/pickrst.c
+++ b/av2/encoder/pickrst.c
@@ -112,7 +112,7 @@ typedef struct {
   // sse and bits are initialised by reset_rsc in search_rest_type
   int64_t sse;
   int64_t bits;
-  int tile_y0, tile_stripe0;
+  int tile_stripe0;
   // Helps convert tile-localized RU indices to frame RU indices.
   int ru_idx_base;
   // Number of RUs in tile

--- a/av2/encoder/ratectrl.c
+++ b/av2/encoder/ratectrl.c
@@ -321,20 +321,15 @@ void av2_rc_init(const AV2EncoderConfig *oxcf, int pass, RATE_CONTROL *rc) {
 
   rc->rolling_target_bits = rc->avg_frame_bandwidth;
   rc->rolling_actual_bits = rc->avg_frame_bandwidth;
-  rc->long_rolling_target_bits = rc->avg_frame_bandwidth;
-  rc->long_rolling_actual_bits = rc->avg_frame_bandwidth;
 
   rc->total_actual_bits = 0;
   rc->total_target_bits = 0;
-  rc->total_target_vs_actual = 0;
 
   rc->frames_since_key = 8;  // Sensible default for first frame.
   rc->this_key_frame_forced = 0;
   rc->next_key_frame_forced = 0;
 
   rc->frames_till_gf_update_due = 0;
-  rc->ni_av_qi = rc_cfg->worst_allowed_q;
-  rc->ni_tot_qi = 0;
   rc->ni_frames = 0;
 
   rc->tot_q = 0.0;
@@ -1780,10 +1775,6 @@ void av2_rc_postencode_update(AV2_COMP *cpi, uint64_t bytes_used) {
       rc->ni_frames++;
       rc->tot_q += av2_convert_qindex_to_q(qindex, cm->seq_params.bit_depth);
       rc->avg_q = rc->tot_q / rc->ni_frames;
-      // Calculate the average Q for normal inter frames (not key or GFU
-      // frames).
-      rc->ni_tot_qi += qindex;
-      rc->ni_av_qi = rc->ni_tot_qi / rc->ni_frames;
     }
   }
 
@@ -1813,18 +1804,12 @@ void av2_rc_postencode_update(AV2_COMP *cpi, uint64_t bytes_used) {
         rc->rolling_target_bits * 3 + rc->this_frame_target, 2);
     rc->rolling_actual_bits = (int)ROUND_POWER_OF_TWO_64(
         rc->rolling_actual_bits * 3 + rc->projected_frame_size, 2);
-    rc->long_rolling_target_bits = (int)ROUND_POWER_OF_TWO_64(
-        rc->long_rolling_target_bits * 31 + rc->this_frame_target, 5);
-    rc->long_rolling_actual_bits = (int)ROUND_POWER_OF_TWO_64(
-        rc->long_rolling_actual_bits * 31 + rc->projected_frame_size, 5);
   }
 
   // Actual bits spent
   rc->total_actual_bits += rc->projected_frame_size;
   rc->total_target_bits +=
       cm->immediate_output_picture ? rc->avg_frame_bandwidth : 0;
-
-  rc->total_target_vs_actual = rc->total_actual_bits - rc->total_target_bits;
 
   if (is_altref_enabled(cpi->oxcf.gf_cfg.lag_in_frames,
                         cpi->oxcf.gf_cfg.enable_auto_arf) &&

--- a/av2/encoder/ratectrl.h
+++ b/av2/encoder/ratectrl.h
@@ -195,8 +195,6 @@ typedef struct {
   int max_frame_bandwidth;  // Maximum burst rate allowed for a frame.
   int prev_avg_frame_bandwidth;
 
-  int ni_av_qi;
-  int ni_tot_qi;
   int ni_frames;
   int avg_frame_qindex[FRAME_TYPES];
   double tot_q;
@@ -213,14 +211,10 @@ typedef struct {
   int rolling_target_bits;
   int rolling_actual_bits;
 
-  int long_rolling_target_bits;
-  int long_rolling_actual_bits;
-
   int rate_error_estimate;
 
   int64_t total_actual_bits;
   int64_t total_target_bits;
-  int64_t total_target_vs_actual;
 
   /*!\endcond */
   /*!
@@ -272,7 +266,6 @@ typedef struct {
   int active_best_quality[MAX_ARF_LAYERS + 1];
 
   /*!\cond */
-  int base_layer_qp;
 
   // Total number of stats used only for kf_boost calculation.
   int num_stats_used_for_kf_boost;

--- a/av2/encoder/rd.c
+++ b/av2/encoder/rd.c
@@ -952,18 +952,11 @@ void av2_fill_coeff_costs(CoeffCosts *coeff_costs, FRAME_CONTEXT *fc,
           pcost->base_cost_zero[q_i][ctx] = pcost->base_cost[ctx][q_i][0];
         }
       }
-      for (int ctx = 0; ctx < SIG_COEF_CONTEXTS_UV; ++ctx) {
-        pcost->base_cost_uv_zero[ctx] = pcost->base_cost_uv[ctx][0];
-      }
-
       // Rearrange costs into base_lf_cost_zero[] array for quicker access.
       for (int q_i = 0; q_i < TCQ_CTXS; q_i++) {
         for (int ctx = 0; ctx < LF_SIG_COEF_CONTEXTS; ++ctx) {
           pcost->base_lf_cost_zero[q_i][ctx] = pcost->base_lf_cost[ctx][q_i][0];
         }
-      }
-      for (int ctx = 0; ctx < LF_SIG_COEF_CONTEXTS_UV; ++ctx) {
-        pcost->base_lf_cost_uv_zero[ctx] = pcost->base_lf_cost_uv[ctx][0];
       }
 
       // Precompute some base_costs for trellis, interleaved for quick access.
@@ -991,20 +984,6 @@ void av2_fill_coeff_costs(CoeffCosts *coeff_costs, FRAME_CONTEXT *fc,
           pcost->base_eob_cost_tbl[idx][ctx][1] =
               pcost->base_eob_cost[ctx][a2 - 1] + av2_cost_literal(1);
         }
-        for (int ctx = 0; ctx < SIG_COEF_CONTEXTS_UV; ++ctx) {
-          // UV coeffs, absLev 0 / 2
-          pcost->base_cost_uv_low_tbl[idx][ctx][0] =
-              pcost->base_cost_uv[ctx][a0] + av2_cost_literal(1);
-          pcost->base_cost_uv_low_tbl[idx][ctx][1] =
-              pcost->base_cost_uv[ctx][a2] + av2_cost_literal(1);
-        }
-        for (int ctx = 0; ctx < SIG_COEF_CONTEXTS_EOB; ++ctx) {
-          // UV EOB coeff, absLev 0 / 2
-          pcost->base_eob_cost_uv_tbl[idx][ctx][0] =
-              pcost->base_eob_cost_uv[ctx][a0 - 1] + av2_cost_literal(1);
-          pcost->base_eob_cost_uv_tbl[idx][ctx][1] =
-              pcost->base_eob_cost_uv[ctx][a2 - 1] + av2_cost_literal(1);
-        }
       }
       for (int idx = 0; idx < 9; idx++) {
         int max = LF_BASE_SYMBOLS - 1;
@@ -1030,20 +1009,6 @@ void av2_fill_coeff_costs(CoeffCosts *coeff_costs, FRAME_CONTEXT *fc,
               pcost->base_lf_eob_cost[ctx][a0 - 1] + av2_cost_literal(1);
           pcost->base_lf_eob_cost_tbl[idx][ctx][1] =
               pcost->base_lf_eob_cost[ctx][a2 - 1] + av2_cost_literal(1);
-        }
-        for (int ctx = 0; ctx < LF_SIG_COEF_CONTEXTS_UV; ++ctx) {
-          // LF UV Coeffs, absLev 0 / 2
-          pcost->base_lf_cost_uv_low_tbl[idx][ctx][0] =
-              pcost->base_lf_cost_uv[ctx][a0] + av2_cost_literal(1);
-          pcost->base_lf_cost_uv_low_tbl[idx][ctx][1] =
-              pcost->base_lf_cost_uv[ctx][a2] + av2_cost_literal(1);
-        }
-        for (int ctx = 0; ctx < SIG_COEF_CONTEXTS_EOB; ++ctx) {
-          // UV EOB coeff, absLev 0 / 2
-          pcost->base_lf_eob_cost_uv_tbl[idx][ctx][0] =
-              pcost->base_lf_eob_cost_uv[ctx][a0 - 1] + av2_cost_literal(1);
-          pcost->base_lf_eob_cost_uv_tbl[idx][ctx][1] =
-              pcost->base_lf_eob_cost_uv[ctx][a2 - 1] + av2_cost_literal(1);
         }
       }
       for (int ctx = 0; ctx < SIG_COEF_CONTEXTS_BOB; ++ctx)

--- a/av2/encoder/rd.h
+++ b/av2/encoder/rd.h
@@ -297,34 +297,7 @@ static INLINE uint32_t get_rd_opt_coeff_thresh(
 }
 
 // Used to reset the state of tx/mb rd hash information
-static INLINE void reset_hash_records(TxfmSearchInfo *const txfm_info,
-                                      int use_inter_txb_hash) {
-  int32_t record_idx;
-
-  // Reset the state for use_inter_txb_hash
-  if (use_inter_txb_hash) {
-    for (record_idx = 0;
-         record_idx < ((MAX_MIB_SIZE >> 1) * (MAX_MIB_SIZE >> 1)); record_idx++)
-      txfm_info->txb_rd_record_8X8[record_idx].num =
-          txfm_info->txb_rd_record_8X8[record_idx].index_start = 0;
-    for (record_idx = 0;
-         record_idx < ((MAX_MIB_SIZE >> 2) * (MAX_MIB_SIZE >> 2)); record_idx++)
-      txfm_info->txb_rd_record_16X16[record_idx].num =
-          txfm_info->txb_rd_record_16X16[record_idx].index_start = 0;
-    for (record_idx = 0;
-         record_idx < ((MAX_MIB_SIZE >> 3) * (MAX_MIB_SIZE >> 3)); record_idx++)
-      txfm_info->txb_rd_record_32X32[record_idx].num =
-          txfm_info->txb_rd_record_32X32[record_idx].index_start = 0;
-    for (record_idx = 0;
-         record_idx < ((MAX_MIB_SIZE >> 4) * (MAX_MIB_SIZE >> 4)); record_idx++)
-      txfm_info->txb_rd_record_64X64[record_idx].num =
-          txfm_info->txb_rd_record_64X64[record_idx].index_start = 0;
-  }
-
-  // Reset the state for use_intra_txb_hash
-  txfm_info->txb_rd_record_intra.num =
-      txfm_info->txb_rd_record_intra.index_start = 0;
-
+static INLINE void reset_hash_records(TxfmSearchInfo *const txfm_info) {
   // Reset the state for use_mb_rd_hash
   txfm_info->mb_rd_record.num = txfm_info->mb_rd_record.index_start = 0;
 }

--- a/av2/encoder/rdopt_utils.h
+++ b/av2/encoder/rdopt_utils.h
@@ -381,7 +381,7 @@ static INLINE void set_mode_eval_params(const struct AV2_COMP *cpi,
       // the decisions would have been sub-optimal
       // TODO(any): Move the evaluation of palette/IntraBC modes before winner
       // mode is processed and clean-up the code below
-      reset_hash_records(txfm_info, cpi->sf.tx_sf.use_inter_txb_hash);
+      reset_hash_records(txfm_info);
 
       break;
     default: assert(0);

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -690,7 +690,6 @@ static void set_good_speed_features_framesize_independent(
     sf->mv_sf.simple_motion_subpel_force_stop = FULL_PEL;
     sf->mv_sf.use_bsize_dependent_search_method = 1;
 
-    sf->tpl_sf.disable_gop_length_decision = 1;
     sf->tpl_sf.subpel_force_stop = FULL_PEL;
     sf->tpl_sf.disable_filtered_key_tpl = 1;
 
@@ -771,7 +770,6 @@ static AVM_INLINE void init_hl_sf(HIGH_LEVEL_SPEED_FEATURES *hl_sf) {
 }
 
 static AVM_INLINE void init_tpl_sf(TPL_SPEED_FEATURES *tpl_sf) {
-  tpl_sf->disable_gop_length_decision = 0;
   tpl_sf->prune_intra_modes = 0;
   tpl_sf->prune_starting_mv = 0;
   tpl_sf->reduce_first_step_size = 0;
@@ -989,7 +987,6 @@ static AVM_INLINE void init_tx_sf(TX_SPEED_FEATURES *tx_sf) {
   tx_sf->skip_pixel_dist_calc_using_tx_dist = false;
   tx_sf->adaptive_tx_type_search_idx = 0;
   tx_sf->adaptive_tx_partition_type_search_idx = 0;
-  tx_sf->use_inter_txb_hash = 1;
   tx_sf->prune_tx_rd_eval_sec_tx_sse = false;
   tx_sf->use_largest_tx_size_for_small_bsize = false;
   tx_sf->restrict_tx_partition_type_search = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -253,8 +253,6 @@ typedef struct HIGH_LEVEL_SPEED_FEATURES {
 
 /*!\cond */
 typedef struct TPL_SPEED_FEATURES {
-  // Enable/disable GOP length adaptive decision.
-  int disable_gop_length_decision;
   // Prune the intra modes search by tpl.
   // If set to 0, we will search all intra modes from DC_PRED to PAETH_PRED.
   // If set to 1, we only search DC_PRED, V_PRED, and H_PRED.
@@ -940,10 +938,6 @@ typedef struct TX_SPEED_FEATURES {
   // 0: no pruning
   // 1-2: progressively increasing aggressiveness of pruning
   int model_based_prune_tx_search_level;
-
-  // Use hash table to store inter txb transform search results
-  // to avoid repeated search on the same residue signal.
-  int use_inter_txb_hash;
 
   // Prune RD evaluation of secondary transform using the SSE of secondary
   // transform output.

--- a/av2/encoder/tpl_model.c
+++ b/av2/encoder/tpl_model.c
@@ -1260,8 +1260,6 @@ void av2_tpl_setup_stats(AV2_COMP *cpi, int gop_eval,
   init_gop_frames_for_tpl(cpi, frame_params, gf_group, gop_eval,
                           &tpl_gf_group_frames, frame_input, &pframe_qindex);
 
-  cpi->rc.base_layer_qp = pframe_qindex;
-
   av2_init_tpl_stats(tpl_data);
 
   tpl_row_mt->sync_read_ptr = av2_tpl_row_mt_sync_read_dummy;

--- a/av2/encoder/trellis_quant.h
+++ b/av2/encoder/trellis_quant.h
@@ -103,7 +103,6 @@ typedef struct tcq_param_t {
   const int32_t *dequant;
   const qm_val_t *iqmatrix;
   const uint16_t *block_eob_rate;
-  const TXB_CTX *txb_ctx;
   const LV_MAP_COEFF_COST *txb_costs;
 } tcq_param_t;
 

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -43,11 +43,6 @@ typedef struct {
   TX_TYPE tx_type;
 } TxCandidateInfo;
 
-typedef struct tx_size_rd_info_node {
-  TXB_RD_INFO *rd_info_array;  // Points to array of size TX_TYPES.
-  struct tx_size_rd_info_node *children[4];
-} TXB_RD_INFO_NODE;
-
 // Mapping of index to IST kernel set (for encoder search only)
 static const uint8_t ist_intra_stx_mapping[IST_SET_SIZE][IST_SET_SIZE] = {
   { 6, 1, 0, 5, 4, 3, 2 },  // DC_PRED
@@ -3056,10 +3051,7 @@ static AVM_INLINE void tx_type_rd(const AV2_COMP *cpi, MACROBLOCK *x,
                                   int block, int plane_bsize, TXB_CTX *txb_ctx,
                                   RD_STATS *rd_stats,
                                   FAST_TX_SEARCH_MODE ftxs_mode,
-                                  int64_t ref_rdcost,
-                                  TXB_RD_INFO *rd_info_array) {
-  (void)rd_info_array;
-
+                                  int64_t ref_rdcost) {
   av2_subtract_txb(x, AVM_PLANE_Y, plane_bsize, blk_col, blk_row, tx_size,
                    cpi->common.width, cpi->common.height, DCT_DCT);
   RD_STATS this_rd_stats;
@@ -3081,8 +3073,8 @@ static AVM_INLINE void try_tx_block_no_split(
     TX_SIZE tx_size, int depth, BLOCK_SIZE plane_bsize,
     const ENTROPY_CONTEXT *ta, const ENTROPY_CONTEXT *tl,
     int txfm_partition_ctx, RD_STATS *rd_stats, int64_t ref_best_rd,
-    FAST_TX_SEARCH_MODE ftxs_mode, TXB_RD_INFO_NODE *rd_info_node,
-    TxCandidateInfo *no_split, const AV2_COMMON *cm) {
+    FAST_TX_SEARCH_MODE ftxs_mode, TxCandidateInfo *no_split,
+    const AV2_COMMON *cm) {
   MACROBLOCKD *const xd = &x->e_mbd;
   MB_MODE_INFO *const mbmi = xd->mi[0];
   struct macroblock_plane *const p = &x->plane[0];
@@ -3102,8 +3094,7 @@ static AVM_INLINE void try_tx_block_no_split(
           .txb_skip_cost[pred_mode_ctx][txb_ctx.txb_skip_ctx][1];
   rd_stats->zero_rate = zero_blk_rate;
   tx_type_rd(cpi, x, tx_size, blk_row, blk_col, block, plane_bsize, &txb_ctx,
-             rd_stats, ftxs_mode, ref_best_rd,
-             rd_info_node ? rd_info_node->rd_info_array : NULL);
+             rd_stats, ftxs_mode, ref_best_rd);
   assert(rd_stats->rate < INT_MAX);
 
   const int pick_skip_txfm =
@@ -3305,7 +3296,7 @@ static void select_tx_partition_type(
     BLOCK_SIZE plane_bsize, ENTROPY_CONTEXT *ta, ENTROPY_CONTEXT *tl,
     TXFM_CONTEXT *tx_above, TXFM_CONTEXT *tx_left, RD_STATS *rd_stats,
     int64_t ref_best_rd, int *is_cost_valid, FAST_TX_SEARCH_MODE ftxs_mode,
-    TXB_RD_INFO_NODE *rd_info_node, int blk_idx) {
+    int blk_idx) {
   av2_init_rd_stats(rd_stats);
   if (ref_best_rd < 0) {
     *is_cost_valid = 0;
@@ -3465,8 +3456,8 @@ static void select_tx_partition_type(
       TxCandidateInfo no_split = { INT64_MAX, 0, TX_TYPES };
       try_tx_block_no_split(cpi, x, offsetr, offsetc, cur_block, sub_tx, 0,
                             plane_bsize, cur_ta, cur_tl, -1, &this_rd_stats,
-                            ref_best_rd - tmp_rd, ftxs_mode, rd_info_node,
-                            &no_split, &cpi->common);
+                            ref_best_rd - tmp_rd, ftxs_mode, &no_split,
+                            &cpi->common);
       partition_entropy_ctxs[txb_idx] = no_split.txb_entropy_ctx;
       partition_tx_types[txb_idx] = no_split.tx_type;
       this_blk_skip[txb_idx] = this_rd_stats.skip_txfm;
@@ -4094,8 +4085,7 @@ void av2_txfm_rd_joint_uv(MACROBLOCK *x, const AV2_COMP *cpi,
 // will be saved in rd_stats. The returned value is the corresponding RD cost.
 static int64_t select_tx_size_and_type(const AV2_COMP *cpi, MACROBLOCK *x,
                                        RD_STATS *rd_stats, BLOCK_SIZE bsize,
-                                       int64_t ref_best_rd,
-                                       TXB_RD_INFO_NODE *rd_info_tree) {
+                                       int64_t ref_best_rd) {
   MACROBLOCKD *const xd = &x->e_mbd;
   const TxfmSearchParams *txfm_params = &x->txfm_search_params;
   assert(is_inter_block(xd->mi[0], xd->tree_type));
@@ -4140,8 +4130,7 @@ static int64_t select_tx_size_and_type(const AV2_COMP *cpi, MACROBLOCK *x,
           get_plane_block_size(bsize, pd->subsampling_x, pd->subsampling_y);
       select_tx_partition_type(cpi, x, idy, idx, block, plane_bsize, ctxa, ctxl,
                                tx_above, tx_left, &pn_rd_stats, best_rd_sofar,
-                               &is_cost_valid, ftxs_mode, rd_info_tree,
-                               blk_idx);
+                               &is_cost_valid, ftxs_mode, blk_idx);
       blk_idx++;
       if (!is_cost_valid || pn_rd_stats.rate == INT_MAX) {
         av2_invalid_rd_stats(rd_stats);
@@ -4154,7 +4143,6 @@ static int64_t select_tx_size_and_type(const AV2_COMP *cpi, MACROBLOCK *x,
       no_skip_txfm_rd =
           RDCOST(x->rdmult, rd_stats->rate + no_skip_txfm_cost, rd_stats->dist);
       block += step;
-      if (rd_info_tree != NULL) rd_info_tree += 1;
     }
   }
 
@@ -4260,15 +4248,8 @@ void av2_pick_recursive_tx_size_type_yrd(const AV2_COMP *cpi, MACROBLOCK *x,
   ++x->txfm_search_info.tx_search_count;
 #endif  // CONFIG_SPEED_STATS
 
-  // Pre-compute residue hashes (transform block level) and find existing or
-  // add new RD records to store and reuse rate and distortion values to speed
-  // up TX size/type search.
-  TXB_RD_INFO_NODE matched_rd_info[4 + 16 + 64];
-  int found_rd_info = 0;
-
   const int64_t rd =
-      select_tx_size_and_type(cpi, x, rd_stats, bsize, ref_best_rd,
-                              found_rd_info ? matched_rd_info : NULL);
+      select_tx_size_and_type(cpi, x, rd_stats, bsize, ref_best_rd);
 
   if (rd == INT64_MAX) {
     // We should always find at least one candidate unless ref_best_rd is less


### PR DESCRIPTION
- Intra txb rd hash is removed in commit a7bbe6a12. Fields associated with them are now being removed.
- Inter txb rd hash is disabled in commit e56083fc and removed in commit 968c4946. Fields associated with them are now being removed
- Remove TXB_RD_INFO/TXB_RD_RECORD subsystem
- MB_RD_INFO.*
- ModeCosts.*
- LV_MAP_COEFF_COST.* is introduced and used by 6780aa983(CWG-E092 Trellis Coded Quantization). TCQ SW cleanup has deleted the file that access this.
- PartitionSearchInfo.variance_low
- RD_SEARCH_MACROBLOCK_CONTEXT.*
- SimpleMotionData.mv_ref
- SimpleMotionDataBufs.b_4x64_0/b_64x4_0/b_4x64_1/b_64x4_1
- CODING_CONTEXT
- RD_RECT_PART_WIN_INFO
- MACROBLOCK.skip_mode
- encode_b_args.ctx
- ToolCfg.enable_cfl_intra
- AV2EncoderConfig.operating_points_count
- TWO_PASS.frame_stats_next_idx
- tcq_param_t.txb_ctx
- RestSearchCtxt.tile_y0
- QUANT_PARAM.tx_size
- PICK_MODE_CONTEXT.parent/index
- RefFrameDistanceInfo.nearest_past_ref/nearest_future_ref
- RATE_CONTROL.*
- EncodeFrameParams.primary_ref_frame
- ExternalFlags.cross_frame_context
- TPL_SPEED_FEATURES.disable_gop_length_decision