### PR TITLE
Skip transform type search and RDOQ in the dry pass

### DIFF
--- a/av2/encoder/intra_mode_search.c
+++ b/av2/encoder/intra_mode_search.c
@@ -1671,6 +1671,11 @@ static AVM_INLINE void refine_winner_intra_mode_tx(
   MACROBLOCKD *const xd = &x->e_mbd;
   MB_MODE_INFO *const mbmi = xd->mi[0];
 
+  // Dry pass ranks partition shapes only, so winner-mode TX refinement is
+  // wasted precision: the dry-pass overrides re-collapse the search back to
+  // MODE_EVAL-quality anyway. See refine_winner_mode_tx() for the inter path.
+  if (x->apply_dry_pass_shortcuts) return;
+
   // If previous searches use only the default tx type/no R-D optimization of
   // quantized coeffs, do an extra search for the best tx type/better R-D
   // optimization of quantized coeffs.

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -7388,6 +7388,12 @@ static AVM_INLINE void refine_winner_mode_tx(
   if (!is_winner_mode_processing_enabled(cpi, best_mbmode, best_mbmode->mode))
     return;
 
+  // Dry pass ranks partition shapes only, so winner-mode TX refinement is
+  // wasted precision: the dry-pass overrides would re-collapse the search
+  // back to MODE_EVAL-quality anyway, and the prediction/residual/tx-size
+  // rebuild it performs first is pure overhead.
+  if (x->apply_dry_pass_shortcuts) return;
+
   // Set params for winner mode evaluation
   set_mode_eval_params(cpi, x, WINNER_MODE_EVAL);
 

--- a/av2/encoder/rdopt_utils.h
+++ b/av2/encoder/rdopt_utils.h
@@ -187,6 +187,24 @@ static TX_MODE select_tx_mode(
     return TX_MODE_SELECT;
   }
 }
+
+// Restrict transform type and size search in the dry pass of the fast two-pass
+// partition search, which only needs a rough shape ranking.
+static INLINE void set_dry_pass_txfm_params(const AV2_COMMON *cm,
+                                            MACROBLOCK *x) {
+  if (!x->apply_dry_pass_shortcuts) return;
+  TxfmSearchParams *txfm_params = &x->txfm_search_params;
+  txfm_params->use_default_intra_tx_type = 1;
+  txfm_params->use_default_inter_tx_type = 1;
+  // Preserve USE_LARGESTALL: it already routes through the fast
+  // choose_largest_tx_size() path, so demoting to USE_FAST_RD would be a
+  // regression. USE_FULL_RD -> USE_FAST_RD relaxes the recursive size search.
+  if (txfm_params->tx_size_search_method != USE_LARGESTALL)
+    txfm_params->tx_size_search_method = USE_FAST_RD;
+  txfm_params->tx_mode_search_type =
+      select_tx_mode(cm, txfm_params->tx_size_search_method);
+}
+
 // Checks the conditions to enable winner mode processing
 static INLINE int is_winner_mode_processing_enabled(
     const struct AV2_COMP *cpi, MB_MODE_INFO *const mbmi,
@@ -386,6 +404,9 @@ static INLINE void set_mode_eval_params(const struct AV2_COMP *cpi,
       break;
     default: assert(0);
   }
+
+  // Applied last so the dry-pass overrides win over per-stage defaults.
+  set_dry_pass_txfm_params(cm, x);
 }
 
 // Similar to store_cfl_required(), but for use during the RDO process,

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -2381,6 +2381,11 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
 
   skip_trellis |=
       !is_trellis_used(cpi->optimize_seg_arr[mbmi->segment_id], DRY_RUN_NORMAL);
+  // Skip RDOQ in the dry pass, except under TCQ whose state-machine dequant
+  // needs trellis-quantized coefficients for correct distortion.
+  skip_trellis |=
+      x->apply_dry_pass_shortcuts &&
+      !tcq_enable(cm->features.tcq_mode, is_lossless, plane, TX_CLASS_2D);
 
   uint8_t best_txb_ctx = 0;
   // txk_allowed = TX_TYPES: >1 tx types are allowed.
@@ -3575,8 +3580,10 @@ static AVM_INLINE void choose_largest_tx_size(const AV2_COMP *const cpi,
   const int64_t no_skip_txfm_rd = is_inter_block(mbmi, xd->tree_type)
                                       ? RDCOST(x->rdmult, no_skip_txfm_rate, 0)
                                       : 0;
-  // Dry pass: skip trellis (no RDOQ) — light quant only.
-  const int skip_trellis = x->apply_dry_pass_shortcuts ? 1 : 0;
+  // Trellis is decided centrally inside search_tx_type() (reached transitively
+  // via av2_txfm_rd_in_plane -> block_rd_txfm), which OR-s in the dry-pass
+  // skip regardless of what the caller passes here.
+  const int skip_trellis = 0;
   av2_txfm_rd_in_plane(x, cpi, rd_stats, ref_best_rd,
                        AVMMIN(no_skip_txfm_rd, skip_txfm_rd), AVM_PLANE_Y, bs,
                        FTXS_NONE, skip_trellis);
@@ -4357,7 +4364,10 @@ int av2_txfm_uvrd(const AV2_COMP *const cpi, MACROBLOCK *x, RD_STATS *rd_stats,
   const BLOCK_SIZE plane_bsize = get_mb_plane_block_size(
       xd, mbmi, AVM_PLANE_U, pd->subsampling_x, pd->subsampling_y);
 
-  const int skip_trellis = 0;
+  // Skip RDOQ in the dry pass for chroma; also flows into search_cctx_type().
+  // No TCQ guard needed here: TCQ is luma-only per the finalized AV2 spec
+  // (tcq_enable() gates on plane == 0).
+  const int skip_trellis = x->apply_dry_pass_shortcuts;
   int is_cost_valid = 1;
   if (is_cctx_allowed(&cpi->common, xd)) {
     RD_STATS this_rd_stats;


### PR DESCRIPTION
The dry pass of the fast two-pass partition search only ranks partition shapes, so a full transform type search and RDOQ are wasted precision. Restrict it to a single default transform type with USE_FAST_RD size search, and skip trellis (except under TCQ, whose state-machine dequant needs the RDOQ coefficients).

Anchor: commit 18a0096
Speed 2 (cpu-used=2): FG16 CTC (33 frames, class A1 and A2, RA)
Speed 3 (cpu-used=3): FG16 CTC (33 frames, class A1 and A2, RA)
Speed 4 (cpu-used=4): FG16 CTC (33 frames, class A1 and A2, RA)

```
1) Speed 2 (cpu-used=2)
  +------------+------+-------+-------+------+------+------+
  | Class      |    Y |    Cb |    Cr | wAvg | Enc% | Dec% |
  +------------+------+-------+-------+------+------+------+
  | A1         | 0.03 | -0.07 | -0.08 | 0.03 |   97 |  100 |
  | A2         | 0.00 |  0.00 |  0.00 | 0.00 |  100 |  100 |
  | Avg w/o B2 | 0.01 | -0.02 | -0.02 | 0.01 |   99 |  100 |
  +------------+------+-------+-------+------+------+------+

2) Speed 3 (cpu-used=3)
  +------------+------+-------+-------+------+------+------+
  | Class      |    Y |    Cb |    Cr | wAvg | Enc% | Dec% |
  +------------+------+-------+-------+------+------+------+
  | A1         | 0.06 | -0.16 |  0.14 | 0.05 |   97 |  100 |
  | A2         | 0.07 | -0.12 | -0.04 | 0.06 |   96 |  100 |
  | Avg w/o B2 | 0.07 | -0.14 |  0.01 | 0.06 |   96 |  100 |
  +------------+------+-------+-------+------+------+------+

3) Speed 4 (cpu-used=4)
  +------------+------+-------+-------+------+------+------+
  | Class      |    Y |    Cb |    Cr | wAvg | Enc% | Dec% |
  +------------+------+-------+-------+------+------+------+
  | A1         | 0.05 | -0.17 | -0.02 | 0.04 |   98 |  100 |
  | A2         | 0.02 |  0.04 | -0.18 | 0.01 |   97 |   99 |
  | Avg w/o B2 | 0.03 | -0.02 | -0.13 | 0.02 |   97 |  100 |
  +------------+------+-------+-------+------+------+------+
```

Speed 2 class A2 shows all zeros because the fast two-pass partition search is not enabled for speed 2 class A2, so this change is a no-op there.

STATS_CHANGED