### PR TITLE
Add SIMD optimization and speed up nonsep Wiener

### DIFF
--- a/av2/common/av2_rtcd_defs.pl
+++ b/av2/common/av2_rtcd_defs.pl
@@ -417,7 +417,11 @@ if (avm_config("CONFIG_AV2_ENCODER") eq "yes") {
                         const int y_uv_hscale, const int y_uv_vscale, const int qstep,
                         const int neg_qstep, const int *src_loc, const int blk_size_x,
                         const int blk_size_y, const int edge_clf";
-  specialize qw/ccso_derive_src_block avx2/
+  specialize qw/ccso_derive_src_block avx2/;
+
+  # WienerNS filter stats accumulation
+  add_proto qw/void av2_accumulate_wienerns_correlation/, "double *A_base, double *b_base, const int16_t *buf, int16_t y, int num_feat";
+  specialize qw/av2_accumulate_wienerns_correlation sse4_1 avx2/;
 }
 
 # WARPED_MOTION / GLOBAL_MOTION functions

--- a/av2/encoder/pickrst.c
+++ b/av2/encoder/pickrst.c
@@ -1640,6 +1640,17 @@ static int compute_wienerns_filter_select_master(
   return 1;
 }
 
+void av2_accumulate_wienerns_correlation_c(double *A_base, double *b_base,
+                                           const int16_t *buf, int16_t y,
+                                           int num_feat) {
+  for (int k = 0; k < num_feat; ++k) {
+    for (int l = 0; l <= k; ++l) {
+      A_base[k * num_feat + l] += (double)buf[k] * (double)buf[l];
+    }
+    b_base[k] += (double)buf[k] * (double)y;
+  }
+}
+
 static int64_t compute_stats_for_wienerns_filter(
     const uint16_t *dgd_hbd, const uint16_t *src_hbd,
     const RestorationTileLimits *limits, int dgd_stride, int src_stride,
@@ -1722,13 +1733,8 @@ static int64_t compute_stats_for_wienerns_filter(
         }
         int16_t y;
         y = ((int64_t)src_hbd[src_id] - dgd_hbd[dgd_id]);
-        for (int k = 0; k < num_feat; ++k) {
-          for (int l = 0; l <= k; ++l) {
-            A[k * num_feat + l + c_id * stride_A] +=
-                (double)buf[k] * (double)buf[l];
-          }
-          b[k + c_id * stride_b] += (double)buf[k] * (double)y;
-        }
+        av2_accumulate_wienerns_correlation(
+            A + c_id * stride_A, b + c_id * stride_b, buf, y, num_feat);
         real_sse += (int64_t)y * (int64_t)y;
         ++num_pixels_in_class[c_id];
       }
@@ -3378,8 +3384,13 @@ static double optimize_frame_filters_for_target_classes(
   double fraction_rus_to_include[][2] = { { .9, .0 }, { .8, .0 }, { .7, .0 },
                                           { .6, .0 }, { .5, .0 }, { .4, .0 },
                                           { .3, .0 }, { .2, .0 }, { .1, 0 } };
-  const int num_ru_perc_to_try =
-      sizeof(fraction_rus_to_include) / sizeof(*fraction_rus_to_include);
+  int num_ru_perc_to_try =
+      (int)(sizeof(fraction_rus_to_include) / sizeof(*fraction_rus_to_include));
+  int max_iterations = num_ru_perc_to_try + 2;
+  if (rsc->lpf_sf->wienerns_fast_frame_filter_opt) {
+    num_ru_perc_to_try = 0;
+    max_iterations = 1;
+  }
   const int solve_iterations = 1;
   double best_cost = DBL_MAX;
 
@@ -3396,7 +3407,7 @@ static double optimize_frame_filters_for_target_classes(
   // num_ru_perc_to_try times. Then a final round to better optimize the best
   // filter.
   int cnt = 0;
-  while (cnt < num_ru_perc_to_try + 2) {
+  while (cnt < max_iterations) {
     ++cnt;
     RdResults rd_results = { 0 };
     for (int n = 0; n < solve_iterations; ++n) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -357,6 +357,11 @@ static void set_good_speed_features_framesize_independent(
 
   if (speed >= 1) {
     sf->lpf_sf.wienerns_refine_iters = 0;
+    sf->lpf_sf.wienerns_fast_frame_filter_opt = 1;
+    // Trim the RU-size candidate set by pyramid level (policy in pickrst.c).
+    // drop_low is disabled later for small resolutions.
+    sf->lpf_sf.reduce_lr_unit_size_by_pyr = 1;
+    sf->lpf_sf.reduce_lr_unit_size_by_pyr_drop_low = 1;
 
     sf->flexmv_sf.prune_non_one_pel_mv_using_best_mv_prec = 1;
     sf->inter_sf.selective_ref_frame = 2;
@@ -647,10 +652,6 @@ static void set_good_speed_features_framesize_independent(
     sf->winner_mode_sf.enable_winner_mode_for_tx_size_srch = 0;
 
     sf->lpf_sf.lpf_pick = LPF_PICK_FROM_FULL_IMAGE_NON_DUAL;
-    // Trim the RU-size candidate set by pyramid level (policy in pickrst.c).
-    // drop_low is disabled later for small resolutions.
-    sf->lpf_sf.reduce_lr_unit_size_by_pyr = 1;
-    sf->lpf_sf.reduce_lr_unit_size_by_pyr_drop_low = 1;
 
     sf->mv_sf.reduce_search_range = 1;
     sf->mv_sf.warp_search_method = WARP_SEARCH_DIAMOND;
@@ -1051,6 +1052,8 @@ static AVM_INLINE void init_lpf_sf(LOOP_FILTER_SPEED_FEATURES *lpf_sf) {
   lpf_sf->early_terminate_ccso_search_by_cost = 0;
   // Off by default: keep full RU-size search for all pyramid levels.
   lpf_sf->reduce_lr_unit_size_by_pyr = 0;
+  lpf_sf->reduce_lr_unit_size_by_pyr_drop_low = 0;
+  lpf_sf->wienerns_fast_frame_filter_opt = 0;
   lpf_sf->ccso_chroma_dep = 0;
 }
 

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -1089,6 +1089,10 @@ typedef struct LOOP_FILTER_SPEED_FEATURES {
   // size at deep pyramid levels. Default 0 keeps the smallest size available.
   int reduce_lr_unit_size_by_pyr_drop_low;
 
+  // If set, use fast search for WIENER_NONSEP frame-level filters: 1 iteration
+  // with all RUs, bypassing percentage subsets and qsort.
+  int wienerns_fast_frame_filter_opt;
+
   // bypass ccso luma plane check
   int ccso_chroma_dep;
 } LOOP_FILTER_SPEED_FEATURES;

--- a/av2/encoder/x86/pickrst_avx2.c
+++ b/av2/encoder/x86/pickrst_avx2.c
@@ -20,4 +20,40 @@
 #include "av2/common/restoration.h"
 #include "av2/encoder/pickrst.h"
 
-/* This is a placeholder file for encoder side optimizations */
+void av2_accumulate_wienerns_correlation_avx2(double *A_base, double *b_base,
+                                              const int16_t *buf, int16_t y,
+                                              int num_feat) {
+  double buf_d[WIENERNS_TAPS_MAX];
+  for (int k = 0; k < num_feat; ++k) {
+    buf_d[k] = (double)buf[k];
+  }
+  const double yd = (double)y;
+  const __m256d vyd = _mm256_set1_pd(yd);
+
+  int k = 0;
+  for (; k + 3 < num_feat; k += 4) {
+    __m256d vb = _mm256_loadu_pd(b_base + k);
+    __m256d vbuf = _mm256_loadu_pd(buf_d + k);
+    vb = _mm256_add_pd(vb, _mm256_mul_pd(vbuf, vyd));
+    _mm256_storeu_pd(b_base + k, vb);
+  }
+  for (; k < num_feat; ++k) {
+    b_base[k] += buf_d[k] * yd;
+  }
+
+  for (int i = 0; i < num_feat; ++i) {
+    double *A_row = A_base + i * num_feat;
+    const double bi = buf_d[i];
+    const __m256d vbi = _mm256_set1_pd(bi);
+    int j = 0;
+    for (; j + 3 <= i; j += 4) {
+      __m256d vA = _mm256_loadu_pd(A_row + j);
+      __m256d vbj = _mm256_loadu_pd(buf_d + j);
+      vA = _mm256_add_pd(vA, _mm256_mul_pd(vbi, vbj));
+      _mm256_storeu_pd(A_row + j, vA);
+    }
+    for (; j <= i; ++j) {
+      A_row[j] += bi * buf_d[j];
+    }
+  }
+}

--- a/av2/encoder/x86/pickrst_sse4.c
+++ b/av2/encoder/x86/pickrst_sse4.c
@@ -18,4 +18,40 @@
 #include "av2/common/restoration.h"
 #include "av2/encoder/pickrst.h"
 
-/* This is a placeholder file for encoder side optimizations */
+void av2_accumulate_wienerns_correlation_sse4_1(double *A_base, double *b_base,
+                                                const int16_t *buf, int16_t y,
+                                                int num_feat) {
+  double buf_d[WIENERNS_TAPS_MAX];
+  for (int k = 0; k < num_feat; ++k) {
+    buf_d[k] = (double)buf[k];
+  }
+  const double yd = (double)y;
+  const __m128d vyd = _mm_set1_pd(yd);
+
+  int k = 0;
+  for (; k + 1 < num_feat; k += 2) {
+    __m128d vb = _mm_loadu_pd(b_base + k);
+    __m128d vbuf = _mm_loadu_pd(buf_d + k);
+    vb = _mm_add_pd(vb, _mm_mul_pd(vbuf, vyd));
+    _mm_storeu_pd(b_base + k, vb);
+  }
+  for (; k < num_feat; ++k) {
+    b_base[k] += buf_d[k] * yd;
+  }
+
+  for (int i = 0; i < num_feat; ++i) {
+    double *A_row = A_base + i * num_feat;
+    const double bi = buf_d[i];
+    const __m128d vbi = _mm_set1_pd(bi);
+    int j = 0;
+    for (; j + 1 <= i; j += 2) {
+      __m128d vA = _mm_loadu_pd(A_row + j);
+      __m128d vbj = _mm_loadu_pd(buf_d + j);
+      vA = _mm_add_pd(vA, _mm_mul_pd(vbi, vbj));
+      _mm_storeu_pd(A_row + j, vA);
+    }
+    for (; j <= i; ++j) {
+      A_row[j] += bi * buf_d[j];
+    }
+  }
+}

--- a/test/av2_wienerns_test.cc
+++ b/test/av2_wienerns_test.cc
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+#include <cmath>
+#include <tuple>
+
+#include "third_party/googletest/src/googletest/include/gtest/gtest.h"
+
+#include "test/acm_random.h"
+#include "test/clear_system_state.h"
+#include "test/register_state_check.h"
+#include "test/util.h"
+
+#include "config/avm_config.h"
+#include "config/av2_rtcd.h"
+
+#include "av2/common/restoration.h"
+
+using libavm_test::ACMRandom;
+
+namespace {
+
+typedef void (*AccumulateWienernsCorrFunc)(double *A_base, double *b_base,
+                                           const int16_t *buf, int16_t y,
+                                           int num_feat);
+
+typedef std::tuple<AccumulateWienernsCorrFunc> AccumulateWienernsCorrParam;
+
+class WienernsCorrTest
+    : public ::testing::TestWithParam<AccumulateWienernsCorrParam> {
+ public:
+  virtual void SetUp() {
+    target_func_ = GET_PARAM(0);
+    rnd_.Reset(ACMRandom::DeterministicSeed());
+  }
+
+  virtual void TearDown() { libavm_test::ClearSystemState(); }
+
+  void RunRandomTest();
+  void RunExtremeTest();
+  void RunSpeedTest(int run_times);
+
+ private:
+  AccumulateWienernsCorrFunc target_func_;
+  ACMRandom rnd_;
+};
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(WienernsCorrTest);
+
+static const int kTestFeatCounts[] = {
+  1, 2, 3, 4, 5, 8, 9, 13, 16, 20, 25, 32
+};
+static const int kNumFeatTests =
+    sizeof(kTestFeatCounts) / sizeof(kTestFeatCounts[0]);
+
+void WienernsCorrTest::RunRandomTest() {
+  double A_ref[WIENERNS_TAPS_MAX * WIENERNS_TAPS_MAX];
+  double A_tst[WIENERNS_TAPS_MAX * WIENERNS_TAPS_MAX];
+  double b_ref[WIENERNS_TAPS_MAX];
+  double b_tst[WIENERNS_TAPS_MAX];
+  int16_t buf[WIENERNS_TAPS_MAX];
+
+  for (int f_idx = 0; f_idx < kNumFeatTests; ++f_idx) {
+    const int num_feat = kTestFeatCounts[f_idx];
+    if (num_feat > WIENERNS_TAPS_MAX) continue;
+
+    for (int iter = 0; iter < 500 && !HasFatalFailure(); ++iter) {
+      for (int i = 0; i < num_feat * num_feat; ++i) {
+        const double init_val = static_cast<double>(rnd_.Rand31() % 100000);
+        A_ref[i] = init_val;
+        A_tst[i] = init_val;
+      }
+      for (int i = 0; i < num_feat; ++i) {
+        const double init_val = static_cast<double>(rnd_.Rand31() % 100000);
+        b_ref[i] = init_val;
+        b_tst[i] = init_val;
+      }
+
+      const int num_samples = 1 + (rnd_.Rand8() % 32);
+      for (int s = 0; s < num_samples; ++s) {
+        for (int k = 0; k < num_feat; ++k) {
+          buf[k] = static_cast<int16_t>((rnd_.Rand16() % 4096) - 2048);
+        }
+        const int16_t y = static_cast<int16_t>((rnd_.Rand16() % 4096) - 2048);
+
+        av2_accumulate_wienerns_correlation_c(A_ref, b_ref, buf, y, num_feat);
+        target_func_(A_tst, b_tst, buf, y, num_feat);
+      }
+
+      for (int k = 0; k < num_feat; ++k) {
+        ASSERT_DOUBLE_EQ(b_ref[k], b_tst[k])
+            << "b mismatch at index " << k << " for num_feat=" << num_feat;
+      }
+
+      for (int i = 0; i < num_feat; ++i) {
+        for (int j = 0; j <= i; ++j) {
+          ASSERT_DOUBLE_EQ(A_ref[i * num_feat + j], A_tst[i * num_feat + j])
+              << "A mismatch at (" << i << ", " << j
+              << ") for num_feat=" << num_feat;
+        }
+      }
+    }
+  }
+}
+
+void WienernsCorrTest::RunExtremeTest() {
+  double A_ref[WIENERNS_TAPS_MAX * WIENERNS_TAPS_MAX];
+  double A_tst[WIENERNS_TAPS_MAX * WIENERNS_TAPS_MAX];
+  double b_ref[WIENERNS_TAPS_MAX];
+  double b_tst[WIENERNS_TAPS_MAX];
+  int16_t buf[WIENERNS_TAPS_MAX];
+
+  const int16_t extreme_vals[] = { -32768, -4095, -2048, -1,   0,
+                                   1,      2047,  4095,  32767 };
+  const int num_extreme = sizeof(extreme_vals) / sizeof(extreme_vals[0]);
+
+  for (int f_idx = 0; f_idx < kNumFeatTests; ++f_idx) {
+    const int num_feat = kTestFeatCounts[f_idx];
+    if (num_feat > WIENERNS_TAPS_MAX) continue;
+
+    for (int e1 = 0; e1 < num_extreme; ++e1) {
+      for (int e2 = 0; e2 < num_extreme; ++e2) {
+        memset(A_ref, 0, sizeof(A_ref));
+        memset(A_tst, 0, sizeof(A_tst));
+        memset(b_ref, 0, sizeof(b_ref));
+        memset(b_tst, 0, sizeof(b_tst));
+
+        for (int k = 0; k < num_feat; ++k) {
+          buf[k] = (k % 2 == 0) ? extreme_vals[e1] : extreme_vals[e2];
+        }
+        const int16_t y = extreme_vals[e1];
+
+        av2_accumulate_wienerns_correlation_c(A_ref, b_ref, buf, y, num_feat);
+        target_func_(A_tst, b_tst, buf, y, num_feat);
+
+        for (int k = 0; k < num_feat; ++k) {
+          ASSERT_DOUBLE_EQ(b_ref[k], b_tst[k])
+              << "Extreme b mismatch at index " << k
+              << " for num_feat=" << num_feat;
+        }
+
+        for (int i = 0; i < num_feat; ++i) {
+          for (int j = 0; j <= i; ++j) {
+            ASSERT_DOUBLE_EQ(A_ref[i * num_feat + j], A_tst[i * num_feat + j])
+                << "Extreme A mismatch at (" << i << ", " << j
+                << ") for num_feat=" << num_feat;
+          }
+        }
+      }
+    }
+  }
+}
+
+void WienernsCorrTest::RunSpeedTest(int run_times) {
+  double A_ref[WIENERNS_TAPS_MAX * WIENERNS_TAPS_MAX] = { 0.0 };
+  double A_tst[WIENERNS_TAPS_MAX * WIENERNS_TAPS_MAX] = { 0.0 };
+  double b_ref[WIENERNS_TAPS_MAX] = { 0.0 };
+  double b_tst[WIENERNS_TAPS_MAX] = { 0.0 };
+  int16_t buf[WIENERNS_TAPS_MAX];
+
+  for (int k = 0; k < WIENERNS_TAPS_MAX; ++k) {
+    buf[k] = static_cast<int16_t>((rnd_.Rand16() % 4096) - 2048);
+  }
+  const int16_t y = static_cast<int16_t>((rnd_.Rand16() % 4096) - 2048);
+
+  for (int f_idx = 0; f_idx < kNumFeatTests; ++f_idx) {
+    const int num_feat = kTestFeatCounts[f_idx];
+    if (num_feat > WIENERNS_TAPS_MAX) continue;
+
+    avm_usec_timer timer;
+    avm_usec_timer_start(&timer);
+    for (int i = 0; i < run_times; ++i) {
+      av2_accumulate_wienerns_correlation_c(A_ref, b_ref, buf, y, num_feat);
+    }
+    avm_usec_timer_mark(&timer);
+    const double time_c = static_cast<double>(avm_usec_timer_elapsed(&timer));
+
+    avm_usec_timer_start(&timer);
+    for (int i = 0; i < run_times; ++i) {
+      target_func_(A_tst, b_tst, buf, y, num_feat);
+    }
+    avm_usec_timer_mark(&timer);
+    const double time_simd =
+        static_cast<double>(avm_usec_timer_elapsed(&timer));
+
+    printf("num_feat %2d: C %7.2fus / SIMD %7.2fus (speedup: %3.2fx)\n",
+           num_feat, time_c, time_simd, time_c / time_simd);
+  }
+}
+
+TEST_P(WienernsCorrTest, RandomValues) { RunRandomTest(); }
+TEST_P(WienernsCorrTest, ExtremeValues) { RunExtremeTest(); }
+TEST_P(WienernsCorrTest, DISABLED_Speed) { RunSpeedTest(200000); }
+
+#if HAVE_SSE4_1
+INSTANTIATE_TEST_SUITE_P(
+    SSE4_1, WienernsCorrTest,
+    ::testing::Values(av2_accumulate_wienerns_correlation_sse4_1));
+#endif  // HAVE_SSE4_1
+
+#if HAVE_AVX2
+INSTANTIATE_TEST_SUITE_P(
+    AVX2, WienernsCorrTest,
+    ::testing::Values(av2_accumulate_wienerns_correlation_avx2));
+#endif  // HAVE_AVX2
+
+}  // namespace

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -211,6 +211,7 @@ if(NOT BUILD_SHARED_LIBS)
     "${AVM_ROOT}/test/intra_mode_mlp_test.cc"
     "${AVM_ROOT}/test/partition_mlp_test.cc"
     "${AVM_ROOT}/test/av2_wedge_utils_test.cc"
+    "${AVM_ROOT}/test/av2_wienerns_test.cc"
     "${AVM_ROOT}/test/av2_ccso_simd_cmp.cc"
     "${AVM_ROOT}/test/blend_a64_mask_1d_test.cc"
     "${AVM_ROOT}/test/blend_a64_mask_test.cc"


### PR DESCRIPTION
This patch accelerates the nonseparable Wiener restoration search through search pruning at speed >= 1 and SIMD optimizations for the autocovariance matrix accumulation:

1. Search Pruning for speed >= 1: Extend speed features reduce_lr_unit_size_by_pyr and reduce_lr_unit_size_by_pyr_drop_low from speed >=4 to speed >= 1 to prune RU unit-size evaluations based on pyramid level (drops the largest RU size for pyr_level >= 3, and the smallest RU size for pyr_level >= 5). Add a speed feature wienerns_fast_frame_filter_opt for speed >= 1 to prune frame-level filter search iterations during optimal class and filter determination.

2. SIMD Vectorization: Add SSE4.1 and AVX2 implementations to accelerate autocovariance matrix and cross-correlation vector accumulation in WienerNS filter stats collection. Unit tests have been added to verify numerical equivalence between SIMD (SSE4.1, AVX2) and reference C implementations. This change is applied to all speed levels, and is bit-exact. Encoder instruction count savings on A3-A5 with 17 frames:
0.11% at speed 0
0.26% at speed 1
0.95% at speed 2

STATS_CHANGED for speed >= 1

Results with the above changes combined, evaluated on 2128e7e90 with 33 frames:
```
    1) Speed 1
      +------------+-------+-------+-------+-------+-------+-------+
      | Class      |     Y |    Cb |    Cr |  wAvg |  Enc% |  Dec% |
      +------------+-------+-------+-------+-------+-------+-------+
      | A1         | +0.03 | +0.12 | +0.19 | +0.04 |  93.4 |  97.9 |
      | A2         | +0.06 | -0.12 | -0.22 | +0.04 |  96.8 |  99.3 |
      +------------+-------+-------+-------+-------+-------+-------+
    
    2) Speed 2
      +------------+-------+-------+-------+-------+-------+-------+
      | Class      |     Y |    Cb |    Cr |  wAvg |  Enc% |  Dec% |
      +------------+-------+-------+-------+-------+-------+-------+
      | A1         | -0.01 | -0.16 | +0.21 | -0.01 |  88.6 | 100.6 |
      | A2         | +0.08 | +0.03 | -0.14 | +0.08 |  93.2 | 102.1 |
      +------------+-------+-------+-------+-------+-------+-------+
    
    3) Speed 3
      +------------+-------+-------+-------+-------+-------+-------+
      | Class      |     Y |    Cb |    Cr |  wAvg |  Enc% |  Dec% |
      +------------+-------+-------+-------+-------+-------+-------+
      | A1         | +0.07 | +0.11 | -0.13 | +0.06 |  86.9 | 101.2 |
      | A2         | +0.01 | -0.01 | -0.05 | +0.00 |  94.8 | 101.4 |
      +------------+-------+-------+-------+-------+-------+-------+

    4) Speed 4
      +------------+-------+-------+-------+-------+-------+-------+
      | Class      |     Y |    Cb |    Cr |  wAvg |  Enc% |  Dec% |
      +------------+-------+-------+-------+-------+-------+-------+
      | A1         | -0.07 | -0.07 | +0.01 | -0.06 |  92.9 | 101.8 |
      | A2         | -0.00 | -0.07 | -0.13 | -0.00 |  97.2 | 102.2 |
      +------------+-------+-------+-------+-------+-------+-------+
```
