### PR TITLE
Fix data race between ensure_tflite_init calls across modules

### DIFF
--- a/av2/encoder/intra_dip_mode_prune_tflite.cc
+++ b/av2/encoder/intra_dip_mode_prune_tflite.cc
@@ -25,12 +25,10 @@ struct DipContext {
   int model_index = -1;
 };
 
-std::mutex dip_prune_mutex;
-
 static void create_interpreter(DipContext *context,
                                const unsigned char *model_def, int model_len) {
-  std::lock_guard<std::mutex> lock(dip_prune_mutex);
-  tflite::LoggerOptions::SetMinimumLogSeverity(tflite::TFLITE_LOG_ERROR);
+  std::lock_guard<std::mutex> lock(avm_tflite_mutex());
+  avm_tflite_set_log_severity_error();
   std::unique_ptr<tflite::FlatBufferModel> model =
       tflite::FlatBufferModel::BuildFromBuffer((const char *)model_def,
                                                model_len);

--- a/av2/encoder/part_split_prune_tflite.cc
+++ b/av2/encoder/part_split_prune_tflite.cc
@@ -45,12 +45,10 @@ struct PartSplitContext {
   std::vector<TfLiteDelegateType> to_delete;
 };
 
-std::mutex tfliteMutex;
-
 static std::unique_ptr<tflite::Interpreter> create_interpreter(
     unsigned char *model_def, std::vector<TfLiteDelegateType> &to_delete) {
-  std::lock_guard<std::mutex> lock(tfliteMutex);
-  tflite::LoggerOptions::SetMinimumLogSeverity(tflite::TFLITE_LOG_ERROR);
+  std::lock_guard<std::mutex> lock(avm_tflite_mutex());
+  avm_tflite_set_log_severity_error();
   tflite::Model *model = (tflite::Model *)tflite::GetModel(model_def);
 
   const int num_threads = 1;

--- a/common/tf_lite_includes.h
+++ b/common/tf_lite_includes.h
@@ -45,4 +45,19 @@
 #pragma clang diagnostic pop
 #endif
 
+#include <mutex>
+
+// Thread-safe helper functions for TFLite initialization across modules.
+inline std::mutex &avm_tflite_mutex() {
+  static std::mutex mtx;
+  return mtx;
+}
+
+inline void avm_tflite_set_log_severity_error() {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    tflite::LoggerOptions::SetMinimumLogSeverity(tflite::TFLITE_LOG_ERROR);
+  });
+}
+
 #endif  // AVM_COMMON_TF_LITE_INCLUDES_H_


### PR DESCRIPTION
part_split_prune_tflite.cc and intra_dip_mode_prune_tflite.cc used separate mutexes when calling tflite::LoggerOptions::SetMinimumLogSeverity and initializing TFLite models. This led to concurrent unsynchronized writes to the global minimum_log_severity_ variable during multithreaded encoding.

This fix unifies the TFLite initialization mutex across modules via avm_tflite_mutex() in common/tf_lite_includes.h and safely sets the log severity once using std::call_once (avm_tflite_set_log_severity_error).

Fixes #5357