### PR TITLE
Cherry pick to av2-enc branch: Fix use-of-uninitialized-value in RtcTest (#5358)

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -1620,9 +1620,11 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
       sf->winner_mode_sf.multi_winner_mode_type = MULTI_WINNER_MODE_OFF;
   }
 
-  set_erp_speed_features(cpi);
-  set_erp_speed_features_framesize_dependent(cpi);
-  set_erp_speed_features_qindex_dependent(cpi);
+  if (cpi->oxcf.mode == GOOD) {
+    set_erp_speed_features(cpi);
+    set_erp_speed_features_framesize_dependent(cpi);
+    set_erp_speed_features_qindex_dependent(cpi);
+  }
 
   set_two_pass_partition_level(cpi);
 }


### PR DESCRIPTION
In av2_set_speed_features_qindex_dependent(), set_erp_speed_features() was called unconditionally for every frame, regardless of whether oxcf->mode was GOOD or REALTIME.

In REALTIME mode, set_rt_speed_features_framesize_independent() disables reference frame pruning (sf->inter_sf.prune_ref_frames = 0). Calling set_erp_speed_features() inadvertently re-enabled prune_ref_frames, causing av2_rd_pick_inter_mode_sb() to call av2_get_prev_partition(), which accessed uninitialized memory in x->sms_bufs because REALTIME mode skips superblock SMS data buffer initialization in init_encode_rd_sb().

Guard set_erp_speed_features*() with `cpi->oxcf.mode == GOOD` so ERP speed features are only applied in GOOD quality mode.

Fixes #5356