### PR TITLE
Bias against CDEF

### DIFF
--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -3137,7 +3137,8 @@ static void cdef_restoration_frame(AV2_COMP *cpi, AV2_COMMON *cm,
 #if CONFIG_ENTROPY_STATS
                     &cpi->td,
 #endif  // CONFIG_ENTROPY_STATS
-                    cpi->sf.lpf_sf.cdef_pick_method, cpi->td.mb.rdmult);
+                    cpi->sf.lpf_sf.cdef_pick_method, cpi->td.mb.rdmult,
+                    cpi->sf.lc_sf.bias_against_cdef);
 
     // Apply the filter
     if (cm->cdef_info.cdef_frame_enable)

--- a/av2/encoder/pickcdef.c
+++ b/av2/encoder/pickcdef.c
@@ -420,7 +420,8 @@ void av2_cdef_search(const YV12_BUFFER_CONFIG *frame,
 #if CONFIG_ENTROPY_STATS
                      ThreadData *td,
 #endif  // CONFIG_ENTROPY_STATS
-                     CDEF_PICK_METHOD pick_method, int rdmult) {
+                     CDEF_PICK_METHOD pick_method, int rdmult,
+                     int bias_against_cdef) {
   if (cm->seq_params.enable_cdef_on_skip_txfm == CDEF_ON_SKIP_TXFM_DISABLED) {
     cm->cdef_info.cdef_on_skip_txfm_frame_enable = 0;
   } else {
@@ -742,8 +743,14 @@ void av2_cdef_search(const YV12_BUFFER_CONFIG *frame,
   }
 
   if (best_cdef_on) {
-    const uint64_t unfiltered_rd =
+    uint64_t unfiltered_rd =
         RDCOST(rdmult, av2_cost_literal(1), unfiltered_mse * 16);
+
+    if (unfiltered_rd < INT64_MAX && bias_against_cdef) {
+      const double bias_against_cdef_thr = 0.9;
+      unfiltered_rd = (int64_t)(unfiltered_rd * bias_against_cdef_thr);
+    }
+
     if (unfiltered_rd < best_rd) {
       best_nb_strength = 1;
       cm->cdef_info.cdef_frame_enable = 0;

--- a/av2/encoder/pickcdef.h
+++ b/av2/encoder/pickcdef.h
@@ -32,6 +32,7 @@ extern "C" {
  * \param[in]      xd           Pointer to common current coding block structure
  * \param[in]      pick_method  The method used to select params
  * \param[in]      rdmult       rd multiplier to use in making param choices
+ * \param[in]      bias_against_cdef  Whether or not enable bias against CDEF
  *
  * Nothing is returned. Instead, optimal CDEF parameters are stored
  * in the \c cdef_info structure of type \ref CdefInfo inside \c cm:
@@ -50,7 +51,8 @@ void av2_cdef_search(const YV12_BUFFER_CONFIG *frame,
 #if CONFIG_ENTROPY_STATS
                      ThreadData *td,
 #endif  // CONFIG_ENTROPY_STATS
-                     CDEF_PICK_METHOD pick_method, int rdmult);
+                     CDEF_PICK_METHOD pick_method, int rdmult,
+                     int bias_against_cdef);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -735,6 +735,9 @@ static void set_good_speed_features_lc_dec_framesize_independent(
     cpi->oxcf.tool_cfg.enable_opfl_refine = 0;
     cpi->oxcf.intra_mode_cfg.enable_mhccp = 0;
     cpi->oxcf.tool_cfg.enable_lf_sub_pu = 0;
+    cpi->oxcf.tool_cfg.enable_cdef_on_skip_txfm = 0;
+
+    sf->lc_sf.bias_against_cdef = cm->current_frame.pyramid_level > 1;
   }
 }
 
@@ -1081,6 +1084,7 @@ static void av2_disable_ml_based_partition_sf(
 
 static AVM_INLINE void init_lc_sf(LC_DEC_SPEED_FEATURES *lc_sf) {
   lc_sf->enable_partition_size_bias = 0;
+  lc_sf->bias_against_cdef = 0;
 }
 
 static AVM_INLINE void set_erp_speed_features_framesize_dependent(
@@ -1324,6 +1328,8 @@ void av2_set_speed_features_framesize_independent(AV2_COMP *cpi, int speed) {
           cpi->oxcf.intra_mode_cfg.enable_mhccp;
       cpi->common.seq_params.enable_lf_sub_pu =
           cpi->oxcf.tool_cfg.enable_lf_sub_pu;
+      cpi->common.seq_params.enable_cdef_on_skip_txfm =
+          cpi->oxcf.tool_cfg.enable_cdef_on_skip_txfm;
     }
   }
 

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -1106,6 +1106,11 @@ typedef struct REALTIME_SPEED_FEATURES {
 typedef struct LC_DEC_SPEED_FEATURES {
   // Bias towards large partitions.
   int enable_partition_size_bias;
+
+  // Only allow CDEF when the improvement is significant.
+  // 0: no bias for CDEF use.
+  // 1: bias against CDEF during RD decision..
+  int bias_against_cdef;
 } LC_DEC_SPEED_FEATURES;
 
 typedef struct FLEXMV_PRECISION_SPEED_FEATURES {


### PR DESCRIPTION
This change is for low-complexity decode mode. Bias against CDEF during frame
level RD decision. Also disabled CDEF for skip blocks.

```
RA CTC test with "--enable-low-complexity-decode=2"
65 frames / speed 1 (base: ad9c4353)
 +-----+-------+--------+-------+----------+----------+
 |Class| WPSNR | SSIM-Y | VMAF  | Enc-time | Dec-time |
 +-----+----- -+-- -----+-------+----------+----------+
 | A1  | 0.40  | -0.18  | -0.36 |   99     |   93     |
 | A2  | 0.47  | -0.19  | -0.13 |   99     |   94     |
 +-----+-------+--------+-------+----------+----------+
```

STATS_CHANGED for "--enable-low-complexity-decode=2"