### PR TITLE
Disable tx partition at speed 6

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -689,6 +689,7 @@ static void set_good_speed_features_framesize_independent(
 
     sf->tx_sf.tx_type_search.winner_mode_tx_type_pruning = 2;
     sf->tx_sf.tx_type_search.prune_tx_type_est_rd = 0;
+    sf->tx_sf.enable_tx_partition = 0;
 
     sf->rd_sf.perform_coeff_opt = is_boosted_arf2_bwd_type ? 4 : 6;
 

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -689,7 +689,7 @@ static void set_good_speed_features_framesize_independent(
 
     sf->tx_sf.tx_type_search.winner_mode_tx_type_pruning = 2;
     sf->tx_sf.tx_type_search.prune_tx_type_est_rd = 0;
-    sf->tx_sf.enable_tx_partition = 0;
+    sf->tx_sf.enable_tx_partition = false;
 
     sf->rd_sf.perform_coeff_opt = is_boosted_arf2_bwd_type ? 4 : 6;
 


### PR DESCRIPTION
Tx partition is disabled for speed >= 6.

Anchor: https://github.com/AOMediaCodec/avm/commit/59be49b8ecb360f3e419acba3429a21b15059935
+---------+--------+--------+--------+--------+----------+----------+
| Summary |   Y    |   U    |   V    |  YUV   | Enc-time | Dec-time |
+---------+--------+--------+--------+--------+----------+----------+
| A1      |  1.38% |  0.40% |  0.48% |  1.27% | 76.5%    | 101%     |
| A2      |  1.43% |  0.47% |  0.81% |  1.35% | 78.4%    | 100%     |
+---------+--------+--------+--------+--------+----------+----------+