### PR TITLE
Enable the dc-only block predictor at speed 2 above a qindex threshold

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -119,9 +119,10 @@ static unsigned int predict_skip_levels[3][MODE_EVAL_TYPES] = { { 0, 0, 0 },
 // Values indicate the aggressiveness of skip flag prediction.
 // 0 : no early DC block prediction
 // 1 : Early DC block prediction based on error variance
-static unsigned int predict_dc_levels[3][MODE_EVAL_TYPES] = { { 0, 0, 0 },
-                                                              { 1, 1, 0 },
-                                                              { 1, 1, 1 } };
+// 2 : Same as 1, but disable skip prediction
+static unsigned int predict_dc_levels[4][MODE_EVAL_TYPES] = {
+  { 0, 0, 0 }, { 1, 1, 0 }, { 1, 1, 1 }, { 2, 2, 0 }
+};
 
 // Intra only frames, golden frames (except alt ref overlays) and
 // alt ref frames tend to be coded at a higher than ambient quality
@@ -1643,4 +1644,15 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
   }
 
   set_two_pass_partition_level(cpi);
+
+  // Set the predict_dc level to { 2, 2, 0 } at speed 2 for high qindex frames.
+  if (speed == 2 && sf->winner_mode_sf.dc_blk_pred_level == 0) {
+    const int dc_blk_pred_qmin =
+        113 + MAXQ_OFFSET * (cm->seq_params.bit_depth - 8);
+    if (cm->quant_params.base_qindex > dc_blk_pred_qmin) {
+      sf->winner_mode_sf.dc_blk_pred_level = 3;
+      memcpy(winner_mode_params->predict_dc_level, predict_dc_levels[3],
+             sizeof(winner_mode_params->predict_dc_level));
+    }
+  }
 }

--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -1647,8 +1647,7 @@ void av2_set_speed_features_qindex_dependent(AV2_COMP *cpi, int speed) {
 
   // Set the predict_dc level to { 2, 2, 0 } at speed 2 for high qindex frames.
   if (speed == 2 && sf->winner_mode_sf.dc_blk_pred_level == 0) {
-    const int dc_blk_pred_qmin =
-        113 + MAXQ_OFFSET * (cm->seq_params.bit_depth - 8);
+    const int dc_blk_pred_qmin = 113 + qindex_offset;
     if (cm->quant_params.base_qindex > dc_blk_pred_qmin) {
       sf->winner_mode_sf.dc_blk_pred_level = 3;
       memcpy(winner_mode_params->predict_dc_level, predict_dc_levels[3],

--- a/av2/encoder/tx_search.c
+++ b/av2/encoder/tx_search.c
@@ -2048,8 +2048,10 @@ static INLINE void predict_dc_only_block(
   uint64_t var_threshold = (uint64_t)(1.8 * qstep * qstep);
   block_var = ROUND_POWER_OF_TWO(block_var, (xd->bd - 8) * 2);
   // Early prediction of skip block if residual mean and variance are less
-  // than qstep based threshold
-  if ((((llabs(*per_px_mean) * dc_coeff_scale[tx_size]) < (dc_qstep << 12)) &&
+  // than qstep based threshold. Skip prediction is disabled at level 2.
+  const bool allow_skip_txfm = x->txfm_search_params.predict_dc_level != 2;
+  if (allow_skip_txfm &&
+      (((llabs(*per_px_mean) * dc_coeff_scale[tx_size]) < (dc_qstep << 12)) &&
        (block_var < var_threshold)) &&
       (!xd->lossless[xd->mi[0]->segment_id] || *block_sse == 0)) {
     // If the normalized mean of residual block is less than the dc qstep and


### PR DESCRIPTION
- Gate in av2_set_speed_features_qindex_dependent(): enable when base_qindex > 113 + MAXQ_OFFSET * (bit_depth - 8).
- New predict_dc_levels row { 2, 2, 0 } takes the dc-only outcome only.

  Class   BD-rate (PSNR wAvg)   Enc instr   Enc wall
  A1              +0.0657%         97.0%      97.8%
  A2              +0.0062%         98.4%      98.6%
Anchor (b42be4efa6af35ff1fca51a1ff1052aedd97322f)
STATS_CHANGED