### PR TITLE
Search DCT_DCT only at dry pass when speed >= 4

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -642,6 +642,7 @@ static void set_good_speed_features_framesize_independent(
     sf->tx_sf.tx_type_search.winner_mode_tx_type_pruning = 1;
     sf->tx_sf.tx_type_search.prune_2d_txfm_mode = TX_TYPE_PRUNE_2;
     sf->tx_sf.tx_type_search.prune_tx_type_est_rd = 1;
+    sf->tx_sf.tx_type_search.dry_pass_use_dct_only = true;
 
     sf->rd_sf.perform_coeff_opt = is_boosted_arf2_bwd_type ? 3 : 5;
     sf->rd_sf.tx_domain_dist_thres_level = 1;
@@ -982,6 +983,7 @@ static AVM_INLINE void init_tx_sf(TX_SPEED_FEATURES *tx_sf) {
   tx_sf->tx_type_search.skip_tx_search_max_eob = 1024;
   tx_sf->tx_type_search.prune_tx_type_using_stats = 0;
   tx_sf->tx_type_search.prune_tx_type_est_rd = 0;
+  tx_sf->tx_type_search.dry_pass_use_dct_only = false;
   tx_sf->tx_type_search.winner_mode_tx_type_pruning = 0;
   tx_sf->txb_split_cap = 1;
   tx_sf->skip_pixel_dist_calc_using_tx_dist = false;

--- a/av2/encoder/speed_features.h
+++ b/av2/encoder/speed_features.h
@@ -168,6 +168,9 @@ typedef struct {
   // Prune tx type search using estimated RDcost
   int prune_tx_type_est_rd;
 
+  // Use DCT_DCT only at dry pass
+  bool dry_pass_use_dct_only;
+
   // Flag used to control the winner mode processing for tx type pruning for
   // inter blocks. It enables further tx type mode pruning based on ML model for
   // mode evaluation and disables tx type mode pruning for winner mode

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -1939,6 +1939,13 @@ get_tx_mask(const AV2_COMP *cpi, MACROBLOCK *x, int plane, int block,
     allowed_tx_mask = (1 << txk_allowed);
   }
 
+  // Restrict tx type search to DCT_DCT only
+  if (x->apply_dry_pass_shortcuts &&
+      cpi->sf.tx_sf.tx_type_search.dry_pass_use_dct_only && plane == 0 &&
+      txk_allowed == PRIMARY_TX_TYPES) {
+    allowed_tx_mask &= (1 << DCT_DCT);
+  }
+
   assert(IMPLIES(txk_allowed < PRIMARY_TX_TYPES,
                  allowed_tx_mask == 1 << txk_allowed));
   *allowed_txk_types = txk_allowed;


### PR DESCRIPTION
Allow DCT_DCT for dry pass at speed 4.

```
+---------+--------+--------+--------+--------+----------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time | Dec-time |
+---------+--------+--------+--------+--------+----------+----------+
| A1      |  0.06% | -0.09% | -0.40% |  0.02% | 99.0%    | 100%     |
| A2      |  0.04% |  0.03% | -0.41% |  0.02% | 98.4%    | 99%      |
+---------+--------+--------+--------+--------+----------+----------+
```