### PR TITLE
Removed unused tmp pred buf and GDF line buffer memory

### DIFF
--- a/av2/common/av2_common_int.h
+++ b/av2/common/av2_common_int.h
@@ -433,12 +433,10 @@ typedef struct BufferPool {
  */
 typedef struct {
   uint16_t
-      gdf_save_above[GDF_TEST_EXTRA_VER_BORDER]
-                    [RESTORATION_LINEBUFFER_WIDTH]; /*!< GDF temporary buffer to
+      *gdf_save_above[GDF_TEST_EXTRA_VER_BORDER]; /*!< GDF temporary buffer to
                                                      save/restore above */
   uint16_t
-      gdf_save_below[GDF_TEST_EXTRA_VER_BORDER]
-                    [RESTORATION_LINEBUFFER_WIDTH]; /*!< GDF temporary buffer to
+      *gdf_save_below[GDF_TEST_EXTRA_VER_BORDER]; /*!< GDF temporary buffer to
                                                      save/restore below */
 } GDFLineBuffers;
 

--- a/av2/common/gdf.c
+++ b/av2/common/gdf.c
@@ -113,7 +113,28 @@ void init_gdf(AV2_COMMON *cm) {
   gi->err_stride = gi->gdf_unit_size + GDF_ERR_STRIDE_MARGIN;
 }
 
-void alloc_gdf_buffers(GdfInfo *gi) {
+static GDFLineBuffers *alloc_gdf_line_buffers(int frame_width) {
+  GDFLineBuffers *glbs = (GDFLineBuffers *)avm_malloc(sizeof(*glbs));
+
+  const int row_len = frame_width + 2 * GDF_TEST_EXTRA_HOR_BORDER;
+  for (int i = 0; i < GDF_TEST_EXTRA_VER_BORDER; ++i) {
+    glbs->gdf_save_above[i] = (uint16_t *)avm_memalign(
+        32, row_len * sizeof(*glbs->gdf_save_above[i]));
+    glbs->gdf_save_below[i] = (uint16_t *)avm_memalign(
+        32, row_len * sizeof(*glbs->gdf_save_below[i]));
+  }
+  return glbs;
+}
+
+static void free_gdf_line_buffers(GDFLineBuffers *glbs) {
+  for (int i = 0; i < GDF_TEST_EXTRA_VER_BORDER; ++i) {
+    avm_free(glbs->gdf_save_above[i]);
+    avm_free(glbs->gdf_save_below[i]);
+  }
+  avm_free(glbs);
+}
+
+void alloc_gdf_buffers(GdfInfo *gi, int frame_width) {
   free_gdf_buffers(gi);
   gi->lap_ptr =
       (uint16_t **)avm_malloc(GDF_NET_INP_GRD_NUM * sizeof(uint16_t *));
@@ -133,7 +154,7 @@ void alloc_gdf_buffers(GdfInfo *gi) {
   memset(gi->err_ptr, 0, gi->err_height * gi->err_stride * sizeof(int16_t));
   gi->gdf_block_flags = (int32_t *)avm_malloc(gi->gdf_block_num * sizeof(int));
   memset(gi->gdf_block_flags, 0, gi->gdf_block_num * sizeof(int));
-  gi->glbs = (GDFLineBuffers *)avm_malloc(sizeof(GDFLineBuffers));
+  gi->glbs = alloc_gdf_line_buffers(frame_width);
   gi->tmp_save_left = (uint16_t *)avm_malloc(
       (gi->gdf_unit_size + 2 * GDF_TEST_EXTRA_VER_BORDER) *
       GDF_TEST_EXTRA_HOR_BORDER * sizeof(*gi->tmp_save_left));
@@ -164,7 +185,7 @@ void free_gdf_buffers(GdfInfo *gi) {
     gi->gdf_block_flags = NULL;
   }
   if (gi->glbs != NULL) {
-    avm_free(gi->glbs);
+    free_gdf_line_buffers(gi->glbs);
     gi->glbs = NULL;
   }
   if (gi->tmp_save_left != NULL) {

--- a/av2/common/gdf.h
+++ b/av2/common/gdf.h
@@ -38,7 +38,7 @@ void init_gdf_test(GdfInfo *gi, int mib_size, int rec_height, int rec_width);
 /*!\brief Function to allocate memory storing block's expected coding error of
  * GDF
  */
-void alloc_gdf_buffers(GdfInfo *gi);
+void alloc_gdf_buffers(GdfInfo *gi, int frame_width);
 
 /*!\brief Function to free memory storing block's expected coding error of GDF
  */

--- a/av2/common/restoration.h
+++ b/av2/common/restoration.h
@@ -246,15 +246,6 @@ typedef struct {
 
 /*!\cond */
 
-// A restoration line buffer needs space for two lines plus a horizontal filter
-// margin of RESTORATION_BORDER_HORZ on each side.
-// The maximum picture width is 8192 * 8 for LR to work properly in this
-// software implementation. This is one quick implementation, the buffer size
-// should be allocated based on picture width
-#define MAX_SUPPORTED_PIC_WIDTH_IN_CCALF_IMP (8192 * 8)
-#define RESTORATION_LINEBUFFER_WIDTH \
-  (MAX_SUPPORTED_PIC_WIDTH_IN_CCALF_IMP * 3 / 2 + 2 * RESTORATION_BORDER_HORZ)
-
 typedef struct RestorationLineBuffers {
   // Temporary buffers to save/restore 3 lines above/below the restoration
   // stripe.

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -3003,7 +3003,7 @@ static AVM_INLINE void setup_gdf(AV2_COMMON *cm,
     cm->gdf_info.gdf_mode = avm_rb_read_bit(rb);
   }
   if (cm->gdf_info.gdf_mode > 0) {
-    alloc_gdf_buffers(&cm->gdf_info);
+    alloc_gdf_buffers(&cm->gdf_info, cm->cur_frame->buf.y_width);
     if (cm->gdf_info.gdf_block_num > 1) {
       cm->gdf_info.gdf_mode += avm_rb_read_bit(rb);
     }

--- a/av2/encoder/block.h
+++ b/av2/encoder/block.h
@@ -1289,7 +1289,7 @@ typedef struct macroblock {
    * Points to a buffer that is used to hold temporary prediction results. This
    * is used to pingpong the prediction in handle_inter_mode.
    */
-  uint16_t *tmp_pred_bufs[2];
+  uint16_t *tmp_pred_bufs;
 
   /*!
    *  Buffer used for upsampled prediction.

--- a/av2/encoder/encoder.c
+++ b/av2/encoder/encoder.c
@@ -1331,12 +1331,10 @@ void av2_change_config(struct AV2_COMP *cpi, const AV2EncoderConfig *oxcf) {
     x->e_mbd.opfl_dst_bufs = x->opfl_dst_bufs;
   }
 
-  for (int i = 0; i < 2; ++i) {
-    if (x->tmp_pred_bufs[i] == NULL) {
-      CHECK_MEM_ERROR(cm, x->tmp_pred_bufs[i],
-                      avm_memalign(32, 2 * MAX_MB_PLANE * MAX_SB_SQUARE *
-                                           sizeof(*x->tmp_pred_bufs[i])));
-    }
+  if (x->tmp_pred_bufs == NULL) {
+    CHECK_MEM_ERROR(cm, x->tmp_pred_bufs,
+                    avm_memalign(32, MAX_MB_PLANE * MAX_SB_SQUARE *
+                                         sizeof(*x->tmp_pred_bufs)));
   }
 
   av2_reset_segment_features(cm);
@@ -1801,9 +1799,7 @@ static AVM_INLINE void free_thread_data(AV2_COMP *cpi) {
     avm_free(thread_data->td->opfl_gxy_bufs);
     avm_free(thread_data->td->opfl_dst_bufs);
     release_compound_type_rd_buffers(&thread_data->td->comp_rd_buffer);
-    for (int j = 0; j < 2; ++j) {
-      avm_free(thread_data->td->tmp_pred_bufs[j]);
-    }
+    avm_free(thread_data->td->tmp_pred_bufs);
     avm_free(thread_data->td->mb.inter_modes_info);
     for (int x = 0; x < 2; x++) {
       for (int y = 0; y < 2; y++) {
@@ -3039,7 +3035,7 @@ void gdf_optimizer(AV2_COMP *cpi, AV2_COMMON *cm) {
  */
 void gdf_optimize_frame(AV2_COMP *cpi, AV2_COMMON *cm) {
   init_gdf(cm);
-  alloc_gdf_buffers(&cm->gdf_info);
+  alloc_gdf_buffers(&cm->gdf_info, cm->cur_frame->buf.y_width);
   gdf_optimizer(cpi, cm);
 #if GDF_VERBOSE
   gdf_print_info(cm, "ENC", cm->current_frame.absolute_poc);

--- a/av2/encoder/encoder.h
+++ b/av2/encoder/encoder.h
@@ -1727,7 +1727,7 @@ typedef struct ThreadData {
   // Temporary buffers used to store intermediate prediction data calculated
   // during the OPFL/SMVR.
   uint16_t *opfl_dst_bufs;
-  uint16_t *tmp_pred_bufs[2];
+  uint16_t *tmp_pred_bufs;
   // Buffer used for upsampled prediction.
   uint16_t *upsample_pred;
   int intrabc_used;

--- a/av2/encoder/encoder_alloc.h
+++ b/av2/encoder/encoder_alloc.h
@@ -257,9 +257,7 @@ static AVM_INLINE void dealloc_compressor_data(AV2_COMP *cpi) {
   avm_free(cpi->td.mb.opfl_vxy_bufs);
   avm_free(cpi->td.mb.opfl_gxy_bufs);
   avm_free(cpi->td.mb.opfl_dst_bufs);
-  for (int j = 0; j < 2; ++j) {
-    avm_free(cpi->td.mb.tmp_pred_bufs[j]);
-  }
+  avm_free(cpi->td.mb.tmp_pred_bufs);
 
 #if CONFIG_DENOISE
   if (cpi->denoise_and_model) {

--- a/av2/encoder/ethread.c
+++ b/av2/encoder/ethread.c
@@ -645,12 +645,10 @@ static AVM_INLINE void create_enc_workers(AV2_COMP *cpi, int num_workers) {
           avm_memalign(16, ((MAX_SB_SIZE + 16) + 16) * MAX_SB_SIZE *
                                sizeof(*thread_data->td->upsample_pred)));
 
-      for (int j = 0; j < 2; ++j) {
-        CHECK_MEM_ERROR(
-            cm, thread_data->td->tmp_pred_bufs[j],
-            avm_memalign(32, 2 * MAX_MB_PLANE * MAX_SB_SQUARE *
-                                 sizeof(*thread_data->td->tmp_pred_bufs[j])));
-      }
+      CHECK_MEM_ERROR(
+          cm, thread_data->td->tmp_pred_bufs,
+          avm_memalign(32, MAX_MB_PLANE * MAX_SB_SQUARE *
+                               sizeof(*thread_data->td->tmp_pred_bufs)));
 
       CHECK_MEM_ERROR(
           cm, thread_data->td->mbmi_ext,
@@ -874,12 +872,7 @@ static AVM_INLINE void prepare_enc_workers(AV2_COMP *cpi, AVxWorkerHook hook,
       thread_data->td->mb.opfl_vxy_bufs = thread_data->td->opfl_vxy_bufs;
       thread_data->td->mb.opfl_gxy_bufs = thread_data->td->opfl_gxy_bufs;
       thread_data->td->mb.opfl_dst_bufs = thread_data->td->opfl_dst_bufs;
-
-      for (int j = 0; j < 2; ++j) {
-        thread_data->td->mb.tmp_pred_bufs[j] =
-            thread_data->td->tmp_pred_bufs[j];
-      }
-
+      thread_data->td->mb.tmp_pred_bufs = thread_data->td->tmp_pred_bufs;
       thread_data->td->mb.e_mbd.tmp_conv_dst = thread_data->td->mb.tmp_conv_dst;
       thread_data->td->mb.e_mbd.tmp_upsample_pred =
           thread_data->td->mb.upsample_pred;

--- a/av2/encoder/rdopt.c
+++ b/av2/encoder/rdopt.c
@@ -9575,7 +9575,7 @@ void av2_rd_pick_inter_mode_sb(struct AV2_COMP *cpi,
   inter_modes_info->num = 0;
 
   // Temporary buffers used by handle_inter_mode().
-  uint16_t *const tmp_buf = x->tmp_pred_bufs[0];
+  uint16_t *const tmp_buf = x->tmp_pred_bufs;
 
   // The best RD found for the reference frame, among single reference modes.
   // Read by in_single_ref_cutoff() to check whether either ref of a compound

--- a/test/gdf_test.cc
+++ b/test/gdf_test.cc
@@ -133,8 +133,8 @@ void test_gdf(int iterations, int height, int width, int depth, int qp_idx,
     for (uint16_t &i : rec) {
       i = clamp(rnd.Rand16() & ((1 << depth) - 1), 0, (1 << depth) - 1);
     }
-    alloc_gdf_buffers(&gi);
-    alloc_gdf_buffers(&ref_gi);
+    alloc_gdf_buffers(&gi, width);
+    alloc_gdf_buffers(&ref_gi, width);
     int top_buf = GDF_TEST_EXTRA_VER_BORDER;
     int bot_buf = GDF_TEST_EXTRA_VER_BORDER;
     const int rec_height = height;


### PR DESCRIPTION
tmp_pred_bufs: collapse the [2] array to a single buffer (the second element has been unused since OBMC was removed) and drop the stale 2x size multiplier left over from the uint8_t -> uint16_t buffer type change.

GDFLineBuffers: allocate the save above/below line buffers to the actual frame width instead of RESTORATION_LINEBUFFER_WIDTH.