### PR TITLE
Apply 8x8 partition floor at 1080p from speed 1

### DIFF
--- a/av2/common/alloccommon.c
+++ b/av2/common/alloccommon.c
@@ -600,9 +600,10 @@ int av2_alloc_superblock_info_buffers(AV2_COMMON *cm) {
   return alloc_sbi(sbi_params);
 }
 
-int av2_alloc_context_buffers(AV2_COMMON *cm, int width, int height) {
+int av2_alloc_context_buffers(AV2_COMMON *cm, int width, int height,
+                              int speed) {
   CommonModeInfoParams *const mi_params = &cm->mi_params;
-  mi_params->set_mb_mi(mi_params, width, height);
+  mi_params->set_mb_mi(mi_params, width, height, speed);
   if (alloc_mi(mi_params, cm, height)) goto fail;
 
   if (av2_alloc_superblock_info_buffers(cm)) goto fail;
@@ -611,7 +612,7 @@ int av2_alloc_context_buffers(AV2_COMMON *cm, int width, int height) {
 
 fail:
   // clear the mi_* values to force a realloc on resync
-  mi_params->set_mb_mi(mi_params, 0, 0);
+  mi_params->set_mb_mi(mi_params, 0, 0, speed);
   av2_free_context_buffers(cm);
   return 1;
 }

--- a/av2/common/alloccommon.h
+++ b/av2/common/alloccommon.h
@@ -36,7 +36,8 @@ int av2_alloc_above_context_buffers(struct CommonContexts *above_contexts,
                                     int num_planes);
 void av2_free_above_context_buffers(struct CommonContexts *above_contexts);
 int av2_alloc_superblock_info_buffers(struct AV2Common *cm);
-int av2_alloc_context_buffers(struct AV2Common *cm, int width, int height);
+int av2_alloc_context_buffers(struct AV2Common *cm, int width, int height,
+                              int speed);
 void av2_init_mi_buffers(struct CommonModeInfoParams *mi_params);
 void av2_free_context_buffers(struct AV2Common *cm);
 

--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -1613,9 +1613,8 @@ struct CommonModeInfoParams {
   int mi_alloc_stride;
   /*!
    * The minimum block size that each element in 'mi_alloc' can correspond to.
-   * For decoder, this is always BLOCK_4X4.
-   * For encoder, this is currently set to BLOCK_4X4 for resolution < 4k,
-   * and BLOCK_8X8 for resolution >= 4k.
+   * For decoder, always BLOCK_4X4. For encoder, BLOCK_8X8 at 4k, and at 1080p
+   * from speed 1; BLOCK_4X4 otherwise. Computed in 'enc_set_mb_mi()'.
    */
   BLOCK_SIZE mi_alloc_bsize;
 
@@ -1702,9 +1701,10 @@ struct CommonModeInfoParams {
    * \param[in,out]   mi_params   object containing common mode info parameters
    * \param           width       frame width
    * \param           height      frame height
+   * \param           speed       encoder speed level (ignored by the decoder)
    */
   void (*set_mb_mi)(struct CommonModeInfoParams *mi_params, int width,
-                    int height);
+                    int height, int speed);
   /**@}*/
 };
 

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -3602,7 +3602,7 @@ static AVM_INLINE void resize_context_buffers(AV2_COMMON *cm, int width,
     // dimensions as well as the overall size.
     if (new_mi_cols > cm->mi_params.mi_cols ||
         new_mi_rows > cm->mi_params.mi_rows) {
-      if (av2_alloc_context_buffers(cm, width, height)) {
+      if (av2_alloc_context_buffers(cm, width, height, 0)) {
         // The cm->mi_* values have been cleared and any existing context
         // buffers have been freed. Clear cm->width and cm->height to be
         // consistent and to force a realloc next time.
@@ -3612,7 +3612,7 @@ static AVM_INLINE void resize_context_buffers(AV2_COMMON *cm, int width,
                            "Failed to allocate context buffers");
       }
     } else {
-      cm->mi_params.set_mb_mi(&cm->mi_params, width, height);
+      cm->mi_params.set_mb_mi(&cm->mi_params, width, height, 0);
     }
     av2_init_mi_buffers(&cm->mi_params);
     cm->width = width;

--- a/av2/decoder/decoder.c
+++ b/av2/decoder/decoder.c
@@ -85,7 +85,8 @@ static void update_subgop_stats(const AV2_COMMON *const cm,
 }
 
 static void dec_set_mb_mi(CommonModeInfoParams *mi_params, int width,
-                          int height) {
+                          int height, int speed) {
+  (void)speed;
   // Ensure that the decoded width and height are both multiples of
   // 8 luma pixels (note: this may only be a multiple of 4 chroma pixels if
   // subsampling is used).

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -246,7 +246,7 @@ static void update_frame_size(AV2_COMP *cpi) {
 
   // We need to reallocate the context buffers here in case we need more mis or
   // if we need more superblocks.
-  if (av2_alloc_context_buffers(cm, cm->width, cm->height)) {
+  if (av2_alloc_context_buffers(cm, cm->width, cm->height, cpi->oxcf.speed)) {
     avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
                        "Failed to allocate context buffers");
   }

--- a/av2/encoder/encoder_alloc.h
+++ b/av2/encoder/encoder_alloc.h
@@ -65,7 +65,7 @@ static AVM_INLINE void alloc_compressor_data(AV2_COMP *cpi) {
   TokenInfo *token_info = &cpi->token_info;
   cpi->alloc_width = cm->width;
   cpi->alloc_height = cm->height;
-  if (av2_alloc_context_buffers(cm, cm->width, cm->height)) {
+  if (av2_alloc_context_buffers(cm, cm->width, cm->height, cpi->oxcf.speed)) {
     avm_internal_error(&cm->error, AVM_CODEC_MEM_ERROR,
                        "Failed to allocate context buffers");
   }

--- a/av2/encoder/encoder_utils.h
+++ b/av2/encoder/encoder_utils.h
@@ -96,16 +96,28 @@ static AVM_INLINE void enc_free_mi(CommonModeInfoParams *mi_params) {
   av2_dealloc_class_id_array(mi_params);
 }
 
+// The smallest block the encoder's partition search may produce: 8x8 at 4k,
+// and at 1080p from speed 1; 4x4 otherwise. Shared by enc_set_mb_mi(), which
+// sizes the mode-info grid, and set_good_speed_feature_framesize_dependent(),
+// which sets default_min_partition_size -- the two must agree.
+static AVM_INLINE BLOCK_SIZE av2_enc_partition_floor(int speed, int width,
+                                                     int height) {
+  const int min_dim = AVMMIN(width, height);
+  if (min_dim >= 2160) return BLOCK_8X8;
+  if (min_dim >= 1080 && speed >= 1) return BLOCK_8X8;
+  return BLOCK_4X4;
+}
+
 static AVM_INLINE void enc_set_mb_mi(CommonModeInfoParams *mi_params, int width,
-                                     int height) {
-  const int is_4k_or_larger = AVMMIN(width, height) >= 2160;
-  mi_params->mi_alloc_bsize = is_4k_or_larger ? BLOCK_8X8 : BLOCK_4X4;
+                                     int height, int speed) {
+  mi_params->mi_alloc_bsize = av2_enc_partition_floor(speed, width, height);
 
   set_mb_mi(mi_params, width, height);
 }
 
 static AVM_INLINE void stat_stage_set_mb_mi(CommonModeInfoParams *mi_params,
-                                            int width, int height) {
+                                            int width, int height, int speed) {
+  (void)speed;
   mi_params->mi_alloc_bsize = BLOCK_16X16;
 
   set_mb_mi(mi_params, width, height);

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -161,9 +161,9 @@ static void set_good_speed_feature_framesize_dependent(
     sf->part_sf.auto_max_partition_based_on_simple_motion = DIRECT_PRED;
   }
 
-  if (is_4k_or_larger) {
-    sf->part_sf.default_min_partition_size = BLOCK_8X8;
-  }
+  // 8x8 partition floor at 4k, and at 1080p from speed 1.
+  sf->part_sf.default_min_partition_size =
+      av2_enc_partition_floor(speed, cm->width, cm->height);
 
   // TODO(huisu@google.com): train models for 720P and above.
   if (!is_720p_or_larger) {
@@ -256,10 +256,6 @@ static void set_good_speed_feature_framesize_dependent(
       sf->part_sf.auto_max_partition_based_on_simple_motion = NOT_IN_USE;
     } else if (is_480p_or_larger) {
       sf->part_sf.auto_max_partition_based_on_simple_motion = DIRECT_PRED;
-    }
-
-    if (is_1080p_or_larger) {
-      sf->part_sf.default_min_partition_size = BLOCK_8X8;
     }
 
     if (is_720p_or_larger) {


### PR DESCRIPTION
The encoder already sets default_min_partition_size to 8x8 at 4k
and larger for all speeds. Extend that floor to 1080p and larger
from speed 1, and drop the now-duplicate 1080p check under
speed >= 6.

Thread the current speed through av2_alloc_context_buffers() to
enc_set_mb_mi() so mi_alloc_bsize tracks the same partition floor
without stashing speed on mi_params. RT keeps its pre-existing
mi_alloc_bsize behavior (always 8x8 at 4k) and will be revisited
separately.

Anchor: commit 4ced699
CTC: FG16 CTC (33 frames, class A1 and A2, RA)

```
1) Speed 1 (cpu-used=1)
  +------------+-------+-------+-------+-------+------+------+
  | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
  +------------+-------+-------+-------+-------+------+------+
  | A1         |  0.00 |  0.00 |  0.00 |  0.00 |  100 |  100 |
  | A2         |  0.14 |  0.32 |  0.85 |  0.17 |   93 |   99 |
  | Avg w/o B2 |  0.10 |  0.22 |  0.60 |  0.12 |   95 |   99 |
  +------------+-------+-------+-------+-------+------+------+

2) Speed 2 (cpu-used=2)
  +------------+-------+-------+-------+-------+------+------+
  | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
  +------------+-------+-------+-------+-------+------+------+
  | A1         |  0.00 |  0.00 |  0.00 |  0.00 |  100 |  100 |
  | A2         |  0.04 |  0.04 |  0.30 |  0.05 |   97 |  100 |
  | Avg w/o B2 |  0.03 |  0.03 |  0.21 |  0.03 |   98 |  100 |
  +------------+-------+-------+-------+-------+------+------+

3) Speed 3 (cpu-used=3)
  +------------+-------+-------+-------+-------+------+------+
  | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
  +------------+-------+-------+-------+-------+------+------+
  | A1         |  0.00 |  0.00 |  0.00 |  0.00 |  100 |  100 |
  | A2         |  0.09 |  0.30 |  0.11 |  0.10 |   96 |  100 |
  | Avg w/o B2 |  0.06 |  0.21 |  0.08 |  0.07 |   97 |  100 |
  +------------+-------+-------+-------+-------+------+------+

4) Speed 4 (cpu-used=4)
  +------------+-------+-------+-------+-------+------+------+
  | Class      |     Y |    Cb |    Cr |  wAvg | Enc% | Dec% |
  +------------+-------+-------+-------+-------+------+------+
  | A1         |  0.02 |  0.02 |  0.00 |  0.02 |  100 |  100 |
  | A2         |  0.20 |  0.27 |  0.00 |  0.20 |   94 |  100 |
  | Avg w/o B2 |  0.15 |  0.19 |  0.00 |  0.14 |   96 |  100 |
  +------------+-------+-------+-------+-------+------+------+
```

STATS_CHANGED