### PR TITLE
Add NEON for fwd_stxfm and inv_stxfm

### DIFF
--- a/av2/av2.cmake
+++ b/av2/av2.cmake
@@ -438,6 +438,7 @@ list(
   "${AVM_ROOT}/av2/encoder/arm/neon/intra_mode_mlp_neon.c"
   "${AVM_ROOT}/av2/encoder/arm/neon/rdopt_neon.c"
   "${AVM_ROOT}/av2/encoder/arm/neon/encodetxb_neon.c"
+  "${AVM_ROOT}/av2/encoder/arm/neon/fwd_stxfm_neon.c"
   "${AVM_ROOT}/av2/encoder/arm/neon/hybrid_fwd_txfm_neon.c")
 
 list(APPEND AVM_AV2_ENCODER_INTRIN_MSA
@@ -454,6 +455,7 @@ list(
   "${AVM_ROOT}/av2/common/arm/highbd_inv_txfm_neon.c"
   "${AVM_ROOT}/av2/common/arm/reconinter_neon.c"
   "${AVM_ROOT}/av2/common/arm/highbd_warp_affine_neon.c"
+  "${AVM_ROOT}/av2/common/arm/stxfm_neon.c"
   "${AVM_ROOT}/av2/common/cdef_block_neon.c")
 
 list(APPEND AVM_AV2_ENCODER_INTRIN_SSE4_2

--- a/av2/common/arm/stxfm_neon.c
+++ b/av2/common/arm/stxfm_neon.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved.
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause
+ * Clear License was not distributed with this source code in the LICENSE file,
+ * you can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.
+ * If the Alliance for Open Media Patent License 1.0 was not distributed with
+ * this source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+#include <arm_neon.h>
+#include <assert.h>
+
+#include "config/av2_rtcd.h"
+
+#include "av2/common/av2_txfm.h"
+#include "av2/common/enums.h"
+
+static INLINE int32x4_t round_shift_s32(int32x4_t v) {
+  const int32x4_t bias = vdupq_n_s32(64);
+  const int32x4_t sign = vshrq_n_s32(v, 31);
+  return vshrq_n_s32(vaddq_s32(vaddq_s32(v, bias), sign), 7);
+}
+
+static INLINE int32x4_t clamp_s32(int32x4_t v, int32x4_t min_v,
+                                  int32x4_t max_v) {
+  return vminq_s32(vmaxq_s32(v, min_v), max_v);
+}
+
+static void inv_stxfm_4x4_kernel(const tran_low_t *src, tran_low_t *dst,
+                                 const int32_t *kernel, int bd) {
+  const int32x4_t max_v = vdupq_n_s32((1 << (7 + bd)) - 1);
+  const int32x4_t min_v = vdupq_n_s32(-(1 << (7 + bd)));
+
+  const int32x4_t s0 = vld1q_s32(src);
+  const int32x4_t s1 = vld1q_s32(src + 4);
+  const int32x2_t s0_lo = vget_low_s32(s0);
+  const int32x2_t s0_hi = vget_high_s32(s0);
+  const int32x2_t s1_lo = vget_low_s32(s1);
+  const int32x2_t s1_hi = vget_high_s32(s1);
+  const int32_t *k = kernel;
+
+  int32x4_t a0 = vmulq_lane_s32(vld1q_s32(k), s0_lo, 0);
+  int32x4_t a1 = vmulq_lane_s32(vld1q_s32(k + 4), s0_lo, 0);
+  int32x4_t a2 = vmulq_lane_s32(vld1q_s32(k + 8), s0_lo, 0);
+  int32x4_t a3 = vmulq_lane_s32(vld1q_s32(k + 12), s0_lo, 0);
+  k += IST_4x4_WIDTH;
+  a0 = vmlaq_lane_s32(a0, vld1q_s32(k), s0_lo, 1);
+  a1 = vmlaq_lane_s32(a1, vld1q_s32(k + 4), s0_lo, 1);
+  a2 = vmlaq_lane_s32(a2, vld1q_s32(k + 8), s0_lo, 1);
+  a3 = vmlaq_lane_s32(a3, vld1q_s32(k + 12), s0_lo, 1);
+  k += IST_4x4_WIDTH;
+  a0 = vmlaq_lane_s32(a0, vld1q_s32(k), s0_hi, 0);
+  a1 = vmlaq_lane_s32(a1, vld1q_s32(k + 4), s0_hi, 0);
+  a2 = vmlaq_lane_s32(a2, vld1q_s32(k + 8), s0_hi, 0);
+  a3 = vmlaq_lane_s32(a3, vld1q_s32(k + 12), s0_hi, 0);
+  k += IST_4x4_WIDTH;
+  a0 = vmlaq_lane_s32(a0, vld1q_s32(k), s0_hi, 1);
+  a1 = vmlaq_lane_s32(a1, vld1q_s32(k + 4), s0_hi, 1);
+  a2 = vmlaq_lane_s32(a2, vld1q_s32(k + 8), s0_hi, 1);
+  a3 = vmlaq_lane_s32(a3, vld1q_s32(k + 12), s0_hi, 1);
+  k += IST_4x4_WIDTH;
+  a0 = vmlaq_lane_s32(a0, vld1q_s32(k), s1_lo, 0);
+  a1 = vmlaq_lane_s32(a1, vld1q_s32(k + 4), s1_lo, 0);
+  a2 = vmlaq_lane_s32(a2, vld1q_s32(k + 8), s1_lo, 0);
+  a3 = vmlaq_lane_s32(a3, vld1q_s32(k + 12), s1_lo, 0);
+  k += IST_4x4_WIDTH;
+  a0 = vmlaq_lane_s32(a0, vld1q_s32(k), s1_lo, 1);
+  a1 = vmlaq_lane_s32(a1, vld1q_s32(k + 4), s1_lo, 1);
+  a2 = vmlaq_lane_s32(a2, vld1q_s32(k + 8), s1_lo, 1);
+  a3 = vmlaq_lane_s32(a3, vld1q_s32(k + 12), s1_lo, 1);
+  k += IST_4x4_WIDTH;
+  a0 = vmlaq_lane_s32(a0, vld1q_s32(k), s1_hi, 0);
+  a1 = vmlaq_lane_s32(a1, vld1q_s32(k + 4), s1_hi, 0);
+  a2 = vmlaq_lane_s32(a2, vld1q_s32(k + 8), s1_hi, 0);
+  a3 = vmlaq_lane_s32(a3, vld1q_s32(k + 12), s1_hi, 0);
+  k += IST_4x4_WIDTH;
+  a0 = vmlaq_lane_s32(a0, vld1q_s32(k), s1_hi, 1);
+  a1 = vmlaq_lane_s32(a1, vld1q_s32(k + 4), s1_hi, 1);
+  a2 = vmlaq_lane_s32(a2, vld1q_s32(k + 8), s1_hi, 1);
+  a3 = vmlaq_lane_s32(a3, vld1q_s32(k + 12), s1_hi, 1);
+
+  vst1q_s32(dst, clamp_s32(round_shift_s32(a0), min_v, max_v));
+  vst1q_s32(dst + 4, clamp_s32(round_shift_s32(a1), min_v, max_v));
+  vst1q_s32(dst + 8, clamp_s32(round_shift_s32(a2), min_v, max_v));
+  vst1q_s32(dst + 12, clamp_s32(round_shift_s32(a3), min_v, max_v));
+}
+
+static void inv_stxfm_8x8_kernel(const tran_low_t *src, tran_low_t *dst,
+                                 const int32_t *kernel, int rh, int bd) {
+  assert(rh % 4 == 0);
+  const int32x4_t max_v = vdupq_n_s32((1 << (7 + bd)) - 1);
+  const int32x4_t min_v = vdupq_n_s32(-(1 << (7 + bd)));
+
+  int32x4_t a0 = vdupq_n_s32(0);
+  int32x4_t a1 = vdupq_n_s32(0);
+  int32x4_t a2 = vdupq_n_s32(0);
+  int32x4_t a3 = vdupq_n_s32(0);
+  int32x4_t a4 = vdupq_n_s32(0);
+  int32x4_t a5 = vdupq_n_s32(0);
+  int32x4_t a6 = vdupq_n_s32(0);
+  int32x4_t a7 = vdupq_n_s32(0);
+  int32x4_t a8 = vdupq_n_s32(0);
+  int32x4_t a9 = vdupq_n_s32(0);
+  int32x4_t a10 = vdupq_n_s32(0);
+  int32x4_t a11 = vdupq_n_s32(0);
+
+  for (int j = 0; j < rh; j += 4) {
+    const int32x4_t s = vld1q_s32(src + j);
+    const int32x2_t s_lo = vget_low_s32(s);
+    const int32x2_t s_hi = vget_high_s32(s);
+    const int32_t *k0 = kernel + j * IST_8x8_WIDTH;
+    const int32_t *k1 = k0 + IST_8x8_WIDTH;
+    const int32_t *k2 = k1 + IST_8x8_WIDTH;
+    const int32_t *k3 = k2 + IST_8x8_WIDTH;
+
+    a0 = vmlaq_lane_s32(a0, vld1q_s32(k0), s_lo, 0);
+    a1 = vmlaq_lane_s32(a1, vld1q_s32(k0 + 4), s_lo, 0);
+    a2 = vmlaq_lane_s32(a2, vld1q_s32(k0 + 8), s_lo, 0);
+    a3 = vmlaq_lane_s32(a3, vld1q_s32(k0 + 12), s_lo, 0);
+    a4 = vmlaq_lane_s32(a4, vld1q_s32(k0 + 16), s_lo, 0);
+    a5 = vmlaq_lane_s32(a5, vld1q_s32(k0 + 20), s_lo, 0);
+    a6 = vmlaq_lane_s32(a6, vld1q_s32(k0 + 24), s_lo, 0);
+    a7 = vmlaq_lane_s32(a7, vld1q_s32(k0 + 28), s_lo, 0);
+    a8 = vmlaq_lane_s32(a8, vld1q_s32(k0 + 32), s_lo, 0);
+    a9 = vmlaq_lane_s32(a9, vld1q_s32(k0 + 36), s_lo, 0);
+    a10 = vmlaq_lane_s32(a10, vld1q_s32(k0 + 40), s_lo, 0);
+    a11 = vmlaq_lane_s32(a11, vld1q_s32(k0 + 44), s_lo, 0);
+
+    a0 = vmlaq_lane_s32(a0, vld1q_s32(k1), s_lo, 1);
+    a1 = vmlaq_lane_s32(a1, vld1q_s32(k1 + 4), s_lo, 1);
+    a2 = vmlaq_lane_s32(a2, vld1q_s32(k1 + 8), s_lo, 1);
+    a3 = vmlaq_lane_s32(a3, vld1q_s32(k1 + 12), s_lo, 1);
+    a4 = vmlaq_lane_s32(a4, vld1q_s32(k1 + 16), s_lo, 1);
+    a5 = vmlaq_lane_s32(a5, vld1q_s32(k1 + 20), s_lo, 1);
+    a6 = vmlaq_lane_s32(a6, vld1q_s32(k1 + 24), s_lo, 1);
+    a7 = vmlaq_lane_s32(a7, vld1q_s32(k1 + 28), s_lo, 1);
+    a8 = vmlaq_lane_s32(a8, vld1q_s32(k1 + 32), s_lo, 1);
+    a9 = vmlaq_lane_s32(a9, vld1q_s32(k1 + 36), s_lo, 1);
+    a10 = vmlaq_lane_s32(a10, vld1q_s32(k1 + 40), s_lo, 1);
+    a11 = vmlaq_lane_s32(a11, vld1q_s32(k1 + 44), s_lo, 1);
+
+    a0 = vmlaq_lane_s32(a0, vld1q_s32(k2), s_hi, 0);
+    a1 = vmlaq_lane_s32(a1, vld1q_s32(k2 + 4), s_hi, 0);
+    a2 = vmlaq_lane_s32(a2, vld1q_s32(k2 + 8), s_hi, 0);
+    a3 = vmlaq_lane_s32(a3, vld1q_s32(k2 + 12), s_hi, 0);
+    a4 = vmlaq_lane_s32(a4, vld1q_s32(k2 + 16), s_hi, 0);
+    a5 = vmlaq_lane_s32(a5, vld1q_s32(k2 + 20), s_hi, 0);
+    a6 = vmlaq_lane_s32(a6, vld1q_s32(k2 + 24), s_hi, 0);
+    a7 = vmlaq_lane_s32(a7, vld1q_s32(k2 + 28), s_hi, 0);
+    a8 = vmlaq_lane_s32(a8, vld1q_s32(k2 + 32), s_hi, 0);
+    a9 = vmlaq_lane_s32(a9, vld1q_s32(k2 + 36), s_hi, 0);
+    a10 = vmlaq_lane_s32(a10, vld1q_s32(k2 + 40), s_hi, 0);
+    a11 = vmlaq_lane_s32(a11, vld1q_s32(k2 + 44), s_hi, 0);
+
+    a0 = vmlaq_lane_s32(a0, vld1q_s32(k3), s_hi, 1);
+    a1 = vmlaq_lane_s32(a1, vld1q_s32(k3 + 4), s_hi, 1);
+    a2 = vmlaq_lane_s32(a2, vld1q_s32(k3 + 8), s_hi, 1);
+    a3 = vmlaq_lane_s32(a3, vld1q_s32(k3 + 12), s_hi, 1);
+    a4 = vmlaq_lane_s32(a4, vld1q_s32(k3 + 16), s_hi, 1);
+    a5 = vmlaq_lane_s32(a5, vld1q_s32(k3 + 20), s_hi, 1);
+    a6 = vmlaq_lane_s32(a6, vld1q_s32(k3 + 24), s_hi, 1);
+    a7 = vmlaq_lane_s32(a7, vld1q_s32(k3 + 28), s_hi, 1);
+    a8 = vmlaq_lane_s32(a8, vld1q_s32(k3 + 32), s_hi, 1);
+    a9 = vmlaq_lane_s32(a9, vld1q_s32(k3 + 36), s_hi, 1);
+    a10 = vmlaq_lane_s32(a10, vld1q_s32(k3 + 40), s_hi, 1);
+    a11 = vmlaq_lane_s32(a11, vld1q_s32(k3 + 44), s_hi, 1);
+  }
+
+  vst1q_s32(dst, clamp_s32(round_shift_s32(a0), min_v, max_v));
+  vst1q_s32(dst + 4, clamp_s32(round_shift_s32(a1), min_v, max_v));
+  vst1q_s32(dst + 8, clamp_s32(round_shift_s32(a2), min_v, max_v));
+  vst1q_s32(dst + 12, clamp_s32(round_shift_s32(a3), min_v, max_v));
+  vst1q_s32(dst + 16, clamp_s32(round_shift_s32(a4), min_v, max_v));
+  vst1q_s32(dst + 20, clamp_s32(round_shift_s32(a5), min_v, max_v));
+  vst1q_s32(dst + 24, clamp_s32(round_shift_s32(a6), min_v, max_v));
+  vst1q_s32(dst + 28, clamp_s32(round_shift_s32(a7), min_v, max_v));
+  vst1q_s32(dst + 32, clamp_s32(round_shift_s32(a8), min_v, max_v));
+  vst1q_s32(dst + 36, clamp_s32(round_shift_s32(a9), min_v, max_v));
+  vst1q_s32(dst + 40, clamp_s32(round_shift_s32(a10), min_v, max_v));
+  vst1q_s32(dst + 44, clamp_s32(round_shift_s32(a11), min_v, max_v));
+}
+
+void inv_stxfm_neon(tran_low_t *src, tran_low_t *dst,
+                    const PREDICTION_MODE mode, const uint8_t stx_idx,
+                    const int size, const int bd) {
+  assert(stx_idx < 4);
+  const int32_t *kernel = (size == 0) ? ist_4x4_kernel_int32[mode][stx_idx][0]
+                                      : ist_8x8_kernel_int32[mode][stx_idx][0];
+  if (size == 0) {
+    inv_stxfm_4x4_kernel(src, dst, kernel, bd);
+  } else {
+    int rh = (size == 1)   ? IST_8x8_HEIGHT_RED
+             : (size == 3) ? IST_ADST_NZ_CNT
+                           : IST_8x8_HEIGHT;
+    inv_stxfm_8x8_kernel(src, dst, kernel, rh, bd);
+  }
+}

--- a/av2/common/av2_rtcd_defs.pl
+++ b/av2/common/av2_rtcd_defs.pl
@@ -137,7 +137,7 @@ specialize qw/av2_copy_pred_array_highbd sse4_1 avx2/;
 
 #inv txfm
 add_proto qw/void inv_stxfm/ , "tran_low_t *src, tran_low_t *dst, const PREDICTION_MODE mode, const uint8_t stx_idx, const int size, const int bd";
-specialize qw/inv_stxfm sse4_1 avx2/;
+specialize qw/inv_stxfm sse4_1 avx2 neon/;
 add_proto qw/void av2_highbd_inv_txfm_add/, "const tran_low_t *input, uint16_t *dest, int stride, const TxfmParam *txfm_param";
 specialize qw/av2_highbd_inv_txfm_add sse4_1 avx2 neon/;
 
@@ -251,7 +251,7 @@ if (avm_config("CONFIG_AV2_ENCODER") eq "yes") {
 
   #fwd txfm
   add_proto qw/void fwd_stxfm/ , "tran_low_t *src, tran_low_t *dst, const PREDICTION_MODE mode, const uint8_t stx_idx, const int size, const int bd";
-  specialize qw/fwd_stxfm sse4_1 avx2/;
+  specialize qw/fwd_stxfm sse4_1 avx2 neon/;
 
   add_proto qw/void fwd_txfm/,  "const int16_t *resi, tran_low_t *coeff, int diff_stride, TxfmParam *txfm_param";
   specialize qw/fwd_txfm avx2/;

--- a/av2/encoder/arm/neon/fwd_stxfm_neon.c
+++ b/av2/encoder/arm/neon/fwd_stxfm_neon.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved.
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause
+ * Clear License was not distributed with this source code in the LICENSE file,
+ * you can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.
+ * If the Alliance for Open Media Patent License 1.0 was not distributed with
+ * this source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+#include <arm_neon.h>
+#include <assert.h>
+
+#include "config/av2_rtcd.h"
+
+#include "av2/common/av2_txfm.h"
+#include "av2/common/enums.h"
+
+static INLINE int32x4_t horizontal_add_4d_s32x4_fast(const int32x4_t sum[4]) {
+  const int32x2_t p0 = vpadd_s32(vget_low_s32(sum[0]), vget_high_s32(sum[0]));
+  const int32x2_t p1 = vpadd_s32(vget_low_s32(sum[1]), vget_high_s32(sum[1]));
+  const int32x2_t p2 = vpadd_s32(vget_low_s32(sum[2]), vget_high_s32(sum[2]));
+  const int32x2_t p3 = vpadd_s32(vget_low_s32(sum[3]), vget_high_s32(sum[3]));
+  const int32x2_t q01 = vpadd_s32(p0, p1);
+  const int32x2_t q23 = vpadd_s32(p2, p3);
+  return vcombine_s32(q01, q23);
+}
+
+static INLINE void fwd_stxfm_4x4_neon(const int32_t *src, int32_t *dst,
+                                      const int32_t *kernel, int bd) {
+  const int32x4_t max_v = vdupq_n_s32((1 << (7 + bd)) - 1);
+  const int32x4_t min_v = vdupq_n_s32(-(1 << (7 + bd)));
+  const int32x4_t bias = vdupq_n_s32(64);
+
+  const int32x4_t s0 = vld1q_s32(src);
+  const int32x4_t s1 = vld1q_s32(src + 4);
+  const int32x4_t s2 = vld1q_s32(src + 8);
+  const int32x4_t s3 = vld1q_s32(src + 12);
+
+  int32x4_t a0 = vmulq_s32(s0, vld1q_s32(kernel));
+  int32x4_t a1 = vmulq_s32(s0, vld1q_s32(kernel + 16));
+  int32x4_t a2 = vmulq_s32(s0, vld1q_s32(kernel + 32));
+  int32x4_t a3 = vmulq_s32(s0, vld1q_s32(kernel + 48));
+  int32x4_t a4 = vmulq_s32(s0, vld1q_s32(kernel + 64));
+  int32x4_t a5 = vmulq_s32(s0, vld1q_s32(kernel + 80));
+  int32x4_t a6 = vmulq_s32(s0, vld1q_s32(kernel + 96));
+  int32x4_t a7 = vmulq_s32(s0, vld1q_s32(kernel + 112));
+
+  a0 = vmlaq_s32(a0, s1, vld1q_s32(kernel + 4));
+  a1 = vmlaq_s32(a1, s1, vld1q_s32(kernel + 20));
+  a2 = vmlaq_s32(a2, s1, vld1q_s32(kernel + 36));
+  a3 = vmlaq_s32(a3, s1, vld1q_s32(kernel + 52));
+  a4 = vmlaq_s32(a4, s1, vld1q_s32(kernel + 68));
+  a5 = vmlaq_s32(a5, s1, vld1q_s32(kernel + 84));
+  a6 = vmlaq_s32(a6, s1, vld1q_s32(kernel + 100));
+  a7 = vmlaq_s32(a7, s1, vld1q_s32(kernel + 116));
+
+  a0 = vmlaq_s32(a0, s2, vld1q_s32(kernel + 8));
+  a1 = vmlaq_s32(a1, s2, vld1q_s32(kernel + 24));
+  a2 = vmlaq_s32(a2, s2, vld1q_s32(kernel + 40));
+  a3 = vmlaq_s32(a3, s2, vld1q_s32(kernel + 56));
+  a4 = vmlaq_s32(a4, s2, vld1q_s32(kernel + 72));
+  a5 = vmlaq_s32(a5, s2, vld1q_s32(kernel + 88));
+  a6 = vmlaq_s32(a6, s2, vld1q_s32(kernel + 104));
+  a7 = vmlaq_s32(a7, s2, vld1q_s32(kernel + 120));
+
+  a0 = vmlaq_s32(a0, s3, vld1q_s32(kernel + 12));
+  a1 = vmlaq_s32(a1, s3, vld1q_s32(kernel + 28));
+  a2 = vmlaq_s32(a2, s3, vld1q_s32(kernel + 44));
+  a3 = vmlaq_s32(a3, s3, vld1q_s32(kernel + 60));
+  a4 = vmlaq_s32(a4, s3, vld1q_s32(kernel + 76));
+  a5 = vmlaq_s32(a5, s3, vld1q_s32(kernel + 92));
+  a6 = vmlaq_s32(a6, s3, vld1q_s32(kernel + 108));
+  a7 = vmlaq_s32(a7, s3, vld1q_s32(kernel + 124));
+
+  const int32x4_t sum0[4] = { a0, a1, a2, a3 };
+  const int32x4_t sum1[4] = { a4, a5, a6, a7 };
+  int32x4_t c0 = horizontal_add_4d_s32x4_fast(sum0);
+  int32x4_t c1 = horizontal_add_4d_s32x4_fast(sum1);
+  int32x4_t sign0 = vshrq_n_s32(c0, 31);
+  c0 = vshrq_n_s32(vaddq_s32(vaddq_s32(c0, bias), sign0), 7);
+  c0 = vminq_s32(vmaxq_s32(c0, min_v), max_v);
+  int32x4_t sign1 = vshrq_n_s32(c1, 31);
+  c1 = vshrq_n_s32(vaddq_s32(vaddq_s32(c1, bias), sign1), 7);
+  c1 = vminq_s32(vmaxq_s32(c1, min_v), max_v);
+  vst1q_s32(dst, c0);
+  vst1q_s32(dst + 4, c1);
+}
+
+static INLINE void fwd_stxfm_8x8_neon(const int32_t *src, int32_t *dst,
+                                      const int32_t *kernel, int reduced_height,
+                                      int bd) {
+  assert(reduced_height % 4 == 0);
+  assert(IST_8x8_WIDTH % 4 == 0);
+  const int32x4_t max_v = vdupq_n_s32((1 << (7 + bd)) - 1);
+  const int32x4_t min_v = vdupq_n_s32(-(1 << (7 + bd)));
+  const int32x4_t bias = vdupq_n_s32(64);
+
+  const int32x4_t src0 = vld1q_s32(src);
+  const int32x4_t src1 = vld1q_s32(src + 4);
+  const int32x4_t src2 = vld1q_s32(src + 8);
+  const int32x4_t src3 = vld1q_s32(src + 12);
+  const int32x4_t src4 = vld1q_s32(src + 16);
+  const int32x4_t src5 = vld1q_s32(src + 20);
+  const int32x4_t src6 = vld1q_s32(src + 24);
+  const int32x4_t src7 = vld1q_s32(src + 28);
+  const int32x4_t src8 = vld1q_s32(src + 32);
+  const int32x4_t src9 = vld1q_s32(src + 36);
+  const int32x4_t src10 = vld1q_s32(src + 40);
+  const int32x4_t src11 = vld1q_s32(src + 44);
+
+  int j = 0;
+  for (; j + 7 < reduced_height; j += 8) {
+    int32x4_t a0 = vdupq_n_s32(0), a1 = vdupq_n_s32(0);
+    int32x4_t a2 = vdupq_n_s32(0), a3 = vdupq_n_s32(0);
+    int32x4_t a4 = vdupq_n_s32(0), a5 = vdupq_n_s32(0);
+    int32x4_t a6 = vdupq_n_s32(0), a7 = vdupq_n_s32(0);
+    const int32_t *k0 = kernel + (j + 0) * IST_8x8_WIDTH;
+    const int32_t *k1 = kernel + (j + 1) * IST_8x8_WIDTH;
+    const int32_t *k2 = kernel + (j + 2) * IST_8x8_WIDTH;
+    const int32_t *k3 = kernel + (j + 3) * IST_8x8_WIDTH;
+    const int32_t *k4 = kernel + (j + 4) * IST_8x8_WIDTH;
+    const int32_t *k5 = kernel + (j + 5) * IST_8x8_WIDTH;
+    const int32_t *k6 = kernel + (j + 6) * IST_8x8_WIDTH;
+    const int32_t *k7 = kernel + (j + 7) * IST_8x8_WIDTH;
+
+    // clang-format off
+#define STEP(S, OFF)                              \
+  a0 = vmlaq_s32(a0, S, vld1q_s32(k0 + OFF));    \
+  a1 = vmlaq_s32(a1, S, vld1q_s32(k1 + OFF));    \
+  a2 = vmlaq_s32(a2, S, vld1q_s32(k2 + OFF));    \
+  a3 = vmlaq_s32(a3, S, vld1q_s32(k3 + OFF));    \
+  a4 = vmlaq_s32(a4, S, vld1q_s32(k4 + OFF));    \
+  a5 = vmlaq_s32(a5, S, vld1q_s32(k5 + OFF));    \
+  a6 = vmlaq_s32(a6, S, vld1q_s32(k6 + OFF));    \
+  a7 = vmlaq_s32(a7, S, vld1q_s32(k7 + OFF));
+
+    STEP(src0, 0)
+    STEP(src1, 4)
+    STEP(src2, 8)
+    STEP(src3, 12)
+    STEP(src4, 16)
+    STEP(src5, 20)
+    STEP(src6, 24)
+    STEP(src7, 28)
+    STEP(src8, 32)
+    STEP(src9, 36)
+    STEP(src10, 40)
+    STEP(src11, 44)
+#undef STEP
+    // clang-format on
+
+    const int32x4_t sum0[4] = { a0, a1, a2, a3 };
+    const int32x4_t sum1[4] = { a4, a5, a6, a7 };
+    int32x4_t c0 = horizontal_add_4d_s32x4_fast(sum0);
+    int32x4_t c1 = horizontal_add_4d_s32x4_fast(sum1);
+    int32x4_t sign0 = vshrq_n_s32(c0, 31);
+    c0 = vshrq_n_s32(vaddq_s32(vaddq_s32(c0, bias), sign0), 7);
+    c0 = vminq_s32(vmaxq_s32(c0, min_v), max_v);
+    int32x4_t sign1 = vshrq_n_s32(c1, 31);
+    c1 = vshrq_n_s32(vaddq_s32(vaddq_s32(c1, bias), sign1), 7);
+    c1 = vminq_s32(vmaxq_s32(c1, min_v), max_v);
+    vst1q_s32(dst + j, c0);
+    vst1q_s32(dst + j + 4, c1);
+  }
+  for (; j + 3 < reduced_height; j += 4) {
+    int32x4_t a0 = vdupq_n_s32(0), a1 = vdupq_n_s32(0);
+    int32x4_t a2 = vdupq_n_s32(0), a3 = vdupq_n_s32(0);
+    const int32_t *k0 = kernel + (j + 0) * IST_8x8_WIDTH;
+    const int32_t *k1 = kernel + (j + 1) * IST_8x8_WIDTH;
+    const int32_t *k2 = kernel + (j + 2) * IST_8x8_WIDTH;
+    const int32_t *k3 = kernel + (j + 3) * IST_8x8_WIDTH;
+    for (int i = 0; i < IST_8x8_WIDTH; i += 4) {
+      int32x4_t s = vld1q_s32(src + i);
+      a0 = vmlaq_s32(a0, s, vld1q_s32(k0 + i));
+      a1 = vmlaq_s32(a1, s, vld1q_s32(k1 + i));
+      a2 = vmlaq_s32(a2, s, vld1q_s32(k2 + i));
+      a3 = vmlaq_s32(a3, s, vld1q_s32(k3 + i));
+    }
+    const int32x4_t sum0[4] = { a0, a1, a2, a3 };
+    int32x4_t c0 = horizontal_add_4d_s32x4_fast(sum0);
+    int32x4_t sign0 = vshrq_n_s32(c0, 31);
+    c0 = vshrq_n_s32(vaddq_s32(vaddq_s32(c0, bias), sign0), 7);
+    c0 = vminq_s32(vmaxq_s32(c0, min_v), max_v);
+    vst1q_s32(dst + j, c0);
+  }
+}
+
+void fwd_stxfm_neon(tran_low_t *src, tran_low_t *dst,
+                    const PREDICTION_MODE mode, const uint8_t stx_idx,
+                    const int size, const int bd) {
+  assert(stx_idx < 4);
+  if (size == 0) {
+    const int32_t *kernel = ist_4x4_kernel_int32[mode][stx_idx][0];
+    fwd_stxfm_4x4_neon(src, dst, kernel, bd);
+  } else {
+    const int32_t *kernel = ist_8x8_kernel_int32[mode][stx_idx][0];
+    int rh = (size == 1)   ? IST_8x8_HEIGHT_RED
+             : (size == 3) ? IST_ADST_NZ_CNT
+                           : IST_8x8_HEIGHT;
+    fwd_stxfm_8x8_neon(src, dst, kernel, rh, bd);
+  }
+}

--- a/test/av2_fwd_txfm2d_test.cc
+++ b/test/av2_fwd_txfm2d_test.cc
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <tuple>
 #include <vector>
 
@@ -23,17 +24,54 @@
 #include "test/av2_txfm_test.h"
 #include "test/function_equivalence_test.h"
 #include "av2/common/av2_txfm.h"
+#include "av2/common/enums.h"
 #include "av2/encoder/hybrid_fwd_txfm.h"
+#include "avm_ports/avm_timer.h"
 
 using libavm_test::ACMRandom;
-using libavm_test::bd;
-using libavm_test::compute_avg_abs_error;
-using libavm_test::input_base;
-using libavm_test::TYPE_TXFM;
 
 using std::vector;
 
 namespace {
+static const int kBitDepths[] = { 8, 10, 12 };
+static const int kNumBitDepths = 3;
+
+template <typename Func>
+void STxfmSpeedTest(Func ref_fn, Func test_fn, int input_size, int num_sizes) {
+  const int bd = 10;
+  av2_init_stxfm_kernels();
+  for (int sb_size = 0; sb_size < num_sizes; ++sb_size) {
+    DECLARE_ALIGNED(32, tran_low_t, input[IST_8x8_WIDTH]) = { 0 };
+    DECLARE_ALIGNED(32, tran_low_t, output[IST_8x8_WIDTH]) = { 0 };
+    ACMRandom rnd(ACMRandom::DeterministicSeed());
+    const int coeff_range = (1 << (bd + 7)) - 1;
+    for (int r = 0; r < input_size; ++r) {
+      input[r] = rnd(2) ? rnd(coeff_range) : -rnd(coeff_range);
+    }
+    avm_usec_timer ref_timer, test_timer;
+    const int knum_loops = 100000000;
+    avm_usec_timer_start(&ref_timer);
+    for (int i = 0; i < knum_loops; ++i) {
+      ref_fn(input, output, 0, 0, sb_size, bd);
+    }
+    avm_usec_timer_mark(&ref_timer);
+    const int elapsed_time_c =
+        static_cast<int>(avm_usec_timer_elapsed(&ref_timer));
+
+    avm_usec_timer_start(&test_timer);
+    for (int i = 0; i < knum_loops; ++i) {
+      test_fn(input, output, 0, 0, sb_size, bd);
+    }
+    avm_usec_timer_mark(&test_timer);
+    const int elapsed_time_simd =
+        static_cast<int>(avm_usec_timer_elapsed(&test_timer));
+
+    printf("sb_size[%d] \t c_time=%d \t simd_time=%d \t gain=%f \n", sb_size,
+           elapsed_time_c, elapsed_time_simd,
+           ((1.0 * elapsed_time_c) / elapsed_time_simd));
+  }
+}
+
 ///////////////////////////////////////////////////////////////
 //       unit-test for 'fwd_stxfm'                           //
 ///////////////////////////////////////////////////////////////
@@ -46,38 +84,42 @@ class AV2FwdSecTxfmTest : public ::testing::TestWithParam<FwdSTxfmFunc> {
   AV2FwdSecTxfmTest() : fwd_stxfm_func_(GetParam()) {}
   void AV2FwdSecTxfmMatchTest() {
     av2_init_stxfm_kernels();
-    for (int set_id = 0; set_id < IST_SET_SIZE; ++set_id) {
-      for (uint8_t stx = 0; stx < STX_TYPES - 1; ++stx) {
-        for (int sb_size = 0; sb_size < 3; ++sb_size) {
-          DECLARE_ALIGNED(32, tran_low_t, input[IST_8x8_WIDTH]) = { 0 };
-          DECLARE_ALIGNED(32, tran_low_t, output[IST_8x8_HEIGHT]) = { 0 };
-          DECLARE_ALIGNED(32, tran_low_t, ref_output[IST_8x8_HEIGHT]) = { 0 };
-          ACMRandom rnd(ACMRandom::DeterministicSeed());
-          const int coeff_range = (1 << (bd + 7)) - 1;
-          for (int cnt = 0; cnt < 3; ++cnt) {
-            if (cnt == 0) {
-              for (int r = 0; r < IST_8x8_WIDTH; ++r) {
-                input[r] = coeff_range;
+    for (int bdi = 0; bdi < kNumBitDepths; ++bdi) {
+      const int bd = kBitDepths[bdi];
+      for (int set_id = 0; set_id < IST_SET_SIZE; ++set_id) {
+        for (uint8_t stx = 0; stx < STX_TYPES - 1; ++stx) {
+          for (int sb_size = 0; sb_size < 4; ++sb_size) {
+            DECLARE_ALIGNED(32, tran_low_t, input[IST_8x8_WIDTH]) = { 0 };
+            DECLARE_ALIGNED(32, tran_low_t, output[IST_8x8_HEIGHT]) = { 0 };
+            DECLARE_ALIGNED(32, tran_low_t, ref_output[IST_8x8_HEIGHT]) = { 0 };
+            ACMRandom rnd(ACMRandom::DeterministicSeed());
+            const int coeff_range = (1 << (bd + 7)) - 1;
+            for (int cnt = 0; cnt < 3; ++cnt) {
+              if (cnt == 0) {
+                for (int r = 0; r < IST_8x8_WIDTH; ++r) {
+                  input[r] = coeff_range;
+                }
+              } else if (cnt == 1) {
+                for (int r = 0; r < IST_8x8_WIDTH; ++r) {
+                  input[r] = -coeff_range;
+                }
+              } else {
+                for (int r = 0; r < IST_8x8_WIDTH; ++r) {
+                  input[r] = rnd(2) ? rnd(coeff_range) : -rnd(coeff_range);
+                }
               }
-            } else if (cnt == 1) {
-              for (int r = 0; r < IST_8x8_WIDTH; ++r) {
-                input[r] = -coeff_range;
+              fwd_stxfm_c(input, ref_output, set_id, stx, sb_size, bd);
+              fwd_stxfm_func_(input, output, set_id, stx, sb_size, bd);
+              int check_rows = (sb_size == 0)   ? IST_4x4_HEIGHT
+                               : (sb_size == 1) ? IST_8x8_HEIGHT_RED
+                               : (sb_size == 3) ? IST_ADST_NZ_CNT
+                                                : IST_8x8_HEIGHT;
+              for (int r = 0; r < check_rows; ++r) {
+                ASSERT_EQ(ref_output[r], output[r])
+                    << "[" << r << "] bd:" << bd << " cnt:" << cnt
+                    << " ref_output: " << ref_output[r]
+                    << " mod_output: " << output[r];
               }
-            } else {
-              for (int r = 0; r < IST_8x8_WIDTH; ++r) {
-                input[r] = rnd(2) ? rnd(coeff_range) : -rnd(coeff_range);
-              }
-            }
-            fwd_stxfm_c(input, ref_output, set_id, stx, sb_size, bd);
-            fwd_stxfm_func_(input, output, set_id, stx, sb_size, bd);
-            int check_rows = (sb_size == 0)   ? IST_4x4_HEIGHT
-                             : (sb_size == 1) ? IST_8x8_HEIGHT_RED
-                                              : IST_8x8_HEIGHT;
-            for (int r = 0; r < check_rows; ++r) {
-              ASSERT_EQ(ref_output[r], output[r])
-                  << "[" << r << "] cnt:" << cnt
-                  << " ref_output: " << ref_output[r]
-                  << " mod_output: " << output[r];
             }
           }
         }
@@ -86,39 +128,7 @@ class AV2FwdSecTxfmTest : public ::testing::TestWithParam<FwdSTxfmFunc> {
   }
 
   void AV2FwdSecTxfmSpeedTest() {
-    av2_init_stxfm_kernels();
-    for (int sb_size = 0; sb_size < 3; ++sb_size) {
-      DECLARE_ALIGNED(32, tran_low_t, input[IST_8x8_WIDTH]) = { 0 };
-      DECLARE_ALIGNED(32, tran_low_t, output[IST_8x8_HEIGHT]) = { 0 };
-      ACMRandom rnd(ACMRandom::DeterministicSeed());
-      const int coeff_range = (1 << (bd + 7)) - 1;
-      for (int r = 0; r < IST_8x8_WIDTH; ++r) {
-        input[r] = rnd(2) ? rnd(coeff_range) : -rnd(coeff_range);
-      }
-      avm_usec_timer ref_timer, test_timer;
-      const int knum_loops = 100000000;
-      avm_usec_timer_start(&ref_timer);
-      for (int i = 0; i < knum_loops; ++i) {
-        fwd_stxfm_c(input, output, 0, 0, sb_size, bd);
-      }
-      avm_usec_timer_mark(&ref_timer);
-      const int elapsed_time_c =
-          static_cast<int>(avm_usec_timer_elapsed(&ref_timer));
-
-      avm_usec_timer_start(&test_timer);
-      for (int i = 0; i < knum_loops; ++i) {
-        fwd_stxfm_func_(input, output, 0, 0, sb_size, bd);
-      }
-      avm_usec_timer_mark(&test_timer);
-      const int elapsed_time_simd =
-          static_cast<int>(avm_usec_timer_elapsed(&test_timer));
-
-      printf(
-          "sb_size[%d] \t c_time=%d \t simd_time=%d \t "
-          "gain=%f \n",
-          sb_size, elapsed_time_c, elapsed_time_simd,
-          ((1.0 * elapsed_time_c) / elapsed_time_simd));
-    }
+    STxfmSpeedTest(fwd_stxfm_c, fwd_stxfm_func_, IST_8x8_WIDTH, 4);
   }
   FwdSTxfmFunc fwd_stxfm_func_;
 };
@@ -137,92 +147,8 @@ INSTANTIATE_TEST_SUITE_P(AVX2, AV2FwdSecTxfmTest,
                          ::testing::Values(fwd_stxfm_avx2));
 #endif  // HAVE_AVX2
 
-///////////////////////////////////////////////////////////////
-//       unit-test for 'inv_stxfm'                           //
-///////////////////////////////////////////////////////////////
-
-typedef void (*InvSTxfmFunc)(tran_low_t *src, tran_low_t *dst,
-                             const PREDICTION_MODE mode, const uint8_t stx_idx,
-                             const int size, const int bd);
-class AV2InvSecTxfmTest : public ::testing::TestWithParam<InvSTxfmFunc> {
- public:
-  AV2InvSecTxfmTest() : inv_stxfm_func_(GetParam()) {}
-  void AV2InvSecTxfmMatchTest() {
-    av2_init_stxfm_kernels();
-    for (int set_id = 0; set_id < IST_SET_SIZE; ++set_id) {
-      for (uint8_t stx = 0; stx < STX_TYPES - 1; ++stx) {
-        for (int sb_size = 0; sb_size < 3; ++sb_size) {
-          DECLARE_ALIGNED(32, tran_low_t, input[IST_8x8_HEIGHT]) = { 0 };
-          DECLARE_ALIGNED(32, tran_low_t, output[IST_8x8_WIDTH]) = { 0 };
-          DECLARE_ALIGNED(32, tran_low_t, ref_output[IST_8x8_WIDTH]) = { 0 };
-          ACMRandom rnd(ACMRandom::DeterministicSeed());
-          const int coeff_range = ((1 << (bd + 7)) - 1);
-          for (int r = 0; r < IST_8x8_HEIGHT; r++) {
-            input[r] = rnd(2) ? rnd(coeff_range) : -rnd(coeff_range);
-          }
-          inv_stxfm_c(input, ref_output, set_id, stx, sb_size, bd);
-          inv_stxfm_func_(input, output, set_id, stx, sb_size, bd);
-          int check_rows = (sb_size == 0) ? IST_4x4_WIDTH : IST_8x8_WIDTH;
-          for (int r = 0; r < check_rows; ++r) {
-            ASSERT_EQ(ref_output[r], output[r])
-                << "[" << r << "] " << " ref_output: " << ref_output[r]
-                << " mod_output: " << output[r];
-          }
-        }
-      }
-    }
-  }
-
-  void AV2InvSecTxfmSpeedTest() {
-    av2_init_stxfm_kernels();
-    for (int sb_size = 0; sb_size < 3; ++sb_size) {
-      DECLARE_ALIGNED(32, tran_low_t, input[IST_8x8_HEIGHT]) = { 0 };
-      DECLARE_ALIGNED(32, tran_low_t, output[IST_8x8_WIDTH]) = { 0 };
-      ACMRandom rnd(ACMRandom::DeterministicSeed());
-      const int coeff_range = ((1 << (bd + 7)) - 1);
-      for (int r = 0; r < IST_8x8_HEIGHT; ++r) {
-        input[r] = rnd(2) ? rnd(coeff_range) : -rnd(coeff_range);
-      }
-      avm_usec_timer ref_timer, test_timer;
-      const int knum_loops = 100000000;
-      avm_usec_timer_start(&ref_timer);
-      for (int i = 0; i < knum_loops; ++i) {
-        fwd_stxfm_c(input, output, 0, 0, sb_size, bd);
-      }
-      avm_usec_timer_mark(&ref_timer);
-      const int elapsed_time_c =
-          static_cast<int>(avm_usec_timer_elapsed(&ref_timer));
-
-      avm_usec_timer_start(&test_timer);
-      for (int i = 0; i < knum_loops; ++i) {
-        inv_stxfm_func_(input, output, 0, 0, sb_size, bd);
-      }
-      avm_usec_timer_mark(&test_timer);
-      const int elapsed_time_simd =
-          static_cast<int>(avm_usec_timer_elapsed(&test_timer));
-
-      printf(
-          "sb_size[%d] \t c_time=%d \t simd_time=%d \t "
-          "gain=%f \n",
-          sb_size, elapsed_time_c, elapsed_time_simd,
-          ((1.0 * elapsed_time_c) / elapsed_time_simd));
-    }
-  }
-  InvSTxfmFunc inv_stxfm_func_;
-};
-
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AV2InvSecTxfmTest);
-
-TEST_P(AV2InvSecTxfmTest, match) { AV2InvSecTxfmMatchTest(); }
-TEST_P(AV2InvSecTxfmTest, DISABLED_Speed) { AV2InvSecTxfmSpeedTest(); }
-
-#if HAVE_SSE4_1
-INSTANTIATE_TEST_SUITE_P(SSE4_1, AV2InvSecTxfmTest,
-                         ::testing::Values(inv_stxfm_sse4_1));
-#endif  // HAVE_SSE4_1
-
-#if HAVE_AVX2
-INSTANTIATE_TEST_SUITE_P(AVX2, AV2InvSecTxfmTest,
-                         ::testing::Values(inv_stxfm_avx2));
-#endif  // HAVE_AVX2
+#if HAVE_NEON
+INSTANTIATE_TEST_SUITE_P(NEON, AV2FwdSecTxfmTest,
+                         ::testing::Values(fwd_stxfm_neon));
+#endif  // HAVE_NEON
 }  // namespace

--- a/test/av2_inv_stxfm_test.cc
+++ b/test/av2_inv_stxfm_test.cc
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, Alliance for Open Media. All rights reserved.
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause
+ * Clear License was not distributed with this source code in the LICENSE file,
+ * you can obtain it at aomedia.org/license/software-license/bsd-3-c-c/.
+ * If the Alliance for Open Media Patent License 1.0 was not distributed with
+ * this source code in the PATENTS file, you can obtain it at
+ * aomedia.org/license/patent-license/.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "config/av2_rtcd.h"
+
+#include "test/acm_random.h"
+#include "av2/common/av2_txfm.h"
+#include "av2/common/enums.h"
+#include "avm_ports/avm_timer.h"
+
+using libavm_test::ACMRandom;
+
+namespace {
+static const int kBitDepths[] = { 8, 10, 12 };
+static const int kNumBitDepths = 3;
+
+typedef void (*InvSTxfmFunc)(tran_low_t *src, tran_low_t *dst,
+                             const PREDICTION_MODE mode, const uint8_t stx_idx,
+                             const int size, const int bd);
+class AV2InvSecTxfmTest : public ::testing::TestWithParam<InvSTxfmFunc> {
+ public:
+  AV2InvSecTxfmTest() : inv_stxfm_func_(GetParam()) {}
+  void AV2InvSecTxfmMatchTest() {
+    av2_init_stxfm_kernels();
+    for (int bdi = 0; bdi < kNumBitDepths; ++bdi) {
+      const int bd = kBitDepths[bdi];
+      for (int set_id = 0; set_id < IST_SET_SIZE; ++set_id) {
+        for (uint8_t stx = 0; stx < STX_TYPES - 1; ++stx) {
+          for (int sb_size = 0; sb_size < 4; ++sb_size) {
+            DECLARE_ALIGNED(32, tran_low_t, input[IST_8x8_HEIGHT]) = { 0 };
+            DECLARE_ALIGNED(32, tran_low_t, output[IST_8x8_WIDTH]) = { 0 };
+            DECLARE_ALIGNED(32, tran_low_t, ref_output[IST_8x8_WIDTH]) = { 0 };
+            ACMRandom rnd(ACMRandom::DeterministicSeed());
+            const int coeff_range = ((1 << (bd + 7)) - 1);
+            for (int cnt = 0; cnt < 3; ++cnt) {
+              memset(output, 0, sizeof(output));
+              memset(ref_output, 0, sizeof(ref_output));
+              if (cnt == 0) {
+                for (int r = 0; r < IST_8x8_HEIGHT; r++) {
+                  input[r] = coeff_range;
+                }
+              } else if (cnt == 1) {
+                for (int r = 0; r < IST_8x8_HEIGHT; r++) {
+                  input[r] = -coeff_range;
+                }
+              } else {
+                for (int r = 0; r < IST_8x8_HEIGHT; r++) {
+                  input[r] = rnd(2) ? rnd(coeff_range) : -rnd(coeff_range);
+                }
+              }
+              inv_stxfm_c(input, ref_output, set_id, stx, sb_size, bd);
+              inv_stxfm_func_(input, output, set_id, stx, sb_size, bd);
+              int check_rows = (sb_size == 0) ? IST_4x4_WIDTH : IST_8x8_WIDTH;
+              for (int r = 0; r < check_rows; ++r) {
+                ASSERT_EQ(ref_output[r], output[r])
+                    << "[" << r << "] bd:" << bd << " cnt:" << cnt
+                    << " ref_output: " << ref_output[r]
+                    << " mod_output: " << output[r];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void AV2InvSecTxfmSpeedTest() {
+    const int bd = 10;
+    av2_init_stxfm_kernels();
+    for (int sb_size = 0; sb_size < 4; ++sb_size) {
+      DECLARE_ALIGNED(32, tran_low_t, input[IST_8x8_HEIGHT]) = { 0 };
+      DECLARE_ALIGNED(32, tran_low_t, output[IST_8x8_WIDTH]) = { 0 };
+      ACMRandom rnd(ACMRandom::DeterministicSeed());
+      const int coeff_range = (1 << (bd + 7)) - 1;
+      for (int r = 0; r < IST_8x8_HEIGHT; ++r) {
+        input[r] = rnd(2) ? rnd(coeff_range) : -rnd(coeff_range);
+      }
+      avm_usec_timer ref_timer, test_timer;
+      const int knum_loops = 100000000;
+      avm_usec_timer_start(&ref_timer);
+      for (int i = 0; i < knum_loops; ++i) {
+        inv_stxfm_c(input, output, 0, 0, sb_size, bd);
+      }
+      avm_usec_timer_mark(&ref_timer);
+      const int elapsed_time_c =
+          static_cast<int>(avm_usec_timer_elapsed(&ref_timer));
+
+      avm_usec_timer_start(&test_timer);
+      for (int i = 0; i < knum_loops; ++i) {
+        inv_stxfm_func_(input, output, 0, 0, sb_size, bd);
+      }
+      avm_usec_timer_mark(&test_timer);
+      const int elapsed_time_simd =
+          static_cast<int>(avm_usec_timer_elapsed(&test_timer));
+
+      printf("sb_size[%d] \t c_time=%d \t simd_time=%d \t gain=%f \n", sb_size,
+             elapsed_time_c, elapsed_time_simd,
+             ((1.0 * elapsed_time_c) / elapsed_time_simd));
+    }
+  }
+  InvSTxfmFunc inv_stxfm_func_;
+};
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AV2InvSecTxfmTest);
+
+TEST_P(AV2InvSecTxfmTest, match) { AV2InvSecTxfmMatchTest(); }
+TEST_P(AV2InvSecTxfmTest, DISABLED_Speed) { AV2InvSecTxfmSpeedTest(); }
+
+#if HAVE_SSE4_1
+INSTANTIATE_TEST_SUITE_P(SSE4_1, AV2InvSecTxfmTest,
+                         ::testing::Values(inv_stxfm_sse4_1));
+#endif  // HAVE_SSE4_1
+
+#if HAVE_AVX2
+INSTANTIATE_TEST_SUITE_P(AVX2, AV2InvSecTxfmTest,
+                         ::testing::Values(inv_stxfm_avx2));
+#endif  // HAVE_AVX2
+
+#if HAVE_NEON
+INSTANTIATE_TEST_SUITE_P(NEON, AV2InvSecTxfmTest,
+                         ::testing::Values(inv_stxfm_neon));
+#endif  // HAVE_NEON
+
+}  // namespace

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -87,6 +87,7 @@ if(NOT BUILD_SHARED_LIBS)
     APPEND
     AVM_UNIT_TEST_COMMON_SOURCES
     "${AVM_ROOT}/test/av2_common_int_test.cc"
+    "${AVM_ROOT}/test/av2_inv_stxfm_test.cc"
     "${AVM_ROOT}/test/bawp_test.cc"
     "${AVM_ROOT}/test/bitwriter_buffer_test.cc"
     "${AVM_ROOT}/test/cdef_test.cc"
@@ -265,6 +266,8 @@ if(NOT BUILD_SHARED_LIBS)
   endif()
 
   list(APPEND AVM_UNIT_TEST_ENCODER_SOURCES "${AVM_ROOT}/test/trellis_test.cc")
+  list(APPEND AVM_UNIT_TEST_ENCODER_SOURCES
+       "${AVM_ROOT}/test/av2_fwd_txfm2d_test.cc")
 
 endif()
 


### PR DESCRIPTION
This adds NEON intrinsics for both forward and inverse secondary
transforms, achieving 1.5x/11.4x speedup over C respectively.

Forward transform uses element-wise multiply-accumulate with preloaded
source vectors and a vpadd_s32 tree reduction. Specialized 4x4 (fully
unrolled) and 8x8 (8-row batched) paths.

Inverse transform uses register-tiled lane-indexed multiply-accumulate.
The 8x8 kernel keeps all 12 output accumulators in registers across the
full input loop, eliminating the store-accumulate pattern used by AVX2.

All intrinsics are ARMv7-compatible (no AArch64-only ops).

fwd_stxfm_neon placed in encoder library (av2/encoder/arm/neon/),
inv_stxfm_neon in common library (av2/common/arm/), matching x86 layout.

Micro-benchmark results (Apple M3 Pro P-core):

| Kernel | C (ns) | NEON (ns) | Speedup |
|--------|--------|-----------|---------|
| fwd_stxfm 4x4 | 12.4 | 7.0 | 1.8x |
| fwd_stxfm 8x8 | 89.3 | 58.1 | 1.5x |
| inv_stxfm 4x4 | 58.1 | 6.0 | 9.6x |
| inv_stxfm 8x8 | 505.9 | 43.4 | 11.4x |

CTC Results (RA, cpu-used=1, 33 frames, A5):

| Metric | Delta |
|--------|-------|
| Encode time | -0.33% |
| BD-rate Y | 0.000% |
| BD-rate Cb | 0.000% |
| BD-rate Cr | 0.000% |

Bit-exact confirmed (all PSNR and bitrate values identical).

Unit tests included (fwd_stxfm in encoder tests, inv_stxfm in common
tests). Tests cover all bit depths (8/10/12), all modes, all sizes
including IST_ADST_NZ_CNT.