### PR TITLE
Disable intrabc in inter frames at speed 2

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -482,6 +482,8 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.reuse_inter_intra_mode = 1;
     sf->inter_sf.selective_ref_frame = 2;
     sf->inter_sf.skip_repeated_newmv = 1;
+    sf->inter_sf.skip_eval_intrabc_in_inter_frame =
+        cm->features.allow_screen_content_tools ? 0 : 1;
     sf->inter_sf.reduce_max_drl_refmvs = 1;
     if (!allow_screen_content_tools) {
       // When reduce_max_drl_refmvs is enabled, keep newmv_drl_search_limit at 2


### PR DESCRIPTION
Results for RA CTC, A1 17 frames, A2 33 frames,
speed 2: (baseline: f90877c79)

```
+----+-------+-------+-------+--------+--------+
| Set| PSNR-Y| PSNR-U| PSNR-V|PSNR-YUV|Enc-time|
+----+-------+-------+-------+--------+--------+
| A1 |-0.01% | 0.08% | 0.00% | -0.01% | 96%    |
| A2 | 0.04% | 0.02% |-0.08% |  0.04% | 98%    |
+----+-------+-------+-------+--------+--------+
```

STATS_CHANGED for speed >= 2