### PR TITLE
Prune 4 parameter warp delta search

### DIFF
--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -2642,8 +2642,11 @@ static AVM_INLINE int handle_warp_delta_mode(
         mbmi->mv[0].as_int = previous_mvs[mbmi->warp_ref_idx].as_int;
       }
     }
-    if (!cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode ||
-        !eval_motion_mode)
+    // `eval_motion_mode` is 1 when `mbmi->mode == WARP_NEWMV`,
+    // `mbmi->motion_mode == WARP_DELTA` and `mbmi->warp_ref_idx` is 2 or 3.
+    // In this case, skip the evaluation since it has already been done
+    // when `eval_motion_mode` is 0.
+    if (!eval_motion_mode)
       valid = av2_refine_mv_for_base_param_warp_model(
           cm, xd, mbmi, mbmi_ext, &ms_params,
           get_warp_search_method(cpi, eval_motion_mode, mbmi->ref_frame[0]),
@@ -2651,13 +2654,14 @@ static AVM_INLINE int handle_warp_delta_mode(
           cpi->sf.mv_sf.warp_mv_refine_early_term);
   } else {
     mbmi->six_param_warp_model_flag = get_default_six_param_flag(cm, mbmi);
-    const int six_param_enabled_by_tid =
-        mbmi->six_param_warp_model_flag &&
-        cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode_by_tid;
-    const bool use_six_param_in_winner =
-        (eval_motion_mode == six_param_enabled_by_tid);
-    if (use_six_param_in_winner ||
-        !cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode) {
+    const int warp_delta_in_winner =
+        mbmi->six_param_warp_model_flag
+            ? cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode_by_tid
+            : cpi->sf.inter_sf.enable_four_param_warp_in_winner_mode;
+    // When warp delta search (4-param / 6-param) is enabled in winner mode,
+    // skip the search when `eval_motion_mode` is 0.
+    const bool do_pick_warp_delta = (eval_motion_mode == warp_delta_in_winner);
+    if (do_pick_warp_delta) {
       valid = av2_pick_warp_delta(
           cm, xd, mbmi, &ms_params, &x->mode_costs, prev_best_models,
           mbmi_ext->warp_param_stack[av2_ref_frame_type(mbmi->ref_frame)],
@@ -3336,8 +3340,9 @@ static int64_t motion_mode_rd(
   for (int mode_index = SIMPLE_TRANSLATION; mode_index < mode_index_end;
        mode_index++) {
     if ((modes_to_search & (1 << mode_index)) == 0) continue;
-    if (cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode &&
-        eval_motion_mode &&
+    assert(IMPLIES(eval_motion_mode,
+                   enable_warp_search_in_winner_mode(&cpi->sf.inter_sf)));
+    if (eval_motion_mode &&
         (mode_index == WARP_CAUSAL || mode_index == WARP_EXTEND))
       continue;
     int warp_ref_idx_limit =
@@ -8832,7 +8837,7 @@ static const unsigned int num_winner_motion_modes[3] = { 0, 10, 6 };
 static AVM_INLINE int is_check_in_winner(const AV2_COMP *cpi,
                                          const MB_MODE_INFO *const mbmi) {
   PREDICTION_MODE this_mode = mbmi->mode;
-  if (cpi->sf.inter_sf.enable_six_param_warp_in_winner_mode) {
+  if (enable_warp_search_in_winner_mode(&cpi->sf.inter_sf)) {
     if (this_mode == WARP_NEWMV) return 1;
   }
   if (cpi->sf.inter_sf.enable_warp_inter_intra_in_winner) {

--- a/av2/encoder/rdopt.h
+++ b/av2/encoder/rdopt.h
@@ -399,6 +399,14 @@ static INLINE bool prune_curr_mv_precision_eval(
 int get_drl_cost(int max_drl_bits, const MB_MODE_INFO *mbmi,
                  const MB_MODE_INFO_EXT *mbmi_ext, const MACROBLOCK *x);
 
+// Returns true if either 4-parameter or 6-parameter warp delta search
+// is enabled in winner mode.
+static INLINE bool enable_warp_search_in_winner_mode(
+    const INTER_MODE_SPEED_FEATURES *inter_sf) {
+  return (inter_sf->enable_six_param_warp_in_winner_mode ||
+          inter_sf->enable_four_param_warp_in_winner_mode);
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -566,6 +566,8 @@ static void set_good_speed_features_framesize_independent(
     sf->inter_sf.reuse_compound_type_data = 0;
     sf->inter_sf.txfm_rd_gate_level =
         boosted ? 0 : (is_boosted_arf2_bwd_type ? 1 : 2);
+    sf->inter_sf.enable_four_param_warp_in_winner_mode =
+        cm->current_frame.pyramid_level >= 3;
 
     // TODO(any): disable_smooth_intra does not have speed up while introducing
     // coding loss. Disable  it before it is improved.
@@ -702,8 +704,10 @@ static void set_good_speed_features_framesize_independent(
     sf->winner_mode_sf.multi_winner_mode_type = MULTI_WINNER_MODE_OFF;
   }
 
-  if (sf->inter_sf.enable_six_param_warp_in_winner_mode) {
+  if (enable_warp_search_in_winner_mode(&sf->inter_sf))
     sf->winner_mode_sf.motion_mode_for_winner_cand = 2;
+
+  if (sf->inter_sf.enable_six_param_warp_in_winner_mode) {
     sf->inter_sf.enable_six_param_warp_in_winner_mode_by_tid =
         cm->current_frame.pyramid_level >= 3 ? 1 : 0;
   }
@@ -889,6 +893,7 @@ static AVM_INLINE void init_flexmv_sf(
 static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->enable_six_param_warp_in_winner_mode = 0;
   inter_sf->enable_six_param_warp_in_winner_mode_by_tid = 0;
+  inter_sf->enable_four_param_warp_in_winner_mode = 0;
   inter_sf->fast_warp_delta_decoupled_search = 0;
   inter_sf->early_term_warp_delta_refine = false;
   inter_sf->comp_inter_joint_search_thresh = BLOCK_4X4;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -619,6 +619,12 @@ typedef struct INTER_MODE_SPEED_FEATURES {
   // Enable six parameter warp in winner mode by tid. If set to 1, enable six
   // parameter warp in winner mode by tid threshold.
   int enable_six_param_warp_in_winner_mode_by_tid;
+
+  // Disable the 4 parameter warp delta refinement during initial mode search
+  // and enable the same during motion mode evaluation for winner candidates.
+  // Enabled for speed >= 3.
+  int enable_four_param_warp_in_winner_mode;
+
   // Drop less likely to be picked reference frames in the RD search.
   // Has five levels for now: 0, 1, 2, 3 and 4, where higher levels prune more
   // aggressively than lower ones. (0 means no pruning).


### PR DESCRIPTION
Added a speed feature to disable 4 parameter
warp delta refinement during the initial mode
search and enable it during motion mode
evaluation for winner candidates.

Enabled for speed >= 3.

Results for RA CTC, A1 17 frames, A2 33 frames,
speed 3: (Anchor: 2128e7e)

```
+-----+------+-------+-----+-------+---------------+
|Class|  Y   |  U    |   V  | YUV  |EncInstCount(%)|
+-----+------+-------+------+------+---------------+
| A1  | 0.03 | -0.04 | 0.02 | 0.02 | 97.5          |
| A2  | 0.05 | -0.16 | 0.17 | 0.05 | 97.1          |
+-----+------+-------+------+------+---------------+
```
STATS_CHANGED for speed >= 3