### PR TITLE
Transform search result cache speed feature for speed 1

### DIFF
--- a/av2/av2.cmake
+++ b/av2/av2.cmake
@@ -290,6 +290,8 @@ list(
   "${AVM_ROOT}/av2/encoder/tokenize.h"
   "${AVM_ROOT}/av2/encoder/tpl_model.c"
   "${AVM_ROOT}/av2/encoder/tpl_model.h"
+  "${AVM_ROOT}/av2/encoder/tx_cache.c"
+  "${AVM_ROOT}/av2/encoder/tx_cache.h"
   "${AVM_ROOT}/av2/encoder/tx_search.c"
   "${AVM_ROOT}/av2/encoder/tx_search.h"
   "${AVM_ROOT}/av2/encoder/intra_mode_search.c"

--- a/av2/encoder/block.h
+++ b/av2/encoder/block.h
@@ -26,6 +26,7 @@
 #include "av2/encoder/hash.h"
 #include "av2/encoder/hash_motion.h"
 #include "av2/encoder/partition_cnn_weights.h"
+#include "av2/encoder/tx_cache.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -762,6 +763,14 @@ typedef struct {
    */
   //! Txfm hash record for the whole coding block.
   MB_RD_RECORD mb_rd_record;
+
+  /*! \brief Transform search result cache.
+   *
+   * Frame-scoped table of winning transform types, see tx_cache.h. Held by
+   * value so that it is per-thread and has this struct's lifetime; gated by
+   * TX_SPEED_FEATURES::use_tx_result_cache.
+   */
+  TxCache tx_result_cache;
 
   /*! \brief Number of txb splits.
    *

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -976,6 +976,7 @@ static AVM_INLINE void init_tx_sf(TX_SPEED_FEATURES *tx_sf) {
   tx_sf->tx_type_search.use_skip_flag_prediction = 1;
   tx_sf->tx_type_search.use_reduced_intra_txset = 0;
   tx_sf->tx_type_search.fast_inter_tx_type_search = 0;
+  tx_sf->use_tx_result_cache = 0;
   tx_sf->tx_type_search.skip_tx_search = 0;
   tx_sf->tx_type_search.eob_adapt_skip_tx_search = false;
   tx_sf->tx_type_search.skip_tx_search_max_eob = 1024;
@@ -1544,6 +1545,11 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
 
   const int qindex_offset = MAXQ_OFFSET * (cm->seq_params.bit_depth - 8);
   const int qindex_thresh3 = 195 + qindex_offset;
+
+  // Speed 1 and fine quantizers only; assigned, not cleared, because this
+  // function runs per frame while the framesize-independent pass does not.
+  sf->tx_sf.use_tx_result_cache = (cpi->oxcf.mode == GOOD && speed == 1 &&
+                                   cpi->oxcf.rc_cfg.qp < 210 + qindex_offset);
 
   if (cpi->oxcf.mode == GOOD && speed == 0) {
     const int qindex_thresh = 124 + qindex_offset;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -937,6 +937,12 @@ typedef struct TX_SPEED_FEATURES {
   // 1-2: progressively increasing aggressiveness of pruning
   int model_based_prune_tx_search_level;
 
+  /*!
+   * Reuse the winning transform type of an identical earlier transform block to
+   * narrow the transform type and IST search (av2/encoder/tx_cache.h).
+   */
+  int use_tx_result_cache;
+
   // Prune RD evaluation of secondary transform using the SSE of secondary
   // transform output.
   bool prune_tx_rd_eval_sec_tx_sse;

--- a/av2/encoder/tx_cache.c
+++ b/av2/encoder/tx_cache.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+#include <assert.h>
+
+#include "avm/avm_integer.h"
+#include "av2/encoder/tx_cache.h"
+
+static AVM_INLINE uint64_t tx_cache_fold(uint64_t h, uint64_t v) {
+  h ^= v;
+  h *= 1099511628211ULL;
+  return h;
+}
+
+// FNV-1a over the residual, the quantizer and the entropy contexts.
+uint64_t av2_tx_cache_hash(const int16_t *residual, int stride, int tx_w,
+                           int tx_h, int qindex, int txb_skip_ctx,
+                           int dc_sign_ctx) {
+  assert(stride >= tx_w);  // else rows overlap and distinct residuals alias
+  uint64_t h = 1469598103934665603ULL;
+  for (int r = 0; r < tx_h; ++r) {
+    const int16_t *row = residual + (size_t)r * stride;
+    for (int c = 0; c < tx_w; ++c) {
+      // uint16_t first: same width, but stops sign extension smearing bits.
+      h = tx_cache_fold(h, (uint64_t)(uint16_t)row[c]);
+    }
+  }
+  h = tx_cache_fold(h, ((uint64_t)qindex << 32) |
+                           ((uint64_t)txb_skip_ctx << 16) | dc_sign_ctx);
+  return tx_cache_fold(h, ((uint64_t)tx_w << 32) | tx_h);
+}
+
+// Fold in the rest of the state that can flip which candidate wins. Only
+// bounded fields are bit-packed; unbounded ones are folded separately so they
+// cannot alias. The superblock coordinates are zero: the key is frame-scoped.
+uint64_t av2_tx_cache_mix(uint64_t h, uint32_t sb_row, uint32_t sb_col,
+                          int is_inter, int is_fsc, int intra_mode,
+                          int rd_model, int skip_trellis, int tx_set_type,
+                          int use_qmatrix, int rdmult) {
+  const uint32_t flags = ((is_inter != 0) << 0) | ((is_fsc != 0) << 1) |
+                         ((skip_trellis != 0) << 2) |
+                         ((use_qmatrix != 0) << 3) | ((rd_model & 0xF) << 4) |
+                         ((intra_mode & 0x3F) << 8) |
+                         ((tx_set_type & 0xFF) << 16);
+  h = tx_cache_fold(h, flags);
+  h = tx_cache_fold(h, (uint32_t)rdmult);
+  h = tx_cache_fold(h, ((uint64_t)sb_row << 32) | sb_col);
+  h ^= h >> 31;
+  return h ? h : 1;
+}
+
+// Cached winning tx_type for this frame, or -1 on a miss. A never-written slot
+// (tag 0) ends the probe: no store for this frame can have walked past it.
+int av2_tx_cache_lookup(const TxCache *cache, uint64_t key, uint32_t frame) {
+  const uint32_t tag = frame + 1;
+  const uint32_t idx = (uint32_t)key & TX_CACHE_MASK;
+  for (int p = 0; p < TX_CACHE_PROBE; ++p) {
+    const TxCacheEntry *e = &cache->entries[(idx + p) & TX_CACHE_MASK];
+    if (e->tag == 0) return -1;
+    if (e->tag == tag && e->key == key) return e->winner;
+  }
+  return -1;
+}
+
+// Takes the first slot in the window that is free, stale, or already this key.
+void av2_tx_cache_store(TxCache *cache, uint64_t key, uint16_t winner,
+                        uint32_t frame) {
+  const uint32_t tag = frame + 1;
+  const uint32_t idx = (uint32_t)key & TX_CACHE_MASK;
+  for (int p = 0; p < TX_CACHE_PROBE; ++p) {
+    TxCacheEntry *e = &cache->entries[(idx + p) & TX_CACHE_MASK];
+    if (e->tag != tag || e->key == key) {
+      e->key = key;
+      e->winner = winner;
+      e->tag = tag;
+      return;
+    }
+  }
+  // Window full of this frame's entries: overwrite the first so it never
+  // stalls.
+  TxCacheEntry *e = &cache->entries[idx];
+  e->key = key;
+  e->winner = winner;
+  e->tag = tag;
+}

--- a/av2/encoder/tx_cache.h
+++ b/av2/encoder/tx_cache.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.  If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+// Transform search result cache: storage only.  An entry holds the transform
+// type that won for a key, plus the frame it was produced in so that entries
+// from earlier frames are ignored and recycled instead of cleared.  The table
+// is embedded in TxfmSearchInfo, so it is per-thread and needs no allocation.
+
+#ifndef AVM_AV2_ENCODER_TX_CACHE_H_
+#define AVM_AV2_ENCODER_TX_CACHE_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TX_CACHE_BITS 16  // 64K entries, 1 MiB
+#define TX_CACHE_SIZE (1u << TX_CACHE_BITS)
+#define TX_CACHE_MASK (TX_CACHE_SIZE - 1u)
+#define TX_CACHE_PROBE 8  // linear probe depth
+
+/*! Cache slot: a fully mixed key, the transform type that won for it, and the
+ *  frame it belongs to (frame_number + 1; 0 means the slot was never written).
+ */
+typedef struct {
+  uint64_t key;
+  uint16_t winner;  // full tx_type: primary | secondary | secondary set
+  uint32_t tag;
+} TxCacheEntry;
+
+/*! Transform search result cache. Entries are scoped to the frame they were
+ *  produced in, so the table is never cleared.
+ */
+typedef struct {
+  TxCacheEntry entries[TX_CACHE_SIZE];
+} TxCache;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // AVM_AV2_ENCODER_TX_CACHE_H_

--- a/av2/encoder/tx_cache.h
+++ b/av2/encoder/tx_cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Alliance for Open Media. All rights reserved
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved
  *
  * This source code is subject to the terms of the BSD 3-Clause Clear License
  * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
@@ -10,10 +10,10 @@
  * aomedia.org/license/patent-license/.
  */
 
-// Transform search result cache: storage only.  An entry holds the transform
-// type that won for a key, plus the frame it was produced in so that entries
-// from earlier frames are ignored and recycled instead of cleared.  The table
-// is embedded in TxfmSearchInfo, so it is per-thread and needs no allocation.
+// Transform search result cache.  An entry holds the transform type that won
+// for a key, plus the frame it was produced in so that entries from earlier
+// frames are ignored and recycled instead of cleared.  The table is embedded
+// in TxfmSearchInfo, so it is per-thread and needs no allocation.
 
 #ifndef AVM_AV2_ENCODER_TX_CACHE_H_
 #define AVM_AV2_ENCODER_TX_CACHE_H_
@@ -30,12 +30,12 @@ extern "C" {
 #define TX_CACHE_PROBE 8  // linear probe depth
 
 /*! Cache slot: a fully mixed key, the transform type that won for it, and the
- *  frame it belongs to (frame_number + 1; 0 means the slot was never written).
+ *  frame it belongs to.
  */
 typedef struct {
-  uint64_t key;
+  uint64_t key;     // hash of the residual and all state that picks the winner
   uint16_t winner;  // full tx_type: primary | secondary | secondary set
-  uint32_t tag;
+  uint32_t tag;     // frame_number + 1; 0 means never written, stale = recycled
 } TxCacheEntry;
 
 /*! Transform search result cache. Entries are scoped to the frame they were
@@ -44,6 +44,29 @@ typedef struct {
 typedef struct {
   TxCacheEntry entries[TX_CACHE_SIZE];
 } TxCache;
+
+/*! Hashes the residual, the quantizer and the entropy contexts into the seed
+ *  of a cache key.
+ */
+uint64_t av2_tx_cache_hash(const int16_t *residual, int stride, int tx_w,
+                           int tx_h, int qindex, int txb_skip_ctx,
+                           int dc_sign_ctx);
+
+/*! Folds the remaining state that can flip which candidate wins into the seed
+ *  \c h and returns the final, never-zero cache key.
+ */
+uint64_t av2_tx_cache_mix(uint64_t h, uint32_t sb_row, uint32_t sb_col,
+                          int is_inter, int is_fsc, int intra_mode,
+                          int rd_model, int skip_trellis, int tx_set_type,
+                          int use_qmatrix, int rdmult);
+
+/*! Returns the winning tx_type cached for \c key in \c frame, or -1 on a miss.
+ */
+int av2_tx_cache_lookup(const TxCache *cache, uint64_t key, uint32_t frame);
+
+/*! Stores \c winner as the result for \c key in \c frame. */
+void av2_tx_cache_store(TxCache *cache, uint64_t key, uint16_t winner,
+                        uint32_t frame);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -2558,11 +2558,11 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
       tx_cache_hit = 1;
       tx_cache_winner.packed_tx_type = (uint16_t)cached;
       const uint16_t winner_bit = 1 << tx_cache_winner.primary_tx;
-      const uint16_t dct_bit = 1 << DCT_DCT;
       if (allowed_tx_mask & winner_bit) {
         // Keep DCT_DCT in the mask: the prune gates inside the loop can reject
         // the winner, and a single-candidate mask would then leave the search
         // with nothing evaluated.
+        const uint16_t dct_bit = 1 << DCT_DCT;
         allowed_tx_mask &= winner_bit | dct_bit;
       } else {
         // The cached winner is not a candidate here, so drop the hit: leaving

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -24,92 +24,6 @@
 #include "av2/encoder/tx_search.h"
 #include "av2/encoder/tx_cache.h"
 
-// Transform search result cache, see av2/encoder/tx_cache.h.
-
-static AVM_INLINE uint64_t tx_cache_fold(uint64_t h, uint64_t v) {
-  h ^= v;
-  h *= 1099511628211ULL;
-  return h;
-}
-
-// FNV-1a over the residual, the quantizer and the entropy contexts.
-static AVM_INLINE uint64_t tx_cache_hash(const int16_t *residual, int stride,
-                                         int tx_w, int tx_h, int qindex,
-                                         int txb_skip_ctx, int dc_sign_ctx) {
-  assert(stride >= tx_w);  // else rows overlap and distinct residuals alias
-  uint64_t h = 1469598103934665603ULL;
-  for (int r = 0; r < tx_h; ++r) {
-    const int16_t *row = residual + (size_t)r * stride;
-    for (int c = 0; c < tx_w; ++c) {
-      // uint16_t first: same width, but stops sign extension smearing bits.
-      h = tx_cache_fold(h, (uint64_t)(uint16_t)row[c]);
-    }
-  }
-  h = tx_cache_fold(h, ((uint64_t)qindex << 32) |
-                           ((uint64_t)txb_skip_ctx << 16) |
-                           (uint64_t)dc_sign_ctx);
-  return tx_cache_fold(h, ((uint64_t)tx_w << 32) | (uint64_t)tx_h);
-}
-
-// Fold in the rest of the state that can flip which candidate wins. Only
-// bounded fields are bit-packed; unbounded ones are folded separately so they
-// cannot alias. The superblock coordinates are zero: the key is frame-scoped.
-static AVM_INLINE uint64_t tx_cache_mix(uint64_t h, uint32_t sb_row,
-                                        uint32_t sb_col, int is_inter,
-                                        int is_fsc, int intra_mode,
-                                        int rd_model, int skip_trellis,
-                                        uint32_t tx_set_type, int use_qmatrix,
-                                        int rdmult) {
-  const uint64_t flags = ((uint64_t)(is_inter ? 1u : 0u) << 0) |
-                         ((uint64_t)(is_fsc ? 1u : 0u) << 1) |
-                         ((uint64_t)(skip_trellis ? 1u : 0u) << 2) |
-                         ((uint64_t)(use_qmatrix ? 1u : 0u) << 3) |
-                         ((uint64_t)(rd_model & 0xF) << 4) |
-                         ((uint64_t)(intra_mode & 0x3F) << 8) |
-                         ((uint64_t)(tx_set_type & 0xFF) << 16);
-  h = tx_cache_fold(h, flags);
-  h = tx_cache_fold(h, (uint64_t)(uint32_t)rdmult);
-  h = tx_cache_fold(h, ((uint64_t)sb_row << 32) | (uint64_t)sb_col);
-  h ^= h >> 31;
-  return h ? h : 1;
-}
-
-// Cached winning tx_type for this frame, or -1 on a miss. A never-written slot
-// (tag 0) ends the probe: no store for this frame can have walked past it.
-static AVM_INLINE int tx_cache_lookup(const TxCache *cache, uint64_t key,
-                                      uint32_t frame) {
-  const uint32_t tag = frame + 1;
-  const uint32_t idx = (uint32_t)key & TX_CACHE_MASK;
-  for (int p = 0; p < TX_CACHE_PROBE; ++p) {
-    const TxCacheEntry *e = &cache->entries[(idx + p) & TX_CACHE_MASK];
-    if (e->tag == 0) return -1;
-    if (e->tag == tag && e->key == key) return (int)e->winner;
-  }
-  return -1;
-}
-
-// Takes the first slot in the window that is free, stale, or already this key.
-static AVM_INLINE void tx_cache_store(TxCache *cache, uint64_t key, int winner,
-                                      uint32_t frame) {
-  const uint32_t tag = frame + 1;
-  const uint32_t idx = (uint32_t)key & TX_CACHE_MASK;
-  for (int p = 0; p < TX_CACHE_PROBE; ++p) {
-    TxCacheEntry *e = &cache->entries[(idx + p) & TX_CACHE_MASK];
-    if (e->tag != tag || e->key == key) {
-      e->key = key;
-      e->winner = (uint16_t)winner;
-      e->tag = tag;
-      return;
-    }
-  }
-  // Window full of this frame's entries: overwrite the first so it never
-  // stalls.
-  TxCacheEntry *e = &cache->entries[idx];
-  e->key = key;
-  e->winner = (uint16_t)winner;
-  e->tag = tag;
-}
-
 struct rdcost_block_args {
   const AV2_COMP *cpi;
   MACROBLOCK *x;
@@ -2629,27 +2543,27 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
         x->plane[AVM_PLANE_Y].src_diff +
         (((blk_row * diff_stride) + blk_col) << MI_SIZE_LOG2);
     const uint64_t base =
-        tx_cache_hash(residual, diff_stride, txw, txh, (int)x->qindex,
-                      txb_ctx ? txb_ctx->txb_skip_ctx : 0,
-                      txb_ctx ? txb_ctx->dc_sign_ctx : 0) ^
-        ((uint64_t)tx_size << 1);
-    tx_cache_key = tx_cache_mix(
-        base, 0u, 0u, is_inter, is_fsc, (int)intra_mode, (int)x->rd_model,
-        skip_trellis,
-        (uint32_t)av2_get_ext_tx_set_type(tx_size, is_inter,
-                                          cm->features.reduced_tx_set_used),
+        av2_tx_cache_hash(residual, diff_stride, txw, txh, x->qindex,
+                          txb_ctx ? txb_ctx->txb_skip_ctx : 0,
+                          txb_ctx ? txb_ctx->dc_sign_ctx : 0) ^
+        (tx_size << 1);
+    tx_cache_key = av2_tx_cache_mix(
+        base, 0u, 0u, is_inter, is_fsc, intra_mode, x->rd_model, skip_trellis,
+        av2_get_ext_tx_set_type(tx_size, is_inter,
+                                cm->features.reduced_tx_set_used),
         av2_use_qmatrix(&cm->quant_params, xd, mbmi->segment_id), x->rdmult);
-    const int cached = tx_cache_lookup(
-        tx_cache, tx_cache_key, (uint32_t)cm->current_frame.frame_number);
+    const int cached = av2_tx_cache_lookup(tx_cache, tx_cache_key,
+                                           cm->current_frame.frame_number);
     if (cached >= 0) {
       tx_cache_hit = 1;
       tx_cache_winner.packed_tx_type = (uint16_t)cached;
-      const uint16_t winner_bit = (uint16_t)(1u << tx_cache_winner.primary_tx);
-      // Keep DCT_DCT in the mask: the prune gates inside the loop can reject
-      // the winner, and a single-candidate mask would then leave the search
-      // with nothing evaluated.
+      const uint16_t winner_bit = 1 << tx_cache_winner.primary_tx;
+      const uint16_t dct_bit = 1 << DCT_DCT;
       if (allowed_tx_mask & winner_bit) {
-        allowed_tx_mask &= (uint16_t)(winner_bit | 1u);
+        // Keep DCT_DCT in the mask: the prune gates inside the loop can reject
+        // the winner, and a single-candidate mask would then leave the search
+        // with nothing evaluated.
+        allowed_tx_mask &= winner_bit | dct_bit;
       } else {
         // The cached winner is not a candidate here, so drop the hit: leaving
         // it set would make every secondary transform mismatch it and skip the
@@ -2941,8 +2855,8 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
 
   if (tx_cache != NULL && best_rd != INT64_MAX &&
       !(best_eob == 1 && best_tx_type.primary_tx != DCT_DCT && !is_inter)) {
-    tx_cache_store(tx_cache, tx_cache_key, (int)best_tx_type.packed_tx_type,
-                   (uint32_t)cm->current_frame.frame_number);
+    av2_tx_cache_store(tx_cache, tx_cache_key, best_tx_type.packed_tx_type,
+                       cm->current_frame.frame_number);
   }
 
   best_rd_stats->skip_txfm = best_eob == 0;

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -2621,7 +2621,7 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
   TxCache *tx_cache = NULL;
   uint64_t tx_cache_key = 0;
   int tx_cache_hit = 0;
-  TX_TYPE tx_cache_winner = DCT_DCT;
+  TX_TYPE tx_cache_winner = MAKE_TX_TYPE_FROM_PRIMARY_TX_TYPE(DCT_DCT);
   if (tx_sf->use_tx_result_cache && plane == AVM_PLANE_Y && !dc_only_blk) {
     tx_cache = &x->txfm_search_info.tx_result_cache;
     const int diff_stride = block_size_wide[plane_bsize];
@@ -2643,14 +2643,20 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
         tx_cache, tx_cache_key, (uint32_t)cm->current_frame.frame_number);
     if (cached >= 0) {
       tx_cache_hit = 1;
-      tx_cache_winner = (TX_TYPE)cached;
-      const uint16_t winner_bit =
-          (uint16_t)(1u << get_primary_tx_type(tx_cache_winner));
+      tx_cache_winner.packed_tx_type = (uint16_t)cached;
+      const uint16_t winner_bit = (uint16_t)(1u << tx_cache_winner.primary_tx);
       // Keep DCT_DCT in the mask: the prune gates inside the loop can reject
       // the winner, and a single-candidate mask would then leave the search
       // with nothing evaluated.
-      if (allowed_tx_mask & winner_bit)
+      if (allowed_tx_mask & winner_bit) {
         allowed_tx_mask &= (uint16_t)(winner_bit | 1u);
+      } else {
+        // The cached winner is not a candidate here, so drop the hit: leaving
+        // it set would make every secondary transform mismatch it and skip the
+        // whole IST search.
+        tx_cache_hit = 0;
+        tx_cache_winner = MAKE_TX_TYPE_FROM_PRIMARY_TX_TYPE(DCT_DCT);
+      }
     }
   }
 
@@ -2719,7 +2725,8 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
         txfm_param.sec_tx_set = stx_set;
         // On a cache hit, evaluate only the cached secondary transform,
         // keeping the no-IST candidate as a baseline.
-        if (tx_cache_hit && packed_tx_type != tx_cache_winner &&
+        if (tx_cache_hit &&
+            tx_type.packed_tx_type != tx_cache_winner.packed_tx_type &&
             !(set_idx == 0 && stx == 0)) {
           continue;
         }
@@ -2933,9 +2940,8 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
   }
 
   if (tx_cache != NULL && best_rd != INT64_MAX &&
-      !(best_eob == 1 && get_primary_tx_type(best_tx_type) != DCT_DCT &&
-        !is_inter)) {
-    tx_cache_store(tx_cache, tx_cache_key, (int)best_tx_type,
+      !(best_eob == 1 && best_tx_type.primary_tx != DCT_DCT && !is_inter)) {
+    tx_cache_store(tx_cache, tx_cache_key, (int)best_tx_type.packed_tx_type,
                    (uint32_t)cm->current_frame.frame_number);
   }
 

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -22,6 +22,93 @@
 #include "av2/encoder/rdopt_utils.h"
 #include "av2/encoder/tx_prune_model_weights.h"
 #include "av2/encoder/tx_search.h"
+#include "av2/encoder/tx_cache.h"
+
+// Transform search result cache, see av2/encoder/tx_cache.h.
+
+static AVM_INLINE uint64_t tx_cache_fold(uint64_t h, uint64_t v) {
+  h ^= v;
+  h *= 1099511628211ULL;
+  return h;
+}
+
+// FNV-1a over the residual, the quantizer and the entropy contexts.
+static AVM_INLINE uint64_t tx_cache_hash(const int16_t *residual, int stride,
+                                         int tx_w, int tx_h, int qindex,
+                                         int txb_skip_ctx, int dc_sign_ctx) {
+  assert(stride >= tx_w);  // else rows overlap and distinct residuals alias
+  uint64_t h = 1469598103934665603ULL;
+  for (int r = 0; r < tx_h; ++r) {
+    const int16_t *row = residual + (size_t)r * stride;
+    for (int c = 0; c < tx_w; ++c) {
+      // uint16_t first: same width, but stops sign extension smearing bits.
+      h = tx_cache_fold(h, (uint64_t)(uint16_t)row[c]);
+    }
+  }
+  h = tx_cache_fold(h, ((uint64_t)qindex << 32) |
+                           ((uint64_t)txb_skip_ctx << 16) |
+                           (uint64_t)dc_sign_ctx);
+  return tx_cache_fold(h, ((uint64_t)tx_w << 32) | (uint64_t)tx_h);
+}
+
+// Fold in the rest of the state that can flip which candidate wins. Only
+// bounded fields are bit-packed; unbounded ones are folded separately so they
+// cannot alias. The superblock coordinates are zero: the key is frame-scoped.
+static AVM_INLINE uint64_t tx_cache_mix(uint64_t h, uint32_t sb_row,
+                                        uint32_t sb_col, int is_inter,
+                                        int is_fsc, int intra_mode,
+                                        int rd_model, int skip_trellis,
+                                        uint32_t tx_set_type, int use_qmatrix,
+                                        int rdmult) {
+  const uint64_t flags = ((uint64_t)(is_inter ? 1u : 0u) << 0) |
+                         ((uint64_t)(is_fsc ? 1u : 0u) << 1) |
+                         ((uint64_t)(skip_trellis ? 1u : 0u) << 2) |
+                         ((uint64_t)(use_qmatrix ? 1u : 0u) << 3) |
+                         ((uint64_t)(rd_model & 0xF) << 4) |
+                         ((uint64_t)(intra_mode & 0x3F) << 8) |
+                         ((uint64_t)(tx_set_type & 0xFF) << 16);
+  h = tx_cache_fold(h, flags);
+  h = tx_cache_fold(h, (uint64_t)(uint32_t)rdmult);
+  h = tx_cache_fold(h, ((uint64_t)sb_row << 32) | (uint64_t)sb_col);
+  h ^= h >> 31;
+  return h ? h : 1;
+}
+
+// Cached winning tx_type for this frame, or -1 on a miss. A never-written slot
+// (tag 0) ends the probe: no store for this frame can have walked past it.
+static AVM_INLINE int tx_cache_lookup(const TxCache *cache, uint64_t key,
+                                      uint32_t frame) {
+  const uint32_t tag = frame + 1;
+  const uint32_t idx = (uint32_t)key & TX_CACHE_MASK;
+  for (int p = 0; p < TX_CACHE_PROBE; ++p) {
+    const TxCacheEntry *e = &cache->entries[(idx + p) & TX_CACHE_MASK];
+    if (e->tag == 0) return -1;
+    if (e->tag == tag && e->key == key) return (int)e->winner;
+  }
+  return -1;
+}
+
+// Takes the first slot in the window that is free, stale, or already this key.
+static AVM_INLINE void tx_cache_store(TxCache *cache, uint64_t key, int winner,
+                                      uint32_t frame) {
+  const uint32_t tag = frame + 1;
+  const uint32_t idx = (uint32_t)key & TX_CACHE_MASK;
+  for (int p = 0; p < TX_CACHE_PROBE; ++p) {
+    TxCacheEntry *e = &cache->entries[(idx + p) & TX_CACHE_MASK];
+    if (e->tag != tag || e->key == key) {
+      e->key = key;
+      e->winner = (uint16_t)winner;
+      e->tag = tag;
+      return;
+    }
+  }
+  // Window full of this frame's entries: overwrite the first so it never
+  // stalls.
+  TxCacheEntry *e = &cache->entries[idx];
+  e->key = key;
+  e->winner = (uint16_t)winner;
+  e->tag = tag;
+}
 
 struct rdcost_block_args {
   const AV2_COMP *cpi;
@@ -2453,7 +2540,7 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
   }
 
   // Bit mask to indicate which transform types are allowed in the RD search.
-  const uint16_t allowed_tx_mask = get_tx_mask(
+  uint16_t allowed_tx_mask = get_tx_mask(
       cpi, x, plane, block, blk_row, blk_col, plane_bsize, tx_size, txb_ctx,
       ftxs_mode, ref_best_rd, dc_only_blk, &txk_allowed, txk_map);
 
@@ -2527,6 +2614,46 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
                              : cm->seq_params.enable_ist) &&
                    !is_fsc && !is_lossless;
 
+  // Transform search result cache.  Deliberately placed here: it is after
+  // skip_trellis is final and after the block above that turns off
+  // transform-domain distortion when `allowed_tx_mask == 0x0001`, so
+  // restricting the mask cannot change any earlier decision.
+  TxCache *tx_cache = NULL;
+  uint64_t tx_cache_key = 0;
+  int tx_cache_hit = 0;
+  TX_TYPE tx_cache_winner = DCT_DCT;
+  if (tx_sf->use_tx_result_cache && plane == AVM_PLANE_Y && !dc_only_blk) {
+    tx_cache = &x->txfm_search_info.tx_result_cache;
+    const int diff_stride = block_size_wide[plane_bsize];
+    const int16_t *const residual =
+        x->plane[AVM_PLANE_Y].src_diff +
+        (((blk_row * diff_stride) + blk_col) << MI_SIZE_LOG2);
+    const uint64_t base =
+        tx_cache_hash(residual, diff_stride, txw, txh, (int)x->qindex,
+                      txb_ctx ? txb_ctx->txb_skip_ctx : 0,
+                      txb_ctx ? txb_ctx->dc_sign_ctx : 0) ^
+        ((uint64_t)tx_size << 1);
+    tx_cache_key = tx_cache_mix(
+        base, 0u, 0u, is_inter, is_fsc, (int)intra_mode, (int)x->rd_model,
+        skip_trellis,
+        (uint32_t)av2_get_ext_tx_set_type(tx_size, is_inter,
+                                          cm->features.reduced_tx_set_used),
+        av2_use_qmatrix(&cm->quant_params, xd, mbmi->segment_id), x->rdmult);
+    const int cached = tx_cache_lookup(
+        tx_cache, tx_cache_key, (uint32_t)cm->current_frame.frame_number);
+    if (cached >= 0) {
+      tx_cache_hit = 1;
+      tx_cache_winner = (TX_TYPE)cached;
+      const uint16_t winner_bit =
+          (uint16_t)(1u << get_primary_tx_type(tx_cache_winner));
+      // Keep DCT_DCT in the mask: the prune gates inside the loop can reject
+      // the winner, and a single-candidate mask would then leave the search
+      // with nothing evaluated.
+      if (allowed_tx_mask & winner_bit)
+        allowed_tx_mask &= (uint16_t)(winner_bit | 1u);
+    }
+  }
+
   const int max_eob = av2_get_max_eob(tx_size);
   // Iterate through all transform type candidates.
   for (int tx_idx = 0; tx_idx < PRIMARY_TX_TYPES; ++tx_idx) {
@@ -2590,6 +2717,12 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
         txfm_param.primary_tx_type = primary_tx_type;
         txfm_param.sec_tx_type = stx;
         txfm_param.sec_tx_set = stx_set;
+        // On a cache hit, evaluate only the cached secondary transform,
+        // keeping the no-IST candidate as a baseline.
+        if (tx_cache_hit && packed_tx_type != tx_cache_winner &&
+            !(set_idx == 0 && stx == 0)) {
+          continue;
+        }
 
         assert(av2_tx_type_in_range(tx_type.primary_tx, tx_type.sec_tx,
                                     tx_type.sec_set, txw, txh));
@@ -2797,6 +2930,13 @@ static void search_tx_type(const AV2_COMP *cpi, MACROBLOCK *x, int plane,
        best_rd == INT64_MAX) &&
       !is_inter) {
     best_tx_type = MAKE_TX_TYPE_FROM_PRIMARY_TX_TYPE(DCT_DCT);
+  }
+
+  if (tx_cache != NULL && best_rd != INT64_MAX &&
+      !(best_eob == 1 && get_primary_tx_type(best_tx_type) != DCT_DCT &&
+        !is_inter)) {
+    tx_cache_store(tx_cache, tx_cache_key, (int)best_tx_type,
+                   (uint32_t)cm->current_frame.frame_number);
   }
 
   best_rd_stats->skip_txfm = best_eob == 0;


### PR DESCRIPTION
Within a frame, remember the winning transform type of a luma transform block, keyed on its residual and on every context value that can change which candidate wins. On a hit the primary transform type mask and the intra secondary transform search are narrowed to that winner, which is still evaluated by the normal path, so only the search breadth shrinks.

The table is 64K entries of 16 bytes, embedded in TxfmSearchInfo, so it is per-thread and needs no allocation. Each entry carries the frame it was produced in, so entries from earlier frames are ignored and recycled instead of cleared.

Enabled for speed 1 and only for sequence quantizers below 210 + MAXQ_OFFSET * (bit_depth - 8): at coarser quantizers the work this prunes has already been taken by the DC-only and skip predictors and the transform-domain RD estimate, while the residual hash costs the same, so there is no speed-up left to win there.

Results for RA CTC, A1 17 frames, A2 33 frames, speed 1: (Anchor: ee0b4ba10)

```
+-----+------+-------+-------+------+---------------+
|Class|  Y   |   U   |   V   | YUV  |Enc wall clock |
+-----+------+-------+-------+------+---------------+
| A1  | 0.03 |  0.01 |  0.03 | 0.03 | 97.2          |
| A2  | 0.02 |  0.18 |  0.13 | 0.03 | 97.9          |
+-----+------+-------+-------+------+---------------+
```

STATS_CHANGED for speed 1