### PR TITLE
Remove few unused fields/structs and functions from av2 context

### DIFF
--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -521,8 +521,6 @@ typedef struct {
   int cdef_on_skip_txfm_frame_enable;
   //! CDEF on/off for current frame
   int cdef_frame_enable;
-  //! Number of CDEF strength values in bits
-  int cdef_bits;
   //! Number of rows in the frame in 4 pixel
   int allocated_mi_rows;
   //! Number of CDEF workers
@@ -710,7 +708,6 @@ typedef struct {
   // unit
   int brt_from_leading;
   int br_ops_dependent_flag;
-  int ops_id;
   int br_ops_id;
   int br_ops_cnt[MAX_NUM_OPS_ID];
   int br_decoder_model_present_op_flag[MAX_NUM_OPS_ID][MAX_OPS_COUNT];
@@ -724,10 +721,6 @@ typedef struct CroppingWindow {
   int crop_win_right_offset;
   int crop_win_top_offset;
   int crop_win_bottom_offset;
-
-  int crop_info_seq_flag;
-  int crop_max_width;
-  int crop_max_height;
 } CroppingWindow;
 
 typedef struct RepresentationInfo {
@@ -811,21 +804,18 @@ typedef struct GlobalLayerConfigurationRecord {
   int lcr_global_payload_present_flag;
   int lcr_seq_profile_tier_level_info_present_flag;
   int lcr_global_atlas_id_present_flag;
-  int lcr_reserved_zero_2bits;
   int lcr_global_atlas_id;
   int lcr_reserved_zero_3bits;
   int lcr_reserved_zero_5bits;
-  int lcr_data_size_present_flag;
   int lcr_global_purpose_id;
   int lcr_dependent_xlayers_flag;
 
   // Derived
-  int LcrMaxNumXLayerCount;  // NUmber of xlauers in this global LCR
+  int LcrMaxNumXLayerCount;  // number of xlayers in this global LCR
   int LcrXLayerID[31];       // number of xlayers in this global LCR
 
   int lcr_doh_constraint_flag;
   int lcr_enforce_tile_alignment_flag;
-  int lcr_reserved_zero_6bits;
   uint32_t lcr_data_size[MAX_NUM_XLAYERS];
   uint32_t lcr_num_dependent_xlayer_map[MAX_NUM_XLAYERS];
   // Xlayer infor for each extended layer in this global LCR
@@ -1259,7 +1249,6 @@ typedef struct SequenceHeader {
   CropWindow conf;
   uint8_t seq_seg_info_present_flag;
   SegmentationInfoSyntax seg_params;
-  int allow_seg_info_change;
   int seq_extension_present_flag;
   // IMPORTANT: the op_params member must be at the end of the struct so that
   // are_seq_headers_consistent() can be implemented with a memcmp() call.
@@ -1296,7 +1285,6 @@ typedef struct {
   int xlayer_id;
   SkipModeInfo skip_mode_info;
   int refresh_frame_flags;  // Which ref frames are overwritten by this frame
-  bool tile_info_present_in_frame_header;
 } CurrentFrame;
 
 /*!\endcond */
@@ -1537,10 +1525,6 @@ typedef struct MultiFrameHeader {
    * Frame Height of frames that reference this multi-frame header
    */
   int mfh_frame_height;
-  /*!
-   * Render size present flag
-   */
-  int mfh_render_size_present_flag;
   /*!
    * Presence of deblocking loop filter levels in this multi-frame header
    */

--- a/av2/common/quant_common.c
+++ b/av2/common/quant_common.c
@@ -179,12 +179,6 @@ const qm_val_t *av2_iqmatrix(const CommonQuantParams *quant_params, int qmlevel,
          qmlevel == NUM_QM_LEVELS - 1);
   return quant_params->giqmatrix[qmlevel][plane][tx_size];
 }
-const qm_val_t *av2_qmatrix(const CommonQuantParams *quant_params, int qmlevel,
-                            int plane, TX_SIZE tx_size) {
-  assert(quant_params->gqmatrix[qmlevel][plane][tx_size] != NULL ||
-         qmlevel == NUM_QM_LEVELS - 1);
-  return quant_params->gqmatrix[qmlevel][plane][tx_size];
-}
 
 // Returns true if the tx_type corresponds to non-identity transform in both
 // horizontal and vertical directions.
@@ -388,52 +382,6 @@ void av2_qm_init(CommonQuantParams *quant_params, int num_planes) {
               &predefined_iwt_matrix_ref[q][c >= 1][current];
           current += size;
         }
-      }
-    }
-  }
-}
-void av2_qm_replace_level(CommonQuantParams *quant_params, int level,
-                          int num_planes, qm_val_t ***fund_matrices) {
-  const int q = level;
-  for (int c = 0; c < num_planes; ++c) {
-    // Generate matrices for each tx size
-    int current = 0;
-    for (int t = 0; t < TX_SIZES_ALL; ++t) {
-      const int size = tx_size_2d[t];
-      const int qm_tx_size = av2_get_adjusted_tx_size(t);
-      if (q == NUM_QM_LEVELS - 1) {
-        assert(quant_params->gqmatrix[q][c][t] == NULL);
-        assert(quant_params->giqmatrix[q][c][t] == NULL);
-      } else if (t != qm_tx_size) {  // Reuse matrices for 'qm_tx_size'
-        assert(t > qm_tx_size);
-        assert(quant_params->gqmatrix[q][c][t] ==
-               quant_params->gqmatrix[q][c][qm_tx_size]);
-        assert(quant_params->giqmatrix[q][c][t] ==
-               quant_params->giqmatrix[q][c][qm_tx_size]);
-      } else if (t <= TX_8X8 || t == TX_4X8 || t == TX_8X4) {
-        // Use user-defined matrix for 8x8/4x8/8x4.
-        // Downscale 8x8 to 4x4 in the case of user-defined matrices.
-        assert(current + size <= QM_TOTAL_SIZE);
-        // Generate the iwt and wt matrices from the base matrices.
-        const int plane = c;
-        scale_tx(t, plane, &quant_params->iwt_matrix_ref[q][plane][current],
-                 fund_matrices);
-        calc_wt_matrix(t, &quant_params->iwt_matrix_ref[q][plane][current],
-                       &quant_params->wt_matrix_ref[q][plane][current]);
-
-        assert(quant_params->gqmatrix[q][c][t] ==
-               &quant_params->wt_matrix_ref[q][plane][current]);
-        assert(quant_params->giqmatrix[q][c][t] ==
-               &quant_params->iwt_matrix_ref[q][plane][current]);
-        current += size;
-      } else {
-        // Sizes larger than 8x8 use the pre-defined matrices.
-        assert(current + size <= QM_TOTAL_SIZE);
-        quant_params->gqmatrix[q][c][t] =
-            &predefined_wt_matrix_ref[q][c >= 1][current];
-        quant_params->giqmatrix[q][c][t] =
-            &predefined_iwt_matrix_ref[q][c >= 1][current];
-        current += size;
       }
     }
   }

--- a/av2/common/quant_common.h
+++ b/av2/common/quant_common.h
@@ -123,16 +123,11 @@ void av2_qm_frame_update(struct CommonQuantParams *quant_params, int num_planes,
                          int qm_id, qm_val_t ***matrix_set);
 void av2_qm_init(struct CommonQuantParams *quant_params, int num_planes);
 
-void av2_qm_replace_level(struct CommonQuantParams *quant_params, int level,
-                          int num_planes, qm_val_t ***fund_matrices);
 void scale_tx(const int txsize, const int plane, qm_val_t *output,
               qm_val_t ***fund_matrices);
 // Get global dequant matrix.
 const qm_val_t *av2_iqmatrix(const struct CommonQuantParams *quant_params,
                              int qmlevel, int plane, TX_SIZE tx_size);
-// Get global quant matrix.
-const qm_val_t *av2_qmatrix(const struct CommonQuantParams *quant_params,
-                            int qmlevel, int plane, TX_SIZE tx_size);
 
 // Get either local / global dequant matrix as appropriate.
 const qm_val_t *av2_get_iqmatrix(const struct CommonQuantParams *quant_params,

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -4482,9 +4482,8 @@ static AVM_INLINE void decode_tile(AV2Decoder *pbi, ThreadData *const td,
       BruActiveMode sb_active_mode = BRU_ACTIVE_SB;
       av2_set_sb_info(cm, xd, mi_row, mi_col, sb_active_mode);
       set_cb_buffer(pbi, dcb, &td->cb_buffer_base, num_planes, 0, 0);
-      // td->ref_mv_bank is initialized as xd->ref_mv_bank, and used
-      // for MV referencing during decoding the tile.
-      // xd->ref_mv_bank is updated as decoding goes.
+      // xd->ref_mv_bank is used for MV referencing during decoding the tile,
+      // and is updated as decoding goes.
       av2_reset_refmv_bank(cm, xd, &tile_info, mi_row, mi_col);
 
       decode_partition_sb(pbi, td, mi_row, mi_col, td->bit_reader, cm->sb_size,

--- a/av2/decoder/decoder.h
+++ b/av2/decoder/decoder.h
@@ -144,9 +144,6 @@ typedef struct ThreadData {
   decode_block_visitor_fn_t inverse_tx_inter_block_visit;
   predict_inter_block_visitor_fn_t predict_inter_block_visit;
   predict_inter_block_visitor_fn_t copy_frame_mvs_block_visit;
-
-  REF_MV_BANK ref_mv_bank;
-  WARP_PARAM_BANK warp_param_bank;
 } ThreadData;
 
 typedef struct AV2DecRowMTJobInfo {
@@ -288,14 +285,9 @@ typedef struct {
 typedef struct {
   RefCntBuffer *ref_frame_map_buf[REF_FRAMES];
   int remapped_ref_idx_buf[INTER_REFS_PER_FRAME];
-  struct SequenceHeader seq_list_buf[MAX_SEQ_NUM];
   MultiFrameHeader mfh_params_buf[MAX_MFH_NUM];
   int valid_for_referencing_buf[REF_FRAMES];
-  struct LayerConfigurationRecord lcr_list_buf[MAX_NUM_XLAYERS][MAX_NUM_LCR];
   int lcr_counter_buf;
-  struct AtlasSegmentInfo atlas_list_buf[MAX_NUM_ATLAS_SEG_ID];
-  int atlas_counter_buf;
-  struct OperatingPointSet ops_list_buf[MAX_NUM_OPS_ID];
   int ops_counter_buf;
   struct LayerConfigurationRecord *active_lcr_buf;
   struct LayerConfigurationRecord lcr_params_buf;
@@ -313,7 +305,6 @@ typedef struct {
   int olk_refresh_frame_flags_buf[MAX_NUM_MLAYERS];
   int olk_co_vcl_refresh_frame_flags_buf[MAX_NUM_MLAYERS];
   SequenceHeader seq_params_buf;
-  int seq_header_count_buf;
   bool mfh_valid_buf[MAX_MFH_NUM];
   int decoding_first_frame;
   int last_olk_tu_display_order_hint;
@@ -390,7 +381,6 @@ typedef struct AV2Decoder {
   int reset_decoder_state;
 
   int tile_size_bytes;
-  int tile_col_size_bytes;
 #if CONFIG_ACCOUNTING
   int acct_enabled;
   Accounting accounting;
@@ -569,11 +559,6 @@ typedef struct AV2Decoder {
    * only for determining first clk/olk in the tu.
    */
   int current_tlayer_id;
-  /*!
-   * Indicates order_hint_bits to parse order_hint of the frames in the current
-   * data chunk This is used only for determining first clk/olk in the tu.
-   */
-  int current_order_hint_bits;
 
   /*!
    * Indicates the number of displayable_frame_unit  per layer between layer_id

--- a/av2/decoder/obu.h
+++ b/av2/decoder/obu.h
@@ -64,37 +64,6 @@ typedef enum {
                              // QM, MFH, BRT
 } temporal_unit_state_t;
 
-// Multi-layer frame validation state
-typedef struct {
-  int mlayer_id;
-  int hidden_picture_count;
-  int showable_picture_count;
-  int has_clk;
-  int has_olk;
-  int display_order_hint;
-  int first_picture_unit_processed;
-} mlayer_frame_state_t;
-
-typedef struct {
-  mlayer_frame_state_t layers[8];  // MAX_NUM_MLAYERS
-  int num_active_layers;
-  int lowest_mlayer_id;
-  int global_display_order_hint;
-  int has_any_showable_unit;
-  int clk_olk_exclusion_violated;
-} mlayer_validation_state_t;
-
-// OBU info structure for validation
-typedef struct {
-  int obu_type;
-  int mlayer_id;
-  int tlayer_id;
-  int xlayer_id;
-  int order_hint;
-  int is_showable;
-  int is_hidden;
-} test_obu_info_t;
-
 int check_temporal_unit_structure(temporal_unit_state_t *state, int obu_type,
                                   int xlayer_id, int metadata_is_suffix,
                                   int prev_obu_type, int prev_xlayer_id);

--- a/av2/encoder/encoder.h
+++ b/av2/encoder/encoder.h
@@ -2278,7 +2278,6 @@ typedef struct {
 
 typedef struct {
   // Some misc info
-  int high_prec;
   int q;
   int order;
 

--- a/av2/encoder/partition_search.c
+++ b/av2/encoder/partition_search.c
@@ -4430,7 +4430,6 @@ static void split_partition_search(
     part_search_state->found_best_partition = true;
     pc_tree->partitioning = PARTITION_SPLIT;
     pc_tree->skippable = skippable;
-  } else if (cpi->sf.part_sf.less_rectangular_check_level > 0) {
   }
 #if CONFIG_COLLECT_PARTITION_STATS
   end_partition_block_timer(part_timing_stats, PARTITION_SPLIT, sum_rdc.rdcost);

--- a/av2/encoder/pickrst.c
+++ b/av2/encoder/pickrst.c
@@ -115,8 +115,6 @@ typedef struct {
   int tile_stripe0;
   // Helps convert tile-localized RU indices to frame RU indices.
   int ru_idx_base;
-  // Number of RUs in tile
-  int num_rus_in_tile;
 
   WienerNonsepInfoBank wienerns_bank;
 
@@ -269,8 +267,6 @@ static AVM_INLINE void rsc_on_tile(void *priv, int idx_base, int tile_row,
   int ru_col_start, ru_col_end;
   get_ru_limits_in_tile(rsc->cm, rsc->plane, tile_row, tile_col, &ru_row_start,
                         &ru_row_end, &ru_col_start, &ru_col_end);
-  rsc->num_rus_in_tile =
-      (ru_row_end - ru_row_start) * (ru_col_end - ru_col_start);
 }
 
 static AVM_INLINE void reset_rsc(RestSearchCtxt *rsc) {

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -310,7 +310,6 @@ static void set_good_speed_features_framesize_independent(
   sf->gm_sf.prune_ref_frame_for_gm_search = boosted ? 0 : 1;
   sf->gm_sf.disable_gm_search_based_on_stats = 1;
 
-  sf->part_sf.less_rectangular_check_level = 1;
   // This speed feature is currently not implemented. See comment in
   // av2_simple_motion_search_prune_rect() function.
   sf->part_sf.simple_motion_search_prune_rect = 0;
@@ -325,7 +324,6 @@ static void set_good_speed_features_framesize_independent(
   sf->inter_sf.prune_motion_mode_level = 1;
   sf->inter_sf.prune_ref_frames = 0;
   sf->inter_sf.prune_wedge_pred_diff_based = 1;
-  sf->inter_sf.reduce_inter_modes = 1;
   sf->inter_sf.selective_ref_frame = 1;
   sf->inter_sf.skip_mode_eval_based_on_rate_cost = 1;
   sf->inter_sf.skip_eval_intrabc_in_inter_frame =
@@ -478,7 +476,6 @@ static void set_good_speed_features_framesize_independent(
         (frame_is_intra_only(&cpi->common) || (allow_screen_content_tools))
             ? 0
             : (boosted ? 1 : 2);
-    sf->inter_sf.reduce_inter_modes = boosted ? 1 : 2;
     sf->inter_sf.reuse_inter_intra_mode = 1;
     sf->inter_sf.selective_ref_frame = 2;
     sf->inter_sf.skip_repeated_newmv = 1;
@@ -521,7 +518,6 @@ static void set_good_speed_features_framesize_independent(
     sf->hl_sf.recode_loop = ALLOW_RECODE_KFARFGF;
 
     sf->part_sf.allow_partition_search_skip = 1;
-    sf->part_sf.less_rectangular_check_level = 2;
     sf->part_sf.simple_motion_search_prune_agg = 1;
     sf->part_sf.simple_motion_search_early_term_none = 1;
     // TODO(Venkat): Clean-up frame type dependency for
@@ -795,7 +791,6 @@ static AVM_INLINE void init_gm_sf(GLOBAL_MOTION_SPEED_FEATURES *gm_sf) {
 
 static AVM_INLINE void init_part_sf(PARTITION_SPEED_FEATURES *part_sf) {
   part_sf->partition_search_type = SEARCH_PARTITION;
-  part_sf->less_rectangular_check_level = 0;
   part_sf->use_square_partition_only_threshold = BLOCK_128X128;
   part_sf->auto_max_partition_based_on_simple_motion = NOT_IN_USE;
   part_sf->default_max_partition_size = BLOCK_LARGEST;
@@ -901,7 +896,6 @@ static AVM_INLINE void init_inter_sf(INTER_MODE_SPEED_FEATURES *inter_sf) {
   inter_sf->model_based_post_interp_filter_breakout = 0;
   inter_sf->skip_temporary_pred_for_opfl = 0;
   inter_sf->enable_warp_inter_intra_in_winner = 0;
-  inter_sf->reduce_inter_modes = 0;
   inter_sf->alt_ref_search_fp = 0;
   inter_sf->disable_switchable_refinemv = 0;
   inter_sf->reduce_comp_refs = 0;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -328,11 +328,6 @@ typedef struct PARTITION_SPEED_FEATURES {
   // 1 - 2 increasing aggressiveness in order.
   int ml_early_term_after_part_split_level;
 
-  // Skip rectangular partition test when partition type none gives better
-  // rd than partition type split. Can take values 0 - 2, 0 referring to no
-  // skipping, and 1 - 2 increasing aggressiveness of skipping in order.
-  int less_rectangular_check_level;
-
   // Use square partition only beyond this block size.
   BLOCK_SIZE use_square_partition_only_threshold;
 
@@ -604,9 +599,6 @@ typedef struct INTER_MODE_SPEED_FEATURES {
 
   // Bypass transform search based on skip rd
   int txfm_rd_gate_level;
-
-  // Limit the inter mode tested in the RD loop
-  int reduce_inter_modes;
 
   // This variable is used to cap the maximum number of times we skip testing a
   // mode to be evaluated. A high value means we will be faster.


### PR DESCRIPTION
- StreamInfo.seq_list_buf/lcr_list_buf/atlas_list_buf/ atlas_counter_buf/ops_list_buf/seq_header_count_buf
- ThreadData.ref_mv_bank/warp_param_bank
- AV2Decoder.tile_col_size_bytes/current_order_hint_bits
- mlayer_frame_state_t
- mlayer_validation_state_t
- test_obu_info_t
- CroppingWindow.crop_info_seq_flag/crop_max_width/ crop_max_height
- GlobalLayerConfigurationRecord.lcr_reserved_zero_2bits/ lcr_reserved_zero_6bits/lcr_data_size_present_flag
- SequenceHeader.allow_seg_info_change
- BufferRemovalTimingInfo.ops_id
- CdefInfo.cdef_bits
- CurrentFrame.tile_info_present_in_frame_header
- MultiFrameHeader.mfh_render_size_present_flag
- RestSearchCtxt.num_rus_in_tile
- INTER_MODE_SPEED_FEATURES.reduce_inter_modes
- MV_STATS.high_prec
- PARTITION_SPEED_FEATURES.less_rectangular_check_level
- Usage of av2_qmatrix() was removed in 99bac040e1 av1 commit. Hence its definition
and declaration are now being removed.
- Usage of av2_qm_replace_level() was removed in 57a0841c5. Hence its definition and declaration
are now being removed.