### PR TITLE
refactor pick filter restoration

### DIFF
--- a/av2/common/restoration.c
+++ b/av2/common/restoration.c
@@ -1654,42 +1654,90 @@ static INLINE void make_wienerns_ds_luma(const uint16_t *src, int src_stride,
   }
 }
 
+static void wienerns_fill_luma_from_dgd(struct AV2Common *cm,
+                                        const uint16_t *dgd, int dgd_stride,
+                                        uint16_t *dst, int dst_stride,
+                                        int height_y, int width_y,
+                                        int height_uv, int width_uv) {
+  (void)height_y;
+  (void)width_y;
+  const int ss_y = cm->seq_params.subsampling_y;
+  const int ss_x = cm->seq_params.subsampling_x;
+#if WIENERNS_CROSS_FILT_LUMA_TYPE == 2
+  const int ds_type = cm->seq_params.cfl_ds_filter_index;
+#endif
+
+#if WIENERNS_CROSS_FILT_LUMA_TYPE == 0
+  for (int r = 0; r < height_uv; ++r) {
+    for (int c = 0; c < width_uv; ++c) {
+      dst[r * dst_stride + c] =
+          dgd[(1 + ss_y) * r * dgd_stride + (1 + ss_x) * c];
+    }
+  }
+#elif WIENERNS_CROSS_FILT_LUMA_TYPE == 1
+  if (ss_x && ss_y) {  // 420
+    for (int r = 0; r < height_uv; ++r) {
+      for (int c = 0; c < width_uv; ++c) {
+        dst[r * dst_stride + c] =
+            (dgd[2 * r * dgd_stride + 2 * c] +
+             dgd[2 * r * dgd_stride + 2 * c + 1] +
+             dgd[(2 * r + 1) * dgd_stride + 2 * c] +
+             dgd[(2 * r + 1) * dgd_stride + 2 * c + 1] + 2) >>
+            2;
+      }
+    }
+  } else if (ss_x && !ss_y) {  // 422
+    for (int r = 0; r < height_uv; ++r) {
+      for (int c = 0; c < width_uv; ++c) {
+        dst[r * dst_stride + c] = (dgd[r * dgd_stride + 2 * c] +
+                                   dgd[r * dgd_stride + 2 * c + 1] + 1) >>
+                                  1;
+      }
+    }
+  } else if (!ss_x && !ss_y) {  // 444
+    for (int r = 0; r < height_uv; ++r) {
+      for (int c = 0; c < width_uv; ++c) {
+        dst[r * dst_stride + c] = dgd[r * dgd_stride + c];
+      }
+    }
+  } else {
+    assert(0 && "Invalid subsampling format");
+  }
+#elif WIENERNS_CROSS_FILT_LUMA_TYPE == 2
+  make_wienerns_ds_luma(dgd, dgd_stride, dst, dst_stride, ds_type, height_uv,
+                        width_uv, ss_x, ss_y);
+#else
+  av2_highbd_resize_plane(dgd, height_y, width_y, dgd_stride, dst, height_uv,
+                          width_uv, dst_stride, cm->seq_params.bit_depth);
+#endif  // WIENERNS_CROSS_FILT_LUMA_TYPE
+}
+
 uint16_t *wienerns_copy_luma_with_virtual_lines(struct AV2Common *cm,
                                                 uint16_t **luma_hbd) {
-  const RestorationInfo *rsi = &cm->rst_info[0];
-
+  const RestorationInfo *rsi = &cm->rst_info[AVM_PLANE_Y];
   const YV12_BUFFER_CONFIG *frame_buf = &cm->cur_frame->buf;
-
   uint16_t *dgd = frame_buf->buffers[AVM_PLANE_Y];
-  int width_y = frame_buf->widths[AVM_PLANE_Y];
-  int height_y = frame_buf->heights[AVM_PLANE_Y];
-  int width_uv = frame_buf->widths[1];
-  int height_uv = frame_buf->heights[1];
-  int in_stride = frame_buf->strides[AVM_PLANE_Y];
-  int border = WIENERNS_UV_BRD;
-  int resized_luma_stride = width_uv + 2 * WIENERNS_UV_BRD;
-  int out_stride = resized_luma_stride;
-#if WIENERNS_CROSS_FILT_LUMA_TYPE == 2
-  int ds_type = cm->seq_params.cfl_ds_filter_index;
-#endif
-  int process_unit_rows = rsi->vert_stripes_per_frame;
-  int resized_luma_height = height_uv + 2 * WIENERNS_UV_BRD * process_unit_rows;
-
-  uint16_t *aug_luma = (uint16_t *)malloc(
-      sizeof(uint16_t) * resized_luma_stride * resized_luma_height);
-  memset(aug_luma, 0,
-         sizeof(*aug_luma) * resized_luma_stride * resized_luma_height);
-
-  uint16_t *luma[1];
-  *luma = aug_luma + border * out_stride + border;
-
-  *luma_hbd = *luma;
-
-  const int ss_x = cm->seq_params.subsampling_x;
-  const int ss_y = cm->seq_params.subsampling_y;
+  const int width_y = frame_buf->widths[AVM_PLANE_Y];
+  const int height_y = frame_buf->heights[AVM_PLANE_Y];
+  const int width_uv = frame_buf->widths[AVM_PLANE_U];
+  const int height_uv = frame_buf->heights[AVM_PLANE_U];
+  const int in_stride = frame_buf->strides[AVM_PLANE_Y];
+  const int resized_luma_stride = width_uv + 2 * WIENERNS_UV_BRD;
+  const int process_unit_rows = rsi->vert_stripes_per_frame;
+  const int resized_luma_height =
+      height_uv + 2 * WIENERNS_UV_BRD * process_unit_rows;
   const int num_tile_rows = cm->tiles.rows;
+  const int ss_y = cm->seq_params.subsampling_y;
   int tile_stripe0 = 0;
-  uint16_t *curr_luma = *luma;
+  uint16_t *ext_luma;
+
+  CHECK_MEM_ERROR(cm, ext_luma,
+                  avm_memalign(16, sizeof(uint16_t) * resized_luma_stride *
+                                       resized_luma_height));
+  *luma_hbd =
+      ext_luma + WIENERNS_UV_BRD * resized_luma_stride + WIENERNS_UV_BRD;
+
+  uint16_t *curr_luma = *luma_hbd;
   uint16_t *curr_dgd = dgd;
   for (int tile_row = 0; tile_row < num_tile_rows; ++tile_row) {
     AV2PixelRect tile_rect;
@@ -1716,8 +1764,8 @@ uint16_t *wienerns_copy_luma_with_virtual_lines(struct AV2Common *cm,
       get_stripe_boundary_info(&remaining_stripes, &tile_rect, 0,
                                &tile_boundary_above, &tile_boundary_below);
       const int h = y1 - y0;
-      const int h_uv = (ss_y ? (h + 1) >> ss_y : h) +
-                       ((y0 > 0) + (y1 < height_y)) * WIENERNS_UV_BRD;
+      const int internal_rows = ((y0 > 0) + (y1 < height_y)) * WIENERNS_UV_BRD;
+      const int h_uv = (ss_y ? (h + 1) >> ss_y : h) + internal_rows;
 
       int copy_above = 1, copy_below = 1;
       if (cm->seq_params.disable_loopfilters_across_tiles == 0) {
@@ -1732,50 +1780,9 @@ uint16_t *wienerns_copy_luma_with_virtual_lines(struct AV2Common *cm,
           cm->rlbs, copy_above, copy_below, rsi->optimized_lr, 0);
       if (y0 > 0) curr_dgd -= WIENERNS_UV_BRD * in_stride << ss_y;
 
-#if WIENERNS_CROSS_FILT_LUMA_TYPE == 0
-      for (int r = 0; r < h_uv; ++r) {
-        for (int c = 0; c < width_uv; ++c) {
-          curr_luma[r * out_stride + c] =
-              curr_dgd[(1 + ss_y) * r * in_stride + (1 + ss_x) * c];
-        }
-      }
-#elif WIENERNS_CROSS_FILT_LUMA_TYPE == 1
-      if (ss_x && ss_y) {  // 420
-        for (int r = 0; r < h_uv; ++r) {
-          for (int c = 0; c < width_uv; ++c) {
-            curr_luma[r * out_stride + c] =
-                (curr_dgd[2 * r * in_stride + 2 * c] +
-                 curr_dgd[2 * r * in_stride + 2 * c + 1] +
-                 curr_dgd[(2 * r + 1) * in_stride + 2 * c] +
-                 curr_dgd[(2 * r + 1) * in_stride + 2 * c + 1] + 2) >>
-                2;
-          }
-        }
-      } else if (ss_x && !ss_y) {  // 422
-        for (int r = 0; r < h_uv; ++r) {
-          for (int c = 0; c < width_uv; ++c) {
-            curr_luma[r * out_stride + c] =
-                (curr_dgd[r * in_stride + 2 * c] +
-                 curr_dgd[r * in_stride + 2 * c + 1] + 1) >>
-                1;
-          }
-        }
-      } else if (!ss_x && !ss_y) {  // 444
-        for (int r = 0; r < h_uv; ++r) {
-          for (int c = 0; c < width_uv; ++c) {
-            curr_luma[r * out_stride + c] = curr_dgd[r * in_stride + c];
-          }
-        }
-      } else {
-        assert(0 && "Invalid dimensions");
-      }
-#elif WIENERNS_CROSS_FILT_LUMA_TYPE == 2
-      make_wienerns_ds_luma(curr_dgd, in_stride, curr_luma, out_stride, ds_type,
-                            h_uv, width_uv, ss_x, ss_y);
-#else
-      av2_highbd_resize_plane(dgd, height_y, width_y, in_stride, *luma,
-                              height_uv, width_uv, out_stride, bd);
-#endif  // WIENERNS_CROSS_FILT_LUMA_TYPE
+      wienerns_fill_luma_from_dgd(
+          cm, curr_dgd, in_stride, curr_luma, resized_luma_stride,
+          h + (internal_rows << ss_y), width_y, h_uv, width_uv);
 
       restore_processing_stripe_boundary(&remaining_stripes, cm->rlbs, h, dgd,
                                          in_stride, copy_above, copy_below,
@@ -1783,183 +1790,32 @@ uint16_t *wienerns_copy_luma_with_virtual_lines(struct AV2Common *cm,
 
       if (y0 > 0) curr_dgd += WIENERNS_UV_BRD * in_stride << ss_y;
       curr_dgd += in_stride * h;
-      curr_luma += out_stride * h_uv;
+      curr_luma += resized_luma_stride * h_uv;
     }
   }
   // extend border by replication
   int internal_luma_height = resized_luma_height - 2 * WIENERNS_UV_BRD;
+  av2_extend_frame(*luma_hbd, width_uv, internal_luma_height,
+                   resized_luma_stride, WIENERNS_UV_BRD, WIENERNS_UV_BRD);
 
-  // Extend side borders
-  for (int r = 0; r < internal_luma_height; ++r) {
-    for (int c = -border; c < 0; ++c)
-      (*luma)[r * out_stride + c] = (*luma)[r * out_stride];
-    for (int c = 0; c < border; ++c)
-      (*luma)[r * out_stride + width_uv + c] =
-          (*luma)[r * out_stride + width_uv - 1];
-  }
-  // Extend top border
-  for (int r = -border; r < 0; ++r) {
-    memcpy(&(*luma)[r * out_stride - border], &(*luma)[-border],
-           (width_uv + 2 * border) * sizeof((*luma)[0]));
-  }
-  // Extend bottom border
-  for (int r = 0; r < border; ++r)
-    memcpy(&(*luma)[(internal_luma_height + r) * out_stride - border],
-           &(*luma)[(internal_luma_height - 1) * out_stride - border],
-           (width_uv + 2 * border) * sizeof((*luma)[0]));
-  return aug_luma;
+  return ext_luma;
 }
 
-uint16_t *wienerns_copy_luma_highbd(const uint16_t *dgd, int height_y,
-                                    int width_y, int in_stride,
+uint16_t *wienerns_copy_luma_highbd(struct AV2Common *cm, const uint16_t *dgd,
+                                    int height_y, int width_y, int in_stride,
                                     uint16_t **luma_hbd, int height_uv,
-                                    int width_uv, int border, int out_stride,
-                                    int bd
-#if WIENERNS_CROSS_FILT_LUMA_TYPE == 2
-                                    ,
-                                    int ds_type
-#endif
-) {
-  (void)bd;
-  uint16_t *aug_luma = (uint16_t *)malloc(
-      sizeof(uint16_t) * (width_uv + 2 * border) * (height_uv + 2 * border));
-  memset(
-      aug_luma, 0,
-      sizeof(*aug_luma) * (width_uv + 2 * border) * (height_uv + 2 * border));
-  uint16_t *luma[1];
-  *luma = aug_luma + border * out_stride + border;
-  *luma_hbd = *luma;
-#if WIENERNS_CROSS_FILT_LUMA_TYPE == 0
-  const int ss_x = (((width_y + 1) >> 1) == width_uv);
-  const int ss_y = (((height_y + 1) >> 1) == height_uv);
-  for (int r = 0; r < height_uv; ++r) {
-    for (int c = 0; c < width_uv; ++c) {
-      (*luma)[r * out_stride + c] =
-          dgd[(1 + ss_y) * r * in_stride + (1 + ss_x) * c];
-    }
-  }
-#elif WIENERNS_CROSS_FILT_LUMA_TYPE == 1
-  const int ss_x = (((width_y + 1) >> 1) == width_uv);
-  const int ss_y = (((height_y + 1) >> 1) == height_uv);
-  if (ss_x && ss_y) {  // 420
-    int r;
-    for (r = 0; r < height_y / 2; ++r) {
-      int c;
-      for (c = 0; c < width_y / 2; ++c) {
-        (*luma)[r * out_stride + c] =
-            (dgd[2 * r * in_stride + 2 * c] +
-             dgd[2 * r * in_stride + 2 * c + 1] +
-             dgd[(2 * r + 1) * in_stride + 2 * c] +
-             dgd[(2 * r + 1) * in_stride + 2 * c + 1] + 2) >>
-            2;
-      }
-      // handle odd width_y
-      for (; c < width_uv; ++c) {
-        (*luma)[r * out_stride + c] =
-            (dgd[2 * r * in_stride + 2 * c] +
-             dgd[(2 * r + 1) * in_stride + 2 * c] + 1) >>
-            1;
-      }
-    }
-    // handle odd height_y
-    for (; r < height_uv; ++r) {
-      int c;
-      for (c = 0; c < width_y / 2; ++c) {
-        (*luma)[r * out_stride + c] =
-            (dgd[2 * r * in_stride + 2 * c] +
-             dgd[2 * r * in_stride + 2 * c + 1] + 1) >>
-            1;
-      }
-      // handle odd height_y and width_y
-      for (; c < width_uv; ++c) {
-        (*luma)[r * out_stride + c] = dgd[2 * r * in_stride + 2 * c];
-      }
-    }
-  } else if (ss_x && !ss_y) {  // 422
-    for (int r = 0; r < height_uv; ++r) {
-      int c;
-      for (c = 0; c < width_y / 2; ++c) {
-        (*luma)[r * out_stride + c] =
-            (dgd[r * in_stride + 2 * c] + dgd[r * in_stride + 2 * c + 1] + 1) >>
-            1;
-      }
-      // handle odd width_y
-      for (; c < width_uv; ++c) {
-        (*luma)[r * out_stride + c] = dgd[r * in_stride + 2 * c];
-      }
-    }
-  } else if (!ss_x && !ss_y) {  // 444
-    for (int r = 0; r < height_uv; ++r) {
-      for (int c = 0; c < width_uv; ++c) {
-        (*luma)[r * out_stride + c] = dgd[r * in_stride + c];
-      }
-    }
-  } else {
-    assert(0 && "Invalid dimensions");
-  }
-#elif WIENERNS_CROSS_FILT_LUMA_TYPE == 2
-  const int ss_x = (((width_y + 1) >> 1) == width_uv);
-  const int ss_y = (((height_y + 1) >> 1) == height_uv);
-  if (ss_x && ss_y) {
-    if (ds_type == 1) {
-      for (int r = 0; r < height_uv; ++r) {
-        for (int c = 0; c < width_uv; ++c) {
-          (*luma)[r * out_stride + c] =
-              (dgd[2 * r * in_stride + 2 * c] +
-               dgd[(2 * r + 1) * in_stride + 2 * c]) >>
-              1;
-        }
-      }
-    } else if (ds_type == 2) {
-      for (int r = 0; r < height_uv; ++r) {
-        for (int c = 0; c < width_uv; ++c) {
-          (*luma)[r * out_stride + c] =
-              dgd[(1 + ss_y) * r * in_stride + (1 + ss_x) * c];
-        }
-      }
-    } else {
-      for (int r = 0; r < height_uv; ++r) {
-        for (int c = 0; c < width_uv; ++c) {
-          (*luma)[r * out_stride + c] =
-              (dgd[2 * r * in_stride + 2 * c] +
-               dgd[2 * r * in_stride + 2 * c + 1] +
-               dgd[(2 * r + 1) * in_stride + 2 * c] +
-               dgd[(2 * r + 1) * in_stride + 2 * c + 1]) >>
-              2;
-        }
-      }
-    }
-  } else {
-    for (int r = 0; r < height_uv; ++r) {
-      for (int c = 0; c < width_uv; ++c) {
-        (*luma)[r * out_stride + c] =
-            dgd[(1 + ss_y) * r * in_stride + (1 + ss_x) * c];
-      }
-    }
-  }
-#else
-  av2_highbd_resize_plane(dgd, height_y, width_y, in_stride, *luma, height_uv,
-                          width_uv, out_stride, bd);
+                                    int width_uv, int border, int out_stride) {
+  uint16_t *ext_luma;
 
-#endif  // WIENERNS_CROSS_FILT_LUMA_TYPE
+  CHECK_MEM_ERROR(cm, ext_luma,
+                  avm_memalign(16, sizeof(uint16_t) * (width_uv + 2 * border) *
+                                       (height_uv + 2 * border)));
+  *luma_hbd = ext_luma + border * out_stride + border;
+  wienerns_fill_luma_from_dgd(cm, dgd, in_stride, *luma_hbd, out_stride,
+                              height_y, width_y, height_uv, width_uv);
+  av2_extend_frame(*luma_hbd, width_uv, height_uv, out_stride, border, border);
 
-  // extend border by replication
-  for (int r = 0; r < height_uv; ++r) {
-    for (int c = -border; c < 0; ++c)
-      (*luma)[r * out_stride + c] = (*luma)[r * out_stride];
-    for (int c = 0; c < border; ++c)
-      (*luma)[r * out_stride + width_uv + c] =
-          (*luma)[r * out_stride + width_uv - 1];
-  }
-  for (int r = -border; r < 0; ++r) {
-    memcpy(&(*luma)[r * out_stride - border], &(*luma)[-border],
-           (width_uv + 2 * border) * sizeof((*luma)[0]));
-  }
-  for (int r = 0; r < border; ++r)
-    memcpy(&(*luma)[(height_uv + r) * out_stride - border],
-           &(*luma)[(height_uv - 1) * out_stride - border],
-           (width_uv + 2 * border) * sizeof((*luma)[0]));
-  return aug_luma;
+  return ext_luma;
 }
 
 typedef void (*stripe_filter_fun)(const RestorationUnitInfo *rui,
@@ -2305,7 +2161,7 @@ static void foreach_rest_unit_in_planes(AV2LrStruct *lr_ctxt, AV2_COMMON *cm,
     av2_foreach_rest_unit_in_plane(cm, plane, &ctxt[plane],
                                    &ctxt[plane].tile_rect);
   }
-  free(luma_buf);
+  avm_free(luma_buf);
 }
 
 void av2_loop_restoration_filter_frame(YV12_BUFFER_CONFIG *frame,

--- a/av2/common/restoration.h
+++ b/av2/common/restoration.h
@@ -440,19 +440,14 @@ static INLINE void set_default_wienerns_fromparams(
 // 0: Skip luma pixels to scale down to chroma (simplest)
 // 1: Average 4 or 2 luma pixels to scale down to chroma
 // 2: Average 2 (top and down) luma pixels to scale down to chroma for 420,
-// could be based on the luma downsampling type from CFL tool 3: Use 8-tap
-// downsampling filter
+//    could be based on the luma downsampling type from CFL tool
+// 3: Use 8-tap downsampling filter
 #define WIENERNS_CROSS_FILT_LUMA_TYPE 2
 
-uint16_t *wienerns_copy_luma_highbd(const uint16_t *dgd, int height_y,
-                                    int width_y, int in_stride, uint16_t **luma,
-                                    int height_uv, int width_uv, int border,
-                                    int out_stride, int bd
-#if WIENERNS_CROSS_FILT_LUMA_TYPE == 2
-                                    ,
-                                    int ds_type
-#endif
-);
+uint16_t *wienerns_copy_luma_highbd(struct AV2Common *cm, const uint16_t *dgd,
+                                    int height_y, int width_y, int in_stride,
+                                    uint16_t **luma_hbd, int height_uv,
+                                    int width_uv, int border, int out_stride);
 
 typedef struct {
   int h_start, h_end, v_start, v_end;

--- a/av2/common/restoration.h
+++ b/av2/common/restoration.h
@@ -392,7 +392,7 @@ typedef struct {
   /*!
    * reference picture index for frame level filter prediction
    */
-  uint8_t rst_ref_pic_idx;
+  int8_t rst_ref_pic_idx;
 } RestorationInfo;
 
 /*!\cond */

--- a/av2/common/restoration.h
+++ b/av2/common/restoration.h
@@ -117,11 +117,6 @@ static INLINE const WienernsFilterParameters *get_wienerns_parameters(
   return is_uv ? &wienerns_filter_uv : &wienerns_filter_y;
 }
 
-static inline int is_frame_filters_enabled(int plane) {
-  (void)plane;
-  return 1;
-}
-
 // Returns the alternate plane whose reference-frame-filters can be used to
 // augment those for plane.
 static inline int alternate_ref_plane(int plane) {

--- a/av2/common/thread_common.c
+++ b/av2/common/thread_common.c
@@ -1227,7 +1227,7 @@ static void foreach_rest_unit_in_planes_mt(AV2LrStruct *lr_ctxt,
   for (i = 0; i < num_workers; ++i) {
     winterface->sync(&workers[i]);
   }
-  if (luma_buf != NULL) free(luma_buf);
+  avm_free(luma_buf);
 }
 
 void av2_loop_restoration_filter_frame_mt(YV12_BUFFER_CONFIG *frame,

--- a/av2/decoder/decodeframe.c
+++ b/av2/decoder/decodeframe.c
@@ -90,7 +90,6 @@ static void read_wienerns_framefilters_hdr(AV2_COMMON *cm, int plane,
 void copy_frame_filters_to_runits_if_needed(AV2_COMMON *cm) {
   const int num_planes = av2_num_planes(cm);
   for (int plane = 0; plane < num_planes; plane++) {
-    if (!is_frame_filters_enabled(plane)) continue;
     RestorationInfo *rsi = &cm->rst_info[plane];
     if ((rsi->frame_restoration_type == RESTORE_WIENER_NONSEP ||
          rsi->frame_restoration_type == RESTORE_SWITCHABLE) &&
@@ -2390,65 +2389,59 @@ static AVM_INLINE void decode_restoration_mode(AV2_COMMON *cm,
         rsi->frame_restoration_type == RESTORE_SWITCHABLE;
     if (is_wiener_nonsep_possible) {
       rsi->frame_filters_initialized = 0;
-      if (is_frame_filters_enabled(p)) {
-        rsi->frame_filters_on = avm_rb_read_bit(rb);
-        rsi->rst_ref_pic_idx = 0;
-        rsi->temporal_pred_flag = 0;
-        if (rsi->frame_filters_on) {
-          const int num_ref_frames =
-              (frame_is_intra_only(cm) || frame_is_sframe(cm))
-                  ? 0
-                  : cm->ref_frames_info.num_total_refs;
+      rsi->frame_filters_on = avm_rb_read_bit(rb);
+      rsi->rst_ref_pic_idx = 0;
+      rsi->temporal_pred_flag = 0;
+      if (rsi->frame_filters_on) {
+        const int num_ref_frames =
+            (frame_is_intra_only(cm) || frame_is_sframe(cm))
+                ? 0
+                : cm->ref_frames_info.num_total_refs;
 
-          if (num_ref_frames > 0) rsi->temporal_pred_flag = avm_rb_read_bit(rb);
-          int num_ref_frames_available = 0;
-          for (int i = 0; i < num_ref_frames; i++) {
-            if (cm->ref_frame_map[cm->remapped_ref_idx[i]] != NULL)
-              num_ref_frames_available +=
-                  !cm->ref_frame_map[cm->remapped_ref_idx[i]]->is_restricted;
-          }
-          if (num_ref_frames_available == 0)
-            assert(rsi->temporal_pred_flag == 0);
-          if (rsi->temporal_pred_flag && num_ref_frames > 1) {
-            rsi->rst_ref_pic_idx = avm_rb_read_literal(
-                rb,
-                avm_ceil_log2(num_ref_frames));  // read_lr_reference_idx
-            if (get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)->is_restricted) {
-              avm_internal_error(
-                  &cm->error, AVM_CODEC_ERROR,
-                  "Invalid rst_ref_pic_idx: restricted reference buffer");
-            }
-          }
+        if (num_ref_frames > 0) rsi->temporal_pred_flag = avm_rb_read_bit(rb);
+        int num_ref_frames_available = 0;
+        for (int i = 0; i < num_ref_frames; i++) {
+          if (cm->ref_frame_map[cm->remapped_ref_idx[i]] != NULL)
+            num_ref_frames_available +=
+                !cm->ref_frame_map[cm->remapped_ref_idx[i]]->is_restricted;
         }
-
-        if (rsi->temporal_pred_flag) {
-          RestorationInfo tmp_rsi =
-              get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)->rst_info[p];
-          if (!tmp_rsi.frame_filters_on) {
-            const int alternate_plane = alternate_ref_plane(p);
-            assert(alternate_plane != -1);
-            tmp_rsi = get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)
-                          ->rst_info[alternate_plane];
-          }
-          if (!tmp_rsi.frame_filters_on) {
+        if (num_ref_frames_available == 0) assert(rsi->temporal_pred_flag == 0);
+        if (rsi->temporal_pred_flag && num_ref_frames > 1) {
+          rsi->rst_ref_pic_idx = avm_rb_read_literal(
+              rb,
+              avm_ceil_log2(num_ref_frames));  // read_lr_reference_idx
+          if (get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)->is_restricted) {
             avm_internal_error(
                 &cm->error, AVM_CODEC_ERROR,
-                "Invalid rst_ref_pic_idx: ref frame frame filter disabled");
+                "Invalid rst_ref_pic_idx: restricted reference buffer");
           }
-          av2_copy_rst_frame_filters(rsi, &tmp_rsi);
-          rsi->frame_filters_initialized = 1;
-
-          av2_copy_rst_frame_filters(&cm->cur_frame->rst_info[p], rsi);
-        } else {
-          if (rsi->frame_filters_on && max_num_classes(p) > 1) {
-            rsi->num_filter_classes = decode_num_filter_classes(
-                avm_rb_read_literal(rb, NUM_FILTER_CLASSES_BITS));
-          } else
-            rsi->num_filter_classes = 1;
         }
+      }
+
+      if (rsi->temporal_pred_flag) {
+        RestorationInfo tmp_rsi =
+            get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)->rst_info[p];
+        if (!tmp_rsi.frame_filters_on) {
+          const int alternate_plane = alternate_ref_plane(p);
+          assert(alternate_plane != -1);
+          tmp_rsi = get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)
+                        ->rst_info[alternate_plane];
+        }
+        if (!tmp_rsi.frame_filters_on) {
+          avm_internal_error(
+              &cm->error, AVM_CODEC_ERROR,
+              "Invalid rst_ref_pic_idx: ref frame frame filter disabled");
+        }
+        av2_copy_rst_frame_filters(rsi, &tmp_rsi);
+        rsi->frame_filters_initialized = 1;
+
+        av2_copy_rst_frame_filters(&cm->cur_frame->rst_info[p], rsi);
       } else {
-        rsi->frame_filters_on = 0;
-        rsi->num_filter_classes = NUM_WIENERNS_CLASS_INIT_CHROMA;
+        if (rsi->frame_filters_on && max_num_classes(p) > 1) {
+          rsi->num_filter_classes = decode_num_filter_classes(
+              avm_rb_read_literal(rb, NUM_FILTER_CLASSES_BITS));
+        } else
+          rsi->num_filter_classes = 1;
       }
     }
     assert(IMPLIES(!rsi->frame_filters_on, !rsi->temporal_pred_flag));
@@ -2563,8 +2556,7 @@ static AVM_INLINE void decode_restoration_mode(AV2_COMMON *cm,
   }
 
   for (int p = 0; p < num_planes; ++p) {
-    if (is_frame_filters_enabled(p) &&
-        to_readwrite_framefilters(&cm->rst_info[p], 0, 0)) {
+    if (to_readwrite_framefilters(&cm->rst_info[p], 0, 0)) {
       read_wienerns_framefilters_hdr(cm, p, rb);
     }
   }
@@ -2634,7 +2626,6 @@ static void read_wienerns_framefilters_hdr(AV2_COMMON *cm, int plane,
   const int is_uv = plane != AVM_PLANE_Y;
   const int nopcw = disable_pcwiener_filters_in_framefilters(&cm->seq_params);
   RestorationInfo *rsi = &cm->rst_info[plane];
-  assert(is_frame_filters_enabled(plane));
   assert(rsi->frame_filters_on && !rsi->frame_filters_initialized);
   if (cm->frame_filter_dictionary == NULL) {
     allocate_frame_filter_dictionary(cm);

--- a/av2/encoder/bitstream.c
+++ b/av2/encoder/bitstream.c
@@ -3076,55 +3076,46 @@ static AVM_INLINE void encode_restoration_mode(
         rsi->frame_restoration_type == RESTORE_SWITCHABLE;
     if (is_wiener_nonsep_possible) {
       rsi->frame_filters_initialized = 0;
-      if (is_frame_filters_enabled(p)) {
-        const int write_frame_filters_on_off = 1;
-        if (write_frame_filters_on_off) {
-          avm_wb_write_literal(wb, rsi->frame_filters_on, 1);
-          if (rsi->frame_filters_on) {
-            const int num_ref_frames =
-                (frame_is_intra_only(cm) || frame_is_sframe(cm))
-                    ? 0
-                    // NOTE: at the encoder num_total_refs may not include
-                    // restricted references
-                    : cm->ref_frames_info.num_valid_refs_with_restricted_ref;
+      avm_wb_write_literal(wb, rsi->frame_filters_on, 1);
+      if (rsi->frame_filters_on) {
+        const int num_ref_frames =
+            (frame_is_intra_only(cm) || frame_is_sframe(cm))
+                ? 0
+                // NOTE: at the encoder num_total_refs may not include
+                // restricted references
+                : cm->ref_frames_info.num_valid_refs_with_restricted_ref;
 
-            if (num_ref_frames > 0)
-              avm_wb_write_bit(wb, rsi->temporal_pred_flag);
-            if (rsi->temporal_pred_flag) {
-              assert(cm->ref_frames_info.num_total_refs > 0);
-            }
-            if (rsi->temporal_pred_flag && num_ref_frames > 1)
-              avm_wb_write_literal(
-                  wb, rsi->rst_ref_pic_idx,
-                  avm_ceil_log2(num_ref_frames));  // write_lr_reference_idx
-          }
-          if (!rsi->temporal_pred_flag) {
-            if (rsi->frame_filters_on && max_num_classes(p) > 1) {
-              avm_wb_write_literal(
-                  wb, encode_num_filter_classes(rsi->num_filter_classes),
-                  NUM_FILTER_CLASSES_BITS);
-            }
-          }
-          if (rsi->frame_filters_on)
-            av2_copy_rst_frame_filters(&cm->cur_frame->rst_info[p], rsi);
-          if (rsi->temporal_pred_flag) {
-            rsi->frame_filters_initialized = 1;
-            if (!get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)
-                     ->rst_info[p]
-                     .frame_filters_on) {
-              // Frame filters are on but no ref for plane p. Must be using
-              // filters from alternate plane.
-              const int alternate_plane = alternate_ref_plane(p);
-              (void)alternate_plane;
-              assert(get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)
-                         ->rst_info[alternate_plane]
-                         .frame_filters_on);
-            }
-          }
+        if (num_ref_frames > 0) avm_wb_write_bit(wb, rsi->temporal_pred_flag);
+        if (rsi->temporal_pred_flag) {
+          assert(cm->ref_frames_info.num_total_refs > 0);
         }
-      } else {
-        assert(rsi->frame_filters_on == 0);
-        assert(rsi->num_filter_classes == NUM_WIENERNS_CLASS_INIT_CHROMA);
+        if (rsi->temporal_pred_flag && num_ref_frames > 1)
+          avm_wb_write_literal(
+              wb, rsi->rst_ref_pic_idx,
+              avm_ceil_log2(num_ref_frames));  // write_lr_reference_idx
+      }
+      if (!rsi->temporal_pred_flag) {
+        if (rsi->frame_filters_on && max_num_classes(p) > 1) {
+          avm_wb_write_literal(
+              wb, encode_num_filter_classes(rsi->num_filter_classes),
+              NUM_FILTER_CLASSES_BITS);
+        }
+      }
+      if (rsi->frame_filters_on)
+        av2_copy_rst_frame_filters(&cm->cur_frame->rst_info[p], rsi);
+      if (rsi->temporal_pred_flag) {
+        rsi->frame_filters_initialized = 1;
+        if (!get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)
+                 ->rst_info[p]
+                 .frame_filters_on) {
+          // Frame filters are on but no ref for plane p. Must be using
+          // filters from alternate plane.
+          const int alternate_plane = alternate_ref_plane(p);
+          (void)alternate_plane;
+          assert(get_ref_frame_buf(cm, rsi->rst_ref_pic_idx)
+                     ->rst_info[alternate_plane]
+                     .frame_filters_on);
+        }
       }
     } else {
       rsi->temporal_pred_flag = 0;
@@ -3163,8 +3154,7 @@ static AVM_INLINE void encode_restoration_mode(
            cm->rst_info[1].restoration_unit_size);
   }
   for (int p = 0; p < num_planes; ++p) {
-    if (is_frame_filters_enabled(p) &&
-        to_readwrite_framefilters(&cm->rst_info[p], 0, 0)) {
+    if (to_readwrite_framefilters(&cm->rst_info[p], 0, 0)) {
       write_wienerns_framefilters_hdr(cm, p, wb);
     }
   }
@@ -3276,7 +3266,6 @@ static AVM_INLINE void write_wienerns_framefilters_hdr(
 
   rsi->frame_filters.num_ref_filters = *cm->num_ref_filters;
   assert(rsi->frame_filters_on && !rsi->frame_filters_initialized);
-  assert(is_frame_filters_enabled(plane));
   const WienernsFilterParameters *nsfilter_params =
       get_wienerns_parameters(base_qindex, plane != AVM_PLANE_Y);
   int skip_filter_write_for_class[WIENERNS_MAX_CLASSES] = { 0 };

--- a/av2/encoder/pickrst.c
+++ b/av2/encoder/pickrst.c
@@ -393,11 +393,9 @@ static AVM_INLINE void search_pc_wiener_visitor(
   // handling frame filters with rtype = RESTORE_WIENER_NONSEP.
   // (i) Run the full pc-wiener, i.e., don't skip, if pc-wiener is not disabled.
   // (Disabling can be accomplished by config or the plane being chroma.)
-  // (ii) If disabled, skip only if frame-filters are off or the number of
-  // filter classes for frame filters is one.
-  bool skip_search =
-      pcwiener_disabled &&
-      (!is_frame_filters_enabled(rsc->plane) || rsc->num_filter_classes == 1);
+  // (ii) If disabled, skip only if the number of filter classes for frame
+  // filters is one.
+  bool skip_search = pcwiener_disabled && rsc->num_filter_classes == 1;
   if (rusi->bru_unit_skipped) {
     skip_search = true;
   }
@@ -1291,7 +1289,6 @@ static void find_best_match_for_filter(const RestSearchCtxt *rsc,
                                        int base_qindex,
                                        int16_t *frame_filter_dictionary,
                                        int dict_stride) {
-  is_frame_filters_enabled(rsc->plane);
   const int is_uv = rsc->plane > 0;
   const int nopcw =
       disable_pcwiener_filters_in_framefilters(&rsc->cm->seq_params);
@@ -2190,12 +2187,8 @@ static void search_wienerns_visitor(const RestorationTileLimits *limits,
 
   // Classification has already been calculated by search_pc_wiener_visitor().
   rui.compute_classification = 0;
-  if (is_frame_filters_enabled(rsc->plane)) {
-    // Ensure search_pc_wiener_visitor was done and classification was computed.
-    assert(rsc->classification_is_buffered);
-  } else {
-    assert(!rsc->classification_is_buffered);
-  }
+  // Ensure search_pc_wiener_visitor was done and classification was computed.
+  assert(rsc->classification_is_buffered);
 
   rui.restoration_type = RESTORE_WIENER_NONSEP;
   const WienernsFilterParameters *nsfilter_params = get_wienerns_parameters(
@@ -2209,8 +2202,7 @@ static void search_wienerns_visitor(const RestorationTileLimits *limits,
   assert(unit_stats->plane == rsc->plane);
   assert(rusi->sse[RESTORE_NONE] == unit_stats->real_sse);
 
-  if (rsc->frame_filters_on && is_frame_filters_enabled(rsc->plane) &&
-      !rusi->bru_unit_skipped) {
+  if (rsc->frame_filters_on && !rusi->bru_unit_skipped) {
     // Pick the best filter for this RU.
     rusi->sse[RESTORE_WIENER_NONSEP] = evaluate_frame_filter(rsc, limits, &rui);
 
@@ -2603,10 +2595,8 @@ static int64_t count_switchable_bits(int rest_type, RestSearchCtxt *rsc,
 
   // Ensure search_switchable does not punish frame level filters.
   const WienerNonsepInfoBank *bank_to_use =
-      rsc->adjust_switchable_for_frame_filters &&
-              is_frame_filters_enabled(rsc->plane)
-          ? &rsc->frame_filter_bank
-          : &rsc->wienerns_bank;
+      rsc->adjust_switchable_for_frame_filters ? &rsc->frame_filter_bank
+                                               : &rsc->wienerns_bank;
 
   if (rest_type > RESTORE_NONE) {
     if (rusi->best_rtype[rest_type - 1] == RESTORE_NONE)
@@ -2628,7 +2618,6 @@ static int64_t count_switchable_bits(int rest_type, RestSearchCtxt *rsc,
   }
 
   if (rsc->adjust_switchable_for_frame_filters &&
-      is_frame_filters_enabled(rsc->plane) &&
       rest_type == RESTORE_WIENER_NONSEP &&
       rsc->frame_filter_bank.bank_size_for_class[0] == 1) {
     coeff_bits = 0;
@@ -2665,7 +2654,6 @@ static void search_switchable_visitor(const RestorationTileLimits *limits,
   }
 
   if (!rsc->adjust_switchable_for_frame_filters && rsc->frame_filters_on &&
-      is_frame_filters_enabled(rsc->plane) &&
       rsc->wienerns_bank.bank_size_for_class[0] == 1) {
     assert(rsc->cm->frame_filter_dictionary != NULL);
     assert(rsc->cm->translated_pcwiener_filters != NULL);
@@ -2963,10 +2951,8 @@ static void finalize_frame_and_unit_info(RestorationType frame_rtype,
   rsi->num_filter_classes = rsc->num_filter_classes;
   rsi->frame_filters = rsc->frame_filter_bank.filter[0];
   rsi->frame_filters = rsc->frame_filters;
-  if (is_frame_filters_enabled(rsc->plane)) {
-    rsi->temporal_pred_flag = rsc->temporal_pred_flag;
-    rsi->rst_ref_pic_idx = rsc->rst_ref_pic_idx;
-  }
+  rsi->temporal_pred_flag = rsc->temporal_pred_flag;
+  rsi->rst_ref_pic_idx = rsc->rst_ref_pic_idx;
 
   if (frame_rtype != RESTORE_NONE) {
     process_by_rutile(rsc, copy_unit_info_visitor);
@@ -3938,7 +3924,7 @@ void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
           }
 
           if (r == RESTORE_WIENER_NONSEP && !cm->bru.enabled &&
-              is_frame_filters_enabled(rsc.plane) && frame_filters_configured) {
+              frame_filters_configured) {
             // Find RDO-num_classes and frame-level filters. After this call
             // multiclass stats collapse to a single class. If that is not
             // desired make a copy of stats.
@@ -3950,8 +3936,7 @@ void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
             frame_filter_dict = rsc.frame_filter_bank;
             frame_filter_cost = rsc.frame_filter_cost;
           }
-          if (r == RESTORE_SWITCHABLE && is_frame_filters_enabled(rsc.plane) &&
-              frame_filters_configured) {
+          if (r == RESTORE_SWITCHABLE && frame_filters_configured) {
             assert(RESTORE_WIENER_NONSEP < RESTORE_SWITCHABLE);
             rsc.frame_filter_bank = frame_filter_dict;
             rsc.frame_filter_cost = frame_filter_cost;
@@ -3967,15 +3952,13 @@ void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
 
           double cost = search_rest_type(&rsc, r);
           int real_r = r;
-          if (r == RESTORE_SWITCHABLE && is_frame_filters_enabled(plane) &&
-              !cm->bru.enabled && frame_filters_configured &&
-              cost > rsc.frame_filters_total_cost &&
+          if (r == RESTORE_SWITCHABLE && !cm->bru.enabled &&
+              frame_filters_configured && cost > rsc.frame_filters_total_cost &&
               best_cost > rsc.frame_filters_total_cost) {
             real_r = replace_with_frame_filters(&rsc, &cost);
           }
           assert(RESTORE_PC_WIENER < RESTORE_WIENER_NONSEP);
-          if (r == RESTORE_PC_WIENER && is_frame_filters_enabled(plane) &&
-              frame_filters_configured) {
+          if (r == RESTORE_PC_WIENER && frame_filters_configured) {
             rsc.classification_is_buffered = 1;  // Buffer is set.
           }
           int invalid_result = 0;
@@ -3988,8 +3971,7 @@ void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
             best_cost = cost;
             best_rtype = real_r;
             best_unit_size = unit_size;
-            if (is_frame_filters_enabled(rsc.plane) &&
-                frame_filters_configured) {
+            if (frame_filters_configured) {
               best_frame_filters_state = rsc.frame_filters_on;
               if (rsc.frame_filters_on) {
                 best_temp_pred_flag = rsc.temporal_pred_flag;
@@ -4003,15 +3985,13 @@ void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
         }
         rsc.classification_is_buffered = 0;  // Buffer is consumed.
       }
-      if (is_frame_filters_enabled(rsc.plane)) {
-        rsc.frame_filters_on = best_frame_filters_state;
-        rsc.temporal_pred_flag = best_temp_pred_flag;
-        rsc.rst_ref_pic_idx = best_temp_ref_idx;
-        if (!frame_filters_configured) {
-          assert(best_temp_ref_idx == -1);
-          assert(best_temp_pred_flag == 0);
-          assert(best_frame_filters_state == 0);
-        }
+      rsc.frame_filters_on = best_frame_filters_state;
+      rsc.temporal_pred_flag = best_temp_pred_flag;
+      rsc.rst_ref_pic_idx = best_temp_ref_idx;
+      if (!frame_filters_configured) {
+        assert(best_temp_ref_idx == -1);
+        assert(best_temp_pred_flag == 0);
+        assert(best_frame_filters_state == 0);
       }
       if (rsi->restoration_unit_size == min_unit_size ||
           best_unit_size == rsi->restoration_unit_size) {

--- a/av2/encoder/pickrst.c
+++ b/av2/encoder/pickrst.c
@@ -364,6 +364,24 @@ static void initialize_rui_for_nonsep_search(const RestSearchCtxt *rsc,
   rui->skip_pcwiener_filtering = 0;
 }
 
+// Populates the mode-info of rui
+static AVM_INLINE void set_rui_mbmi_index(const RestSearchCtxt *rsc,
+                                          const RestorationTileLimits *limits,
+                                          RestorationUnitInfo *rui) {
+  const int ss_x = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_x;
+  const int ss_y = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_y;
+  const int start_mi_x = limits->h_start >> (MI_SIZE_LOG2 - ss_x);
+  const int start_mi_y = limits->v_start >> (MI_SIZE_LOG2 - ss_y);
+  const int mbmi_idx =
+      get_mi_grid_idx(&rsc->cm->mi_params, start_mi_y, start_mi_x);
+  rui->mbmi_ptr = rsc->cm->mi_params.mi_grid_base + mbmi_idx;
+  rui->ss_x = ss_x;
+  rui->ss_y = ss_y;
+  rui->mi_stride = rsc->cm->mi_params.mi_stride;
+  rui->lossless_segment = rsc->cm->features.lossless_segment;
+  rui->cm = rsc->cm;
+}
+
 static int count_pc_wiener_bits() {
   // No side-information for now.
   return 0;
@@ -409,18 +427,7 @@ static AVM_INLINE void search_pc_wiener_visitor(
 
   RestorationUnitInfo rui;
   initialize_rui_for_nonsep_search(rsc, &rui);
-  const int ss_x = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_x;
-  const int ss_y = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_y;
-  const int start_mi_x = limits->h_start >> (MI_SIZE_LOG2 - ss_x);
-  const int start_mi_y = limits->v_start >> (MI_SIZE_LOG2 - ss_y);
-  const int mbmi_idx =
-      get_mi_grid_idx(&rsc->cm->mi_params, start_mi_y, start_mi_x);
-  rui.mbmi_ptr = rsc->cm->mi_params.mi_grid_base + mbmi_idx;
-  rui.ss_x = ss_x;
-  rui.ss_y = ss_y;
-  rui.mi_stride = rsc->cm->mi_params.mi_stride;
-  rui.lossless_segment = rsc->cm->features.lossless_segment;
-  rui.cm = rsc->cm;
+  set_rui_mbmi_index(rsc, limits, &rui);
   // Only need the classification if running for frame filters.
   rui.skip_pcwiener_filtering = pcwiener_disabled ? 1 : 0;
 
@@ -460,18 +467,7 @@ static int64_t calc_finer_tile_search_error(const RestSearchCtxt *rsc,
                                             RestorationUnitInfo *rui) {
   int64_t err = 0;
   if (limits != NULL) {
-    const int ss_x = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_x;
-    const int ss_y = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_y;
-    const int start_mi_x = limits->h_start >> (MI_SIZE_LOG2 - ss_x);
-    const int start_mi_y = limits->v_start >> (MI_SIZE_LOG2 - ss_y);
-    const int mbmi_idx =
-        get_mi_grid_idx(&rsc->cm->mi_params, start_mi_y, start_mi_x);
-    rui->mbmi_ptr = rsc->cm->mi_params.mi_grid_base + mbmi_idx;
-    rui->ss_x = ss_x;
-    rui->ss_y = ss_y;
-    rui->mi_stride = rsc->cm->mi_params.mi_stride;
-    rui->lossless_segment = rsc->cm->features.lossless_segment;
-    rui->cm = rsc->cm;
+    set_rui_mbmi_index(rsc, limits, rui);
     err = try_restoration_unit(rsc, limits, tile, rui);
   } else {
     Vector *current_unit_stack = rsc->unit_stack;
@@ -481,20 +477,7 @@ static int64_t calc_finer_tile_search_error(const RestSearchCtxt *rsc,
     VECTOR_FOR_EACH(current_unit_stack, listed_unit) {
       RstUnitSnapshot *old_unit = (RstUnitSnapshot *)(listed_unit.pointer);
       if (old_unit->rest_unit_idx == idx && !rsc->rusi[idx].bru_unit_skipped) {
-        const int ss_x = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_x;
-        const int ss_y = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_y;
-        const int start_mi_x =
-            old_unit->limits.h_start >> (MI_SIZE_LOG2 - ss_x);
-        const int start_mi_y =
-            old_unit->limits.v_start >> (MI_SIZE_LOG2 - ss_y);
-        const int mbmi_idx =
-            get_mi_grid_idx(&rsc->cm->mi_params, start_mi_y, start_mi_x);
-        rui->mbmi_ptr = rsc->cm->mi_params.mi_grid_base + mbmi_idx;
-        rui->ss_x = ss_x;
-        rui->ss_y = ss_y;
-        rui->mi_stride = rsc->cm->mi_params.mi_stride;
-        rui->lossless_segment = rsc->cm->features.lossless_segment;
-        rui->cm = rsc->cm;
+        set_rui_mbmi_index(rsc, &old_unit->limits, rui);
         err += try_restoration_unit(rsc, &old_unit->limits, tile, rui);
         n++;
         if (n >= (int)current_unit_indices->size) break;
@@ -535,20 +518,7 @@ static int64_t reset_unit_stack_dst_buffers(const RestSearchCtxt *rsc,
           // Revert to old unit's filters.
           copy_nsfilter_taps(&rui->wienerns_info, &old_rusi->wienerns_info);
         }
-        const int ss_x = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_x;
-        const int ss_y = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_y;
-        const int start_mi_x =
-            old_unit->limits.h_start >> (MI_SIZE_LOG2 - ss_x);
-        const int start_mi_y =
-            old_unit->limits.v_start >> (MI_SIZE_LOG2 - ss_y);
-        const int mbmi_idx =
-            get_mi_grid_idx(&rsc->cm->mi_params, start_mi_y, start_mi_x);
-        rui->mbmi_ptr = rsc->cm->mi_params.mi_grid_base + mbmi_idx;
-        rui->ss_x = ss_x;
-        rui->ss_y = ss_y;
-        rui->mi_stride = rsc->cm->mi_params.mi_stride;
-        rui->lossless_segment = rsc->cm->features.lossless_segment;
-        rui->cm = rsc->cm;
+        set_rui_mbmi_index(rsc, &old_unit->limits, rui);
         err += try_restoration_unit(rsc, &old_unit->limits, tile, rui);
         n++;
         if (n >= (int)current_unit_indices->size) break;
@@ -766,6 +736,61 @@ static int get_subset_from_nsfilter(
   return -1;
 }
 
+typedef struct {
+  int64_t *best_err;
+  double *best_cost;
+  WienerNonsepInfo *best;
+  WienerNonsepInfoBank **ref_bank_ptr;
+  WienerNonsepInfoBank **cur_bank_ptr;
+  int *reset_dict;
+} FinerSearchState;
+
+static int eval_wienerns_candidate(
+    const RestSearchCtxt *rsc, const RestorationTileLimits *limits,
+    const AV2PixelRect *tile_rect, RestorationUnitInfo *rui,
+    const WienernsFilterParameters *nsfilter_params, int wiener_class_id,
+    int c_id, FinerSearchState *st) {
+  const MACROBLOCK *const x = rsc->x;
+  const int64_t err = calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
+  if (rsc->frame_filters_on) {
+    initialize_bank_with_best_frame_filter_match(
+        rsc, &rui->wienerns_info, *st->cur_bank_ptr, *st->reset_dict);
+    *st->reset_dict = 0;
+  }
+  const int c_id_for_bits =
+      wiener_class_id == ALL_WIENERNS_CLASSES ? ALL_WIENERNS_CLASSES : c_id;
+  const int64_t bits = count_wienerns_bits_set(
+      rsc->plane, &x->mode_costs, &rui->wienerns_info, *st->cur_bank_ptr,
+      nsfilter_params, c_id_for_bits);
+  const double cost = RDCOST_DBL_WITH_NATIVE_BD_DIST(
+      x->rdmult, bits >> 4, err, rsc->cm->seq_params.bit_depth);
+  if (cost >= *st->best_cost) return 0;
+  *st->best_err = err;
+  *st->best_cost = cost;
+  copy_nsfilter_taps_for_class(st->best, &rui->wienerns_info, c_id);
+  if (rsc->frame_filters_on) {
+    WienerNonsepInfoBank *tmp_ptr = *st->ref_bank_ptr;
+    *st->ref_bank_ptr = *st->cur_bank_ptr;
+    *st->cur_bank_ptr = tmp_ptr;
+  }
+  return 1;
+}
+
+// After a per-class refinement pass, restore class c_id's taps to the best
+// found and recompute dst so it reflects the winning filter. No-op unless more
+// than one class is in play and a class restriction is active.
+static void finer_reestablish_dst(const RestSearchCtxt *rsc,
+                                  const RestorationTileLimits *limits,
+                                  const AV2PixelRect *tile_rect,
+                                  RestorationUnitInfo *rui,
+                                  const WienerNonsepInfo *best, int c_id,
+                                  int c_id_begin, int c_id_end) {
+  if (c_id_end - c_id_begin > 1 && rui->wiener_class_id_restrict != -1) {
+    copy_nsfilter_taps_for_class(&rui->wienerns_info, best, c_id);
+    calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
+  }
+}
+
 static int64_t finer_tile_search_wienerns(
     const RestSearchCtxt *rsc, const RestorationTileLimits *limits,
     const AV2PixelRect *tile_rect, RestorationUnitInfo *rui,
@@ -817,6 +842,8 @@ static int64_t finer_tile_search_wienerns(
   (void)ncoeffs;
 
   int reset_dict = 1;
+  FinerSearchState st = { &best_err,     &best_cost,    &best,
+                          &ref_bank_ptr, &cur_bank_ptr, &reset_dict };
   if (rsc->frame_filters_on) {
     assert(wiener_class_id == ALL_WIENERNS_CLASSES);
     copy_nsfilter_taps(&rui->wienerns_info, &best);
@@ -828,24 +855,8 @@ static int64_t finer_tile_search_wienerns(
           av2_constref_from_wienerns_bank(ref_bank_ptr, bank_ref, c_id), c_id);
       rui->wiener_class_id_restrict = c_id;
 
-      const int64_t err =
-          calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-      initialize_bank_with_best_frame_filter_match(rsc, &rui->wienerns_info,
-                                                   cur_bank_ptr, reset_dict);
-      reset_dict = 0;
-      const int64_t bits = count_wienerns_bits_set(
-          rsc->plane, &x->mode_costs, &rui->wienerns_info, cur_bank_ptr,
-          nsfilter_params, ALL_WIENERNS_CLASSES);
-      const double cost = RDCOST_DBL_WITH_NATIVE_BD_DIST(
-          x->rdmult, bits >> 4, err, rsc->cm->seq_params.bit_depth);
-      if (cost < best_cost) {
-        best_err = err;
-        best_cost = cost;
-        copy_nsfilter_taps_for_class(&best, &rui->wienerns_info, c_id);
-        WienerNonsepInfoBank *tmp_ptr = ref_bank_ptr;
-        ref_bank_ptr = cur_bank_ptr;
-        cur_bank_ptr = tmp_ptr;
-      } else {
+      if (!eval_wienerns_candidate(rsc, limits, tile_rect, rui, nsfilter_params,
+                                   wiener_class_id, c_id, &st)) {
         copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
         // Re-establish dst.
         if (c_id_end - c_id_begin > 1 && rui->wiener_class_id_restrict != -1) {
@@ -913,34 +924,11 @@ static int64_t finer_tile_search_wienerns(
           for (int ci = cmin; ci < cmax; ++ci) {
             rui_wienerns_info_nsfilter[i] = ci;
             rui_wienerns_info_nsfilter[i + 1] = ci;
-            const int64_t err =
-                calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-            if (rsc->frame_filters_on) {
-              initialize_bank_with_best_frame_filter_match(
-                  rsc, &rui->wienerns_info, cur_bank_ptr, reset_dict);
-              reset_dict = 0;
-            }
-            const int c_id_for_bits = wiener_class_id == ALL_WIENERNS_CLASSES
-                                          ? ALL_WIENERNS_CLASSES
-                                          : c_id;
-            const int64_t bits = count_wienerns_bits_set(
-                rsc->plane, &x->mode_costs, &rui->wienerns_info, cur_bank_ptr,
-                nsfilter_params, c_id_for_bits);
-            const double cost = RDCOST_DBL_WITH_NATIVE_BD_DIST(
-                x->rdmult, bits >> 4, err, rsc->cm->seq_params.bit_depth);
-            if (cost < best_cost) {
+            if (eval_wienerns_candidate(rsc, limits, tile_rect, rui,
+                                        nsfilter_params, wiener_class_id, c_id,
+                                        &st))
               no_improv = 0;
-              best_err = err;
-              best_cost = cost;
-              copy_nsfilter_taps_for_class(&best, &rui->wienerns_info, c_id);
-              if (rsc->frame_filters_on) {
-                WienerNonsepInfoBank *tmp_ptr = ref_bank_ptr;
-                ref_bank_ptr = cur_bank_ptr;
-                cur_bank_ptr = tmp_ptr;
-              }
-            }
           }
-          // copy_nsfilter_taps_for_class(&curr, &best, c_id);
           rui_wienerns_info_nsfilter[i] = best_nsfilter[i];
           rui_wienerns_info_nsfilter[i + 1] = best_nsfilter[i + 1];
           i++;
@@ -974,34 +962,11 @@ static int64_t finer_tile_search_wienerns(
             continue;
           }
           rui_wienerns_info_nsfilter[i] = ci;
-          const int64_t err =
-              calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-          if (rsc->frame_filters_on) {
-            initialize_bank_with_best_frame_filter_match(
-                rsc, &rui->wienerns_info, cur_bank_ptr, reset_dict);
-            reset_dict = 0;
-          }
-          const int c_id_for_bits = wiener_class_id == ALL_WIENERNS_CLASSES
-                                        ? ALL_WIENERNS_CLASSES
-                                        : c_id;
-          const int64_t bits = count_wienerns_bits_set(
-              rsc->plane, &x->mode_costs, &rui->wienerns_info, cur_bank_ptr,
-              nsfilter_params, c_id_for_bits);
-          const double cost = RDCOST_DBL_WITH_NATIVE_BD_DIST(
-              x->rdmult, bits >> 4, err, rsc->cm->seq_params.bit_depth);
-          if (cost < best_cost) {
+          if (eval_wienerns_candidate(rsc, limits, tile_rect, rui,
+                                      nsfilter_params, wiener_class_id, c_id,
+                                      &st))
             no_improv = 0;
-            best_err = err;
-            best_cost = cost;
-            copy_nsfilter_taps_for_class(&best, &rui->wienerns_info, c_id);
-            if (rsc->frame_filters_on) {
-              WienerNonsepInfoBank *tmp_ptr = ref_bank_ptr;
-              ref_bank_ptr = cur_bank_ptr;
-              cur_bank_ptr = tmp_ptr;
-            }
-          }
         }
-        // copy_nsfilter_taps_for_class(&curr, &best, c_id);
         rui_wienerns_info_nsfilter[i] = best_nsfilter[i];
       }
       if (no_improv) {
@@ -1010,12 +975,9 @@ static int64_t finer_tile_search_wienerns(
       copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
       // copy_nsfilter_taps_for_class(&curr, &rui->wienerns_info, c_id);
     }
-    // Re-establish dst.
-    if (refine_iters && c_id_end - c_id_begin > 1 &&
-        rui->wiener_class_id_restrict != -1) {
-      copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
-      calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-    }
+    if (refine_iters)
+      finer_reestablish_dst(rsc, limits, tile_rect, rui, &best, c_id,
+                            c_id_begin, c_id_end);
   }
   copy_nsfilter_taps(&rui->wienerns_info, &best);
   if (rsc->frame_filters_on) {
@@ -1050,37 +1012,12 @@ static int64_t finer_tile_search_wienerns(
         rui_wienerns_info_nsfilter[i + 1] = avg;
         i++;
       }
-      const int64_t err =
-          calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-      if (rsc->frame_filters_on) {
-        initialize_bank_with_best_frame_filter_match(rsc, &rui->wienerns_info,
-                                                     cur_bank_ptr, reset_dict);
-        reset_dict = 0;
-      }
-      const int c_id_for_bits =
-          wiener_class_id == ALL_WIENERNS_CLASSES ? ALL_WIENERNS_CLASSES : c_id;
-      const int64_t bits = count_wienerns_bits_set(
-          rsc->plane, &x->mode_costs, &rui->wienerns_info, cur_bank_ptr,
-          nsfilter_params, c_id_for_bits);
-      const double cost = RDCOST_DBL_WITH_NATIVE_BD_DIST(
-          x->rdmult, bits >> 4, err, rsc->cm->seq_params.bit_depth);
-      if (cost < best_cost) {
-        best_err = err;
-        best_cost = cost;
-        copy_nsfilter_taps_for_class(&best, &rui->wienerns_info, c_id);
-        if (rsc->frame_filters_on) {
-          WienerNonsepInfoBank *tmp_ptr = ref_bank_ptr;
-          ref_bank_ptr = cur_bank_ptr;
-          cur_bank_ptr = tmp_ptr;
-        }
-      } else {
+      if (!eval_wienerns_candidate(rsc, limits, tile_rect, rui, nsfilter_params,
+                                   wiener_class_id, c_id, &st)) {
         copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
       }
-      // Re-establish dst.
-      if (c_id_end - c_id_begin > 1 && rui->wiener_class_id_restrict != -1) {
-        copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
-        calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-      }
+      finer_reestablish_dst(rsc, limits, tile_rect, rui, &best, c_id,
+                            c_id_begin, c_id_end);
     }
     copy_nsfilter_taps(&rui->wienerns_info, &best);
     if (rsc->frame_filters_on) {
@@ -1099,44 +1036,19 @@ static int64_t finer_tile_search_wienerns(
         get_subset_from_nsfilter(nsfilter_params, rui_wienerns_info_nsfilter);
     assert(subset != -1);
     rui->wiener_class_id_restrict = c_id;
-    const int c_id_for_bits =
-        wiener_class_id == ALL_WIENERNS_CLASSES ? ALL_WIENERNS_CLASSES : c_id;
 
     for (int s = 0; s < subset; ++s) {
       for (int i = beg_feat; i < end_feat; ++i) {
         if (!nsfilter_params->subset_config[s][i])
           rui_wienerns_info_nsfilter[i] = 0;
       }
-      const int64_t err =
-          calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-      if (rsc->frame_filters_on) {
-        initialize_bank_with_best_frame_filter_match(rsc, &rui->wienerns_info,
-                                                     cur_bank_ptr, reset_dict);
-        reset_dict = 0;
-      }
-      const int64_t bits = count_wienerns_bits_set(
-          rsc->plane, &x->mode_costs, &rui->wienerns_info, cur_bank_ptr,
-          nsfilter_params, c_id_for_bits);
-      const double cost = RDCOST_DBL_WITH_NATIVE_BD_DIST(
-          x->rdmult, bits >> 4, err, rsc->cm->seq_params.bit_depth);
-      if (cost < best_cost) {
-        best_err = err;
-        best_cost = cost;
-        copy_nsfilter_taps_for_class(&best, &rui->wienerns_info, c_id);
-        if (rsc->frame_filters_on) {
-          WienerNonsepInfoBank *tmp_ptr = ref_bank_ptr;
-          ref_bank_ptr = cur_bank_ptr;
-          cur_bank_ptr = tmp_ptr;
-        }
-      } else {
+      if (!eval_wienerns_candidate(rsc, limits, tile_rect, rui, nsfilter_params,
+                                   wiener_class_id, c_id, &st)) {
         copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
       }
     }
-    // Re-establish dst.
-    if (c_id_end - c_id_begin > 1 && rui->wiener_class_id_restrict != -1) {
-      copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
-      calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-    }
+    finer_reestablish_dst(rsc, limits, tile_rect, rui, &best, c_id, c_id_begin,
+                          c_id_end);
   }
   copy_nsfilter_taps(&rui->wienerns_info, &best);
   if (rsc->frame_filters_on) {
@@ -1179,34 +1091,11 @@ static int64_t finer_tile_search_wienerns(
             copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
             continue;
           }
-          const int64_t err =
-              calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-          if (rsc->frame_filters_on) {
-            initialize_bank_with_best_frame_filter_match(
-                rsc, &rui->wienerns_info, cur_bank_ptr, reset_dict);
-            reset_dict = 0;
-          }
-          const int c_id_for_bits = wiener_class_id == ALL_WIENERNS_CLASSES
-                                        ? ALL_WIENERNS_CLASSES
-                                        : c_id;
-          const int64_t bits = count_wienerns_bits_set(
-              rsc->plane, &x->mode_costs, &rui->wienerns_info, cur_bank_ptr,
-              nsfilter_params, c_id_for_bits);
-          const double cost = RDCOST_DBL_WITH_NATIVE_BD_DIST(
-              x->rdmult, bits >> 4, err, rsc->cm->seq_params.bit_depth);
-          if (cost < best_cost) {
+          if (eval_wienerns_candidate(rsc, limits, tile_rect, rui,
+                                      nsfilter_params, wiener_class_id, c_id,
+                                      &st))
             no_improv = 0;
-            best_err = err;
-            best_cost = cost;
-            copy_nsfilter_taps_for_class(&best, &rui->wienerns_info, c_id);
-            if (rsc->frame_filters_on) {
-              WienerNonsepInfoBank *tmp_ptr = ref_bank_ptr;
-              ref_bank_ptr = cur_bank_ptr;
-              cur_bank_ptr = tmp_ptr;
-            }
-          }
         }
-        // copy_nsfilter_taps_for_class(&curr, &best, c_id);
         rui_wienerns_info_nsfilter[i] = best_nsfilter[i];
         rui_wienerns_info_nsfilter[i + 1] = best_nsfilter[i + 1];
       }
@@ -1214,13 +1103,9 @@ static int64_t finer_tile_search_wienerns(
         break;
       }
       copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
-      // copy_nsfilter_taps_for_class(&curr, &rui->wienerns_info, c_id);
     }
-    // Re-establish dst.
-    if (c_id_end - c_id_begin > 1 && rui->wiener_class_id_restrict != -1) {
-      copy_nsfilter_taps_for_class(&rui->wienerns_info, &best, c_id);
-      calc_finer_tile_search_error(rsc, limits, tile_rect, rui);
-    }
+    finer_reestablish_dst(rsc, limits, tile_rect, rui, &best, c_id, c_id_begin,
+                          c_id_end);
   }
 
   copy_nsfilter_taps(&rui->wienerns_info, &best);
@@ -2032,18 +1917,7 @@ static void gather_stats_wienerns(const RestorationTileLimits *limits,
       rsc->cm->quant_params.base_qindex, rsc->plane != AVM_PLANE_Y);
   assert(rsc->num_filter_classes == rsc->wienerns_bank.filter[0].num_classes);
 
-  const int ss_x = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_x;
-  const int ss_y = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_y;
-  const int start_mi_x = limits->h_start >> (MI_SIZE_LOG2 - ss_x);
-  const int start_mi_y = limits->v_start >> (MI_SIZE_LOG2 - ss_y);
-  const int mbmi_idx =
-      get_mi_grid_idx(&rsc->cm->mi_params, start_mi_y, start_mi_x);
-  rui.mbmi_ptr = rsc->cm->mi_params.mi_grid_base + mbmi_idx;
-  rui.ss_x = ss_x;
-  rui.ss_y = ss_y;
-  rui.mi_stride = rsc->cm->mi_params.mi_stride;
-  rui.lossless_segment = rsc->cm->features.lossless_segment;
-  rui.cm = rsc->cm;
+  set_rui_mbmi_index(rsc, limits, &rui);
   // Calculate and save this RU's stats.
   RstUnitStats unit_stats;
   memset(&unit_stats, 0, sizeof(unit_stats));
@@ -2172,18 +2046,7 @@ static void search_wienerns_visitor(const RestorationTileLimits *limits,
 
   RestorationUnitInfo rui;
   initialize_rui_for_nonsep_search(rsc, &rui);
-  const int ss_x = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_x;
-  const int ss_y = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_y;
-  const int start_mi_x = limits->h_start >> (MI_SIZE_LOG2 - ss_x);
-  const int start_mi_y = limits->v_start >> (MI_SIZE_LOG2 - ss_y);
-  const int mbmi_idx =
-      get_mi_grid_idx(&rsc->cm->mi_params, start_mi_y, start_mi_x);
-  rui.mbmi_ptr = rsc->cm->mi_params.mi_grid_base + mbmi_idx;
-  rui.ss_x = ss_x;
-  rui.ss_y = ss_y;
-  rui.mi_stride = rsc->cm->mi_params.mi_stride;
-  rui.lossless_segment = rsc->cm->features.lossless_segment;
-  rui.cm = rsc->cm;
+  set_rui_mbmi_index(rsc, limits, &rui);
 
   // Classification has already been calculated by search_pc_wiener_visitor().
   rui.compute_classification = 0;
@@ -3263,20 +3126,6 @@ static RdResults update_cost_and_weights_wienerns(RestSearchCtxt *rsc,
     int64_t distortion = INT64_MAX;
     int64_t distortion_none = 0;
     if (!rsc->rusi[unit_stats_ptr->ru_idx].bru_unit_skipped) {
-      const int ss_x = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_x;
-      const int ss_y = (rsc->plane > 0) && rsc->cm->seq_params.subsampling_y;
-      const int start_mi_x =
-          unit_stats_ptr->limits.h_start >> (MI_SIZE_LOG2 - ss_x);
-      const int start_mi_y =
-          unit_stats_ptr->limits.v_start >> (MI_SIZE_LOG2 - ss_y);
-      const int mbmi_idx =
-          get_mi_grid_idx(&rsc->cm->mi_params, start_mi_y, start_mi_x);
-      rui->lossless_segment = rsc->cm->features.lossless_segment;
-      rui->cm = rsc->cm;
-      rui->mbmi_ptr = rsc->cm->mi_params.mi_grid_base + mbmi_idx;
-      rui->ss_x = ss_x;
-      rui->ss_y = ss_y;
-      rui->mi_stride = rsc->cm->mi_params.mi_stride;
       distortion = calc_finer_tile_search_error(rsc, &unit_stats_ptr->limits,
                                                 &rsc->tile_rect, rui);
       distortion_none = unit_stats_ptr->real_sse;
@@ -3820,15 +3669,10 @@ void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
   const YV12_BUFFER_CONFIG *dgd = &cpi->common.cur_frame->buf;
   rsc.luma_stride = dgd->widths[1] + 2 * WIENERNS_UV_BRD;
   luma_buf = wienerns_copy_luma_highbd(
-      dgd->buffers[AVM_PLANE_Y], dgd->heights[AVM_PLANE_Y],
+      cm, dgd->buffers[AVM_PLANE_Y], dgd->heights[AVM_PLANE_Y],
       dgd->widths[AVM_PLANE_Y], dgd->strides[AVM_PLANE_Y], &luma,
-      dgd->heights[1], dgd->widths[1], WIENERNS_UV_BRD, rsc.luma_stride,
-      cm->seq_params.bit_depth
-#if WIENERNS_CROSS_FILT_LUMA_TYPE == 2
-      ,
-      cm->seq_params.cfl_ds_filter_index
-#endif
-  );
+      dgd->heights[AVM_PLANE_U], dgd->widths[AVM_PLANE_U], WIENERNS_UV_BRD,
+      rsc.luma_stride);
   assert(luma_buf != NULL);
 
   rsc.luma_stat = luma;
@@ -4013,8 +3857,8 @@ void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
   }
 
   avm_free(rusi);
-  free(luma_buf);
-  free(luma_virtual_buf);
+  avm_free(luma_buf);
+  avm_free(luma_virtual_buf);
   av2_free_restoration_line_buffers(rsc.rlbs);
   avm_free(rsc.wienerns_tmpbuf);
   avm_vector_destroy(&wienerns_stats);

--- a/av2/encoder/pickrst.c
+++ b/av2/encoder/pickrst.c
@@ -136,8 +136,9 @@ typedef struct {
   int num_wiener_nonsep;  // debug: number of RESTORE_WIENER_NONSEP RUs.
 
   const uint16_t *luma;
+  uint16_t *luma_buf;
   const uint16_t *luma_stat;
-
+  uint16_t *luma_stat_buf;
   int luma_stride;
 
   RestorationLineBuffers *rlbs;
@@ -156,7 +157,7 @@ typedef struct {
   // whether frame filter is predicted from a reference picture
   uint8_t temporal_pred_flag;
   // reference picture index for frame level filter prediction
-  uint8_t rst_ref_pic_idx;
+  int8_t rst_ref_pic_idx;
   WienerNonsepInfo frame_filters;
   AV2PixelRect tile_rect;
 } RestSearchCtxt;
@@ -276,41 +277,32 @@ static AVM_INLINE void reset_rsc(RestSearchCtxt *rsc) {
   avm_vector_clear(rsc->unit_indices);
 }
 
-static AVM_INLINE void init_rsc(const YV12_BUFFER_CONFIG *src,
-                                const AV2_COMMON *cm, const MACROBLOCK *x,
-                                const LOOP_FILTER_SPEED_FEATURES *lpf_sf,
-                                int plane, RestUnitSearchInfo *rusi,
-                                Vector *unit_stack, Vector *unit_indices,
-                                YV12_BUFFER_CONFIG *dst, RestSearchCtxt *rsc) {
-  rsc->src = src;
-  rsc->dst = dst;
-  rsc->cm = cm;
-  rsc->x = x;
-  rsc->plane = plane;
-  rsc->rusi = rusi;
-  rsc->lpf_sf = lpf_sf;
-
+static AVM_INLINE void init_rsc(RestSearchCtxt *rsc, int plane) {
+  const AV2_COMMON *cm = rsc->cm;
+  const YV12_BUFFER_CONFIG *src = rsc->src;
   const YV12_BUFFER_CONFIG *dgd = &cm->cur_frame->buf;
   const int is_uv = plane != AVM_PLANE_Y;
+
+  rsc->plane = plane;
   rsc->plane_width = src->widths[is_uv];
   rsc->plane_height = src->heights[is_uv];
-  rsc->src_buffer = src->buffers[plane];
-  rsc->src_stride = src->strides[is_uv];
   rsc->dgd_buffer = dgd->buffers[plane];
   rsc->dgd_stride = dgd->strides[is_uv];
-  rsc->tile_rect = av2_whole_frame_rect(cm, is_uv);
+  rsc->src_buffer = src->buffers[plane];
+  rsc->src_stride = src->strides[is_uv];
   assert(src->widths[is_uv] == dgd->widths[is_uv]);
   assert(src->heights[is_uv] == dgd->heights[is_uv]);
-  rsc->unit_stack = unit_stack;
-  rsc->unit_indices = unit_indices;
+  rsc->classification_is_buffered = 0;
+  rsc->adjust_switchable_for_frame_filters = 0;
   rsc->num_stats_classes = default_num_classes(plane);
   rsc->num_filter_classes = rsc->num_stats_classes;
   rsc->best_num_filter_classes = rsc->num_filter_classes;
   rsc->frame_filters_on = 0;
   rsc->num_wiener_nonsep = 0;
   rsc->tskip_zero_flag = 0;
-  rsc->classification_is_buffered = 0;
-  rsc->adjust_switchable_for_frame_filters = 0;
+  rsc->temporal_pred_flag = 0;
+  rsc->rst_ref_pic_idx = -1;
+  rsc->tile_rect = av2_whole_frame_rect(cm, is_uv);
   reset_all_banks(rsc);
 }
 
@@ -2812,11 +2804,9 @@ static void finalize_frame_and_unit_info(RestorationType frame_rtype,
   rsi->frame_filters_on = rsc->frame_filters_on;
   rsi->frame_filters_initialized = 0;
   rsi->num_filter_classes = rsc->num_filter_classes;
-  rsi->frame_filters = rsc->frame_filter_bank.filter[0];
   rsi->frame_filters = rsc->frame_filters;
   rsi->temporal_pred_flag = rsc->temporal_pred_flag;
   rsi->rst_ref_pic_idx = rsc->rst_ref_pic_idx;
-
   if (frame_rtype != RESTORE_NONE) {
     process_by_rutile(rsc, copy_unit_info_visitor);
   }
@@ -3613,255 +3603,318 @@ static int replace_with_frame_filters(RestSearchCtxt *rsc, double *best_cost) {
   return final_r;
 }
 
-void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
+typedef struct {
+  RestorationType r_type;
+  double cost;
+  int ru_size;
+  int8_t frame_filters_on;
+  int8_t temp_pred_flag;
+  int8_t temp_ref_idx;
+} PlaneSearchBest;
+
+static void search_restoration_type(AV2_COMMON *const cm, RestSearchCtxt *rsc,
+                                    PlaneSearchBest *best,
+                                    RestorationType r_type,
+                                    WienerNonsepInfoBank *frame_filter_dict,
+                                    double *frame_filter_cost) {
+  const uint8_t lr_disable_mask =
+      rsc->cm->features.lr_tools_disable_mask[rsc->plane != AVM_PLANE_Y];
+  const bool frame_filters_configured =
+      (lr_disable_mask & (1 << RESTORE_WIENER_NONSEP)) ? 0 : 1;
+
+  gather_stats_rest_type(rsc, r_type);
+
+  if (r_type == RESTORE_WIENER_NONSEP) {
+    rsc->num_filter_classes = default_num_classes(rsc->plane);
+  }
+
+  if (r_type == RESTORE_WIENER_NONSEP && !rsc->cm->bru.enabled &&
+      frame_filters_configured) {
+    // Find RDO-num_classes and frame-level filters. After this call
+    // multiclass stats collapse to a single class. If that is not
+    // desired make a copy of stats.
+    rsc->frame_filters_on = 1;
+
+    find_optimal_num_classes_and_frame_filters(rsc);
+
+    // Store for later copy into SWITCHABLE.
+    *frame_filter_dict = rsc->frame_filter_bank;
+    *frame_filter_cost = rsc->frame_filter_cost;
+  }
+
+  if (r_type == RESTORE_SWITCHABLE && !rsc->cm->bru.enabled &&
+      frame_filters_configured) {
+    assert(RESTORE_WIENER_NONSEP < RESTORE_SWITCHABLE);
+    rsc->frame_filter_bank = *frame_filter_dict;
+    rsc->frame_filter_cost = *frame_filter_cost;
+  }
+
+  rsc->frame_filters_on = 0;
+  rsc->num_filter_classes = 1;
+  if (r_type == RESTORE_WIENER_NONSEP || r_type == RESTORE_SWITCHABLE) {
+    rsc->num_wiener_nonsep = 0;
+  }
+
+  double cost = search_rest_type(rsc, r_type);
+  int real_r_type = r_type;
+  if (r_type == RESTORE_SWITCHABLE && !rsc->cm->bru.enabled &&
+      frame_filters_configured && cost > rsc->frame_filters_total_cost &&
+      best->cost > rsc->frame_filters_total_cost) {
+    real_r_type = replace_with_frame_filters(rsc, &cost);
+  }
+  assert(RESTORE_PC_WIENER < RESTORE_WIENER_NONSEP);
+  if (r_type == RESTORE_PC_WIENER && frame_filters_configured) {
+    rsc->classification_is_buffered = 1;  // Buffer is set.
+  }
+  int invalid_result = 0;
+  if (r_type == RESTORE_PC_WIENER && rsc->plane != AVM_PLANE_Y) {
+    invalid_result = 1;
+    assert(cost >= best->cost);
+  }
+  const int found_best = cost < best->cost && !invalid_result;
+  if (found_best) {
+    RestorationInfo *rsi = &cm->rst_info[rsc->plane];
+
+    best->cost = cost;
+    best->r_type = real_r_type;
+    best->ru_size = rsi->restoration_unit_size;
+    if (frame_filters_configured) {
+      best->frame_filters_on = rsc->frame_filters_on;
+      if (rsc->frame_filters_on) {
+        best->temp_pred_flag = rsc->temporal_pred_flag;
+        best->temp_ref_idx = rsc->rst_ref_pic_idx;
+      } else {
+        best->temp_pred_flag = 0;
+        best->temp_ref_idx = -1;
+      }
+    }
+  }
+  if (!frame_filters_configured) {
+    assert(best->temp_ref_idx == -1);
+    assert(best->temp_pred_flag == 0);
+    assert(best->frame_filters_on == 0);
+  }
+}
+
+static void search_unit_size(AV2_COMMON *const cm, RestSearchCtxt *rsc,
+                             PlaneSearchBest *best, int ru_size) {
+  RestorationInfo *rsi = &cm->rst_info[rsc->plane];
+
+  assert(rsc->adjust_switchable_for_frame_filters == 0);
+  avm_vector_clear(rsc->wienerns_stats);
+  rsi->restoration_unit_size = ru_size;
+  av2_reset_restoration_struct(cm, rsi, rsc->plane != AVM_PLANE_Y);
+
+  const int ru_count = rest_tiles_in_plane(cm, rsc->plane);
+  const RestorationType r_types =
+      (ru_count > 1) ? RESTORE_TYPES : RESTORE_SWITCHABLE_TYPES;
+  const uint8_t lr_disable_mask =
+      rsc->cm->features.lr_tools_disable_mask[rsc->plane != AVM_PLANE_Y];
+  WienerNonsepInfoBank frame_filter_dict;
+  double frame_filter_cost = DBL_MAX;
+  for (RestorationType r_type = 0; r_type < r_types; ++r_type) {
+    // Need classification and related stats. Run search_pc_wiener_visitor
+    // without any filtering. (Follow pcwiener_disabled.)
+    if ((r_type != RESTORE_PC_WIENER) && (lr_disable_mask & (1 << r_type))) {
+      continue;
+    }
+    search_restoration_type(cm, rsc, best, r_type, &frame_filter_dict,
+                            &frame_filter_cost);
+  }
+  rsc->classification_is_buffered = 0;  // Buffer is consumed.
+  rsc->frame_filters_on = best->frame_filters_on;
+  rsc->temporal_pred_flag = best->temp_pred_flag;
+  rsc->rst_ref_pic_idx = best->temp_ref_idx;
+}
+
+static void search_plane_restoration(AV2_COMP *const cpi, RestSearchCtxt *rsc,
+                                     int plane) {
+  AV2_COMMON *const cm = &cpi->common;
+  RestorationInfo *rsi = &cm->rst_info[plane];
+  const LOOP_FILTER_SPEED_FEATURES *const sf = rsc->lpf_sf;
+
+  init_rsc(rsc, plane);
+
+  // disable search
+  const bool frame_inactive =
+      cm->current_frame.frame_type != KEY_FRAME && cm->bru.frame_inactive_flag;
+  if (frame_inactive || (sf->disable_loop_restoration_chroma &&
+                         (plane == AVM_PLANE_U || plane == AVM_PLANE_V))) {
+    finalize_frame_and_unit_info(RESTORE_NONE, rsi, rsc);
+    return;
+  }
+
+  av2_extend_frame(rsc->dgd_buffer, rsc->plane_width, rsc->plane_height,
+                   rsc->dgd_stride, RESTORATION_BORDER_HORZ,
+                   RESTORATION_BORDER_VERT);
+
+  int min_ru_size = rsi->min_restoration_unit_size;
+  int max_ru_size = rsi->max_restoration_unit_size;
+  // Trim the RU-size search window by pyramid level: drop the largest at
+  // level >= 3, and also drop the smallest at level >= 5 when drop_low is
+  // set.
+  if (sf->reduce_lr_unit_size_by_pyr) {
+    int level = rsc->cm->current_frame.pyramid_level;
+    int drop_high = level >= 3;
+    int drop_low = (sf->reduce_lr_unit_size_by_pyr_drop_low && level >= 5);
+    int hi_unit_size = max_ru_size >> drop_high;
+    int lo_unit_size = min_ru_size << drop_low;
+    hi_unit_size = AVMMAX(hi_unit_size, min_ru_size);
+    if (lo_unit_size > hi_unit_size) lo_unit_size = min_ru_size;
+    min_ru_size = lo_unit_size;
+    max_ru_size = hi_unit_size;
+  }
+
+  PlaneSearchBest best = { .r_type = RESTORE_NONE,
+                           .cost = DBL_MAX,
+                           .ru_size = min_ru_size,
+                           .frame_filters_on = 0,
+                           .temp_pred_flag = 0,
+                           .temp_ref_idx = -1 };
+  for (int ru_size = min_ru_size; ru_size <= max_ru_size; ru_size <<= 1) {
+    // ru_size can be not smaller than stripe size, this process could only be
+    // triggered for 422 coding.
+    if (plane != AVM_PLANE_Y &&
+        ru_size < (64 >> rsc->cm->seq_params.subsampling_y)) {
+      continue;
+    }
+    // chroma planes share ru size
+    if (plane == AVM_PLANE_V &&
+        ru_size != rsc->cm->rst_info[AVM_PLANE_U].restoration_unit_size) {
+      continue;
+    }
+
+    search_unit_size(cm, rsc, &best, ru_size);
+
+    if (rsi->restoration_unit_size == min_ru_size ||
+        rsi->restoration_unit_size == best.ru_size) {
+      finalize_frame_and_unit_info(best.r_type, rsi, rsc);
+    }
+  }
+  assert(IMPLIES(cm->features.lr_tools_count[plane] < 2,
+                 rsi->frame_restoration_type != RESTORE_SWITCHABLE));
+  rsi->restoration_unit_size = best.ru_size;
+  av2_reset_restoration_struct(cm, rsi, plane != AVM_PLANE_Y);
+  int ru_num = rest_tiles_in_plane(cm, plane != AVM_PLANE_Y);
+  adjust_frame_rtype(rsi, ru_num, rsc, &cpi->oxcf.tool_cfg);
+}
+
+static RestSearchCtxt *alloc_rst_search_context(AV2_COMP *const cpi,
+                                                const YV12_BUFFER_CONFIG *src,
+                                                int max_ru_count) {
   AV2_COMMON *const cm = &cpi->common;
   MACROBLOCK *const x = &cpi->td.mb;
-  const int num_planes = av2_num_planes(cm);
-  assert(!cm->features.all_lossless);
+  const bool is_mono = cm->seq_params.monochrome;
 
-  av2_fill_lr_rates(&x->mode_costs, x->e_mbd.tile_ctx);
-
-  int ntiles[2];
-  for (int is_uv = 0; is_uv < 2; ++is_uv) {
-    cm->rst_info[is_uv].restoration_unit_size =
-        cm->rst_info[is_uv].min_restoration_unit_size;
-    av2_reset_restoration_struct(cm, &cm->rst_info[is_uv], is_uv);
-    ntiles[is_uv] = rest_tiles_in_plane(cm, is_uv);
-  }
-  int max_ntile = AVMMAX(ntiles[0], ntiles[1]);
-  RestUnitSearchInfo *rusi =
-      (RestUnitSearchInfo *)avm_memalign(16, sizeof(*rusi) * max_ntile);
-
+  RestUnitSearchInfo *rusi;
   // If the restoration unit dimensions are not multiples of
   // rsi->restoration_unit_size then some elements of the rusi array may be
   // left uninitialised when we reach copy_unit_info(...). This is not a
   // problem, as these elements are ignored later, but in order to quiet
   // Valgrind's warnings we initialise the array below.
-  memset(rusi, 0, sizeof(*rusi) * max_ntile);
-  x->rdmult = cpi->rd.RDMULT;
+  CHECK_MEM_ERROR(cm, rusi, avm_calloc(max_ru_count, sizeof(*rusi)));
 
-  Vector unit_stack;
-  avm_vector_setup(&unit_stack,
-                   1,                                // resizable capacity
-                   sizeof(struct RstUnitSnapshot));  // element size
-  Vector unit_indices;
-  avm_vector_setup(&unit_indices,
-                   1,             // resizable capacity
-                   sizeof(int));  // element size
+  Vector *unit_stack;
+  CHECK_MEM_ERROR(cm, unit_stack, avm_memalign(16, sizeof(*unit_stack)));
+  avm_vector_setup(unit_stack, /*capacity=*/1,
+                   /*element_size=*/sizeof(struct RstUnitSnapshot));
 
-  RestSearchCtxt rsc;
-  const int plane_start = AVM_PLANE_Y;
-  const int plane_end = num_planes > 1 ? AVM_PLANE_V : AVM_PLANE_Y;
+  Vector *unit_indices;
+  CHECK_MEM_ERROR(cm, unit_indices, avm_memalign(16, sizeof(*unit_indices)));
+  avm_vector_setup(unit_indices, /*capacity=*/1, /*element_size=*/sizeof(int));
 
-  Vector wienerns_stats;
-  avm_vector_setup(&wienerns_stats,
-                   1,                             // resizable capacity
-                   sizeof(struct RstUnitStats));  // element size
-  rsc.wienerns_stats = &wienerns_stats;
-  WienerNonsepInfoBank frame_filter_dict;
-  double frame_filter_cost = DBL_MAX;
-  int best_frame_filters_state = 0;
-  int8_t best_temp_pred_flag = 0;
-  int8_t best_temp_ref_idx = -1;
+  Vector *wienerns_stats;
+  CHECK_MEM_ERROR(cm, wienerns_stats,
+                  avm_memalign(16, sizeof(*wienerns_stats)));
+  avm_vector_setup(wienerns_stats, /*capacity=*/1,
+                   /*element_size=*/sizeof(struct RstUnitStats));
 
   uint16_t *luma = NULL;
-  uint16_t *luma_buf;
-  const YV12_BUFFER_CONFIG *dgd = &cpi->common.cur_frame->buf;
-  rsc.luma_stride = dgd->widths[1] + 2 * WIENERNS_UV_BRD;
-  luma_buf = wienerns_copy_luma_highbd(
-      cm, dgd->buffers[AVM_PLANE_Y], dgd->heights[AVM_PLANE_Y],
-      dgd->widths[AVM_PLANE_Y], dgd->strides[AVM_PLANE_Y], &luma,
-      dgd->heights[AVM_PLANE_U], dgd->widths[AVM_PLANE_U], WIENERNS_UV_BRD,
-      rsc.luma_stride);
-  assert(luma_buf != NULL);
-
-  rsc.luma_stat = luma;
-
+  uint16_t *luma_buf = NULL;
   uint16_t *luma_virtual = NULL;
-  uint16_t *luma_virtual_buf;
+  uint16_t *luma_virtual_buf = NULL;
+  int ns_luma_stride = 0;
+  if (!is_mono) {
+    const YV12_BUFFER_CONFIG *dgd = &cm->cur_frame->buf;
 
-  rsc.rlbs = NULL;
-  av2_alloc_restoration_line_buffers(cm, &rsc.rlbs);
+    ns_luma_stride = dgd->widths[AVM_PLANE_U] + 2 * WIENERNS_UV_BRD;
+    luma_buf = wienerns_copy_luma_highbd(
+        cm, dgd->buffers[AVM_PLANE_Y], dgd->heights[AVM_PLANE_Y],
+        dgd->widths[AVM_PLANE_Y], dgd->strides[AVM_PLANE_Y], &luma,
+        dgd->heights[AVM_PLANE_U], dgd->widths[AVM_PLANE_U], WIENERNS_UV_BRD,
+        ns_luma_stride);
 
-  luma_virtual_buf = wienerns_copy_luma_with_virtual_lines(cm, &luma_virtual);
-  rsc.luma = luma_virtual;
-
-  rsc.wienerns_tmpbuf =
-      (double *)avm_malloc(WIENERNS_TMPBUF_SIZE * sizeof(*rsc.wienerns_tmpbuf));
-
-  for (int plane = plane_start; plane <= plane_end; ++plane) {
-    init_rsc(src, &cpi->common, x, &cpi->sf.lpf_sf, plane, rusi, &unit_stack,
-             &unit_indices, &cpi->trial_frame_rst, &rsc);
-
-    const int plane_ntiles = ntiles[plane > 0];
-    const RestorationType num_rtypes =
-        (plane_ntiles > 1) ? RESTORE_TYPES : RESTORE_SWITCHABLE_TYPES;
-
-    double best_cost = DBL_MAX;
-    RestorationType best_rtype = RESTORE_NONE;
-    best_frame_filters_state = 0;
-    best_temp_pred_flag = 0;
-    best_temp_ref_idx = -1;
-    rsc.temporal_pred_flag = 0;
-    const int frame_filters_configured =
-        cpi->common.features.lr_tools_disable_mask[plane > 0] &
-                (1 << RESTORE_WIENER_NONSEP)
-            ? 0
-            : 1;
-    RestorationInfo *rsi = &cm->rst_info[plane];
-    int max_unit_size = rsi->max_restoration_unit_size;
-    int min_unit_size = rsi->min_restoration_unit_size;
-
-    int best_unit_size = min_unit_size;
-
-    if (cpi->sf.lpf_sf.reduce_lr_unit_size_by_pyr) {
-      // Trim the RU-size search window by pyramid level: drop the largest at
-      // level>=3, and also drop the smallest at level>=5 when drop_low is set.
-      const int pyr_level = cm->current_frame.pyramid_level;
-      const int drop_high = (pyr_level >= 3);
-      const int drop_low =
-          (cpi->sf.lpf_sf.reduce_lr_unit_size_by_pyr_drop_low &&
-           pyr_level >= 5);
-      int hi_unit_size = max_unit_size >> drop_high;
-      int lo_unit_size = min_unit_size << drop_low;
-      if (hi_unit_size < min_unit_size) hi_unit_size = min_unit_size;
-      if (lo_unit_size > hi_unit_size) lo_unit_size = min_unit_size;
-      min_unit_size = lo_unit_size;
-      max_unit_size = hi_unit_size;
-    }
-
-    for (int unit_size = min_unit_size; unit_size <= max_unit_size;
-         unit_size <<= 1) {
-      // ru_size can be not smaller than stripe size, this process could only be
-      // triggered for 422 coding.
-      if (plane > 0 && unit_size < (64 >> cm->seq_params.subsampling_y)) {
-        continue;
-      }
-
-      if (plane == 2 && unit_size != cm->rst_info[1].restoration_unit_size) {
-        continue;
-      }
-      avm_vector_clear(&wienerns_stats);
-
-      rsi->restoration_unit_size = unit_size;
-
-      av2_reset_restoration_struct(cm, rsi, plane > 0);
-      if (!cpi->sf.lpf_sf.disable_loop_restoration_chroma || !plane) {
-        av2_extend_frame(rsc.dgd_buffer, rsc.plane_width, rsc.plane_height,
-                         rsc.dgd_stride, RESTORATION_BORDER_HORZ,
-                         RESTORATION_BORDER_VERT);
-
-        assert(rsc.adjust_switchable_for_frame_filters == 0);
-        for (RestorationType r = 0; r < num_rtypes; ++r) {
-          if (
-              // Need classification and related stats. Run
-              // search_pc_wiener_visitor without any filtering. (Follow
-              // pcwiener_disabled.)
-              (r != RESTORE_PC_WIENER) &&
-              cpi->common.features.lr_tools_disable_mask[plane > 0] & (1 << r))
-            continue;
-
-          gather_stats_rest_type(&rsc, r);
-
-          if (r == RESTORE_WIENER_NONSEP) {
-            rsc.num_filter_classes = default_num_classes(rsc.plane);
-          }
-
-          if (r == RESTORE_WIENER_NONSEP && !cm->bru.enabled &&
-              frame_filters_configured) {
-            // Find RDO-num_classes and frame-level filters. After this call
-            // multiclass stats collapse to a single class. If that is not
-            // desired make a copy of stats.
-
-            rsc.frame_filters_on = 1;
-            find_optimal_num_classes_and_frame_filters(&rsc);
-
-            // Store for later copy into SWITCHABLE.
-            frame_filter_dict = rsc.frame_filter_bank;
-            frame_filter_cost = rsc.frame_filter_cost;
-          }
-          if (r == RESTORE_SWITCHABLE && frame_filters_configured) {
-            assert(RESTORE_WIENER_NONSEP < RESTORE_SWITCHABLE);
-            rsc.frame_filter_bank = frame_filter_dict;
-            rsc.frame_filter_cost = frame_filter_cost;
-          }
-          rsc.frame_filters_on = 0;
-          rsc.num_filter_classes = 1;
-          if (r == RESTORE_WIENER_NONSEP || r == RESTORE_SWITCHABLE)
-            rsc.num_wiener_nonsep = 0;
-          // If the full frame is skipped, no need to search other type
-          if (cm->current_frame.frame_type != KEY_FRAME &&
-              cm->bru.frame_inactive_flag && r != 0)
-            continue;
-
-          double cost = search_rest_type(&rsc, r);
-          int real_r = r;
-          if (r == RESTORE_SWITCHABLE && !cm->bru.enabled &&
-              frame_filters_configured && cost > rsc.frame_filters_total_cost &&
-              best_cost > rsc.frame_filters_total_cost) {
-            real_r = replace_with_frame_filters(&rsc, &cost);
-          }
-          assert(RESTORE_PC_WIENER < RESTORE_WIENER_NONSEP);
-          if (r == RESTORE_PC_WIENER && frame_filters_configured) {
-            rsc.classification_is_buffered = 1;  // Buffer is set.
-          }
-          int invalid_result = 0;
-          if (r == RESTORE_PC_WIENER && plane != AVM_PLANE_Y) {
-            invalid_result = 1;
-            assert(cost >= best_cost);
-          }
-          const int found_best = cost < best_cost && !invalid_result;
-          if (found_best) {
-            best_cost = cost;
-            best_rtype = real_r;
-            best_unit_size = unit_size;
-            if (frame_filters_configured) {
-              best_frame_filters_state = rsc.frame_filters_on;
-              if (rsc.frame_filters_on) {
-                best_temp_pred_flag = rsc.temporal_pred_flag;
-                best_temp_ref_idx = rsc.rst_ref_pic_idx;
-              } else {
-                best_temp_pred_flag = 0;
-                best_temp_ref_idx = -1;
-              }
-            }
-          }
-        }
-        rsc.classification_is_buffered = 0;  // Buffer is consumed.
-      }
-      rsc.frame_filters_on = best_frame_filters_state;
-      rsc.temporal_pred_flag = best_temp_pred_flag;
-      rsc.rst_ref_pic_idx = best_temp_ref_idx;
-      if (!frame_filters_configured) {
-        assert(best_temp_ref_idx == -1);
-        assert(best_temp_pred_flag == 0);
-        assert(best_frame_filters_state == 0);
-      }
-      if (rsi->restoration_unit_size == min_unit_size ||
-          best_unit_size == rsi->restoration_unit_size) {
-        finalize_frame_and_unit_info(best_rtype, &cm->rst_info[plane], &rsc);
-      }
-    }
-    assert(IMPLIES(
-        cm->features.lr_tools_count[plane] < 2,
-        cm->rst_info[plane].frame_restoration_type != RESTORE_SWITCHABLE));
-    rsi->restoration_unit_size = best_unit_size;
-    av2_reset_restoration_struct(cm, rsi, plane > 0);
-    int ru_num = rest_tiles_in_plane(cm, plane > 0);
-    adjust_frame_rtype(&cm->rst_info[plane], ru_num, &rsc, &cpi->oxcf.tool_cfg);
-    /*
-    printf("[Frame %d][%d]: unit_size %d best_frame_filters_state %d(%d)\n",
-           cm->current_frame.order_hint, plane, best_unit_size,
-           best_frame_filters_state, rsc.best_num_filter_classes);
-           */
+    luma_virtual_buf = wienerns_copy_luma_with_virtual_lines(cm, &luma_virtual);
   }
 
-  avm_free(rusi);
-  avm_free(luma_buf);
-  avm_free(luma_virtual_buf);
-  av2_free_restoration_line_buffers(rsc.rlbs);
-  avm_free(rsc.wienerns_tmpbuf);
-  avm_vector_destroy(&wienerns_stats);
-  avm_vector_destroy(&unit_stack);
-  avm_vector_destroy(&unit_indices);
+  RestorationLineBuffers *rlbs = NULL;
+  av2_alloc_restoration_line_buffers(cm, &rlbs);
+
+  double *wienerns_tmpbuf;
+  CHECK_MEM_ERROR(cm, wienerns_tmpbuf,
+                  avm_malloc(WIENERNS_TMPBUF_SIZE * sizeof(*wienerns_tmpbuf)));
+
+  RestSearchCtxt *rsc;
+  CHECK_MEM_ERROR(cm, rsc, avm_malloc(sizeof(*rsc)));
+  rsc->src = src;
+  rsc->dst = &cpi->trial_frame_rst;
+  rsc->cm = cm;
+  rsc->x = x;
+  rsc->rusi = rusi;
+  rsc->lpf_sf = &cpi->sf.lpf_sf;
+  rsc->wienerns_stats = wienerns_stats;
+  rsc->luma = luma_virtual;
+  rsc->luma_buf = luma_virtual_buf;
+  rsc->luma_stat = luma;
+  rsc->luma_stat_buf = luma_buf;
+  rsc->luma_stride = ns_luma_stride;
+  rsc->rlbs = rlbs;
+  rsc->wienerns_tmpbuf = wienerns_tmpbuf;
+  rsc->unit_stack = unit_stack;
+  rsc->unit_indices = unit_indices;
+
+  return rsc;
+}
+
+static void free_rst_search_context(RestSearchCtxt *rsc) {
+  avm_free(rsc->rusi);
+  avm_free(rsc->luma_stat_buf);
+  avm_free(rsc->luma_buf);
+  av2_free_restoration_line_buffers(rsc->rlbs);
+  avm_free(rsc->wienerns_tmpbuf);
+  avm_vector_destroy(rsc->wienerns_stats);
+  avm_free(rsc->wienerns_stats);
+  avm_vector_destroy(rsc->unit_stack);
+  avm_free(rsc->unit_stack);
+  avm_vector_destroy(rsc->unit_indices);
+  avm_free(rsc->unit_indices);
+  avm_free(rsc);
+}
+
+void av2_pick_filter_restoration(const YV12_BUFFER_CONFIG *src, AV2_COMP *cpi) {
+  AV2_COMMON *const cm = &cpi->common;
+  MACROBLOCK *const x = &cpi->td.mb;
+  const int is_mono = cm->seq_params.monochrome;
+
+  assert(!cm->features.all_lossless);
+
+  av2_fill_lr_rates(&x->mode_costs, x->e_mbd.tile_ctx);
+  x->rdmult = cpi->rd.RDMULT;
+
+  int ntiles[2];
+  int max_ntile = 0;
+  for (int is_uv = 0; is_uv <= (is_mono ? 0 : 1); ++is_uv) {
+    cm->rst_info[is_uv].restoration_unit_size =
+        cm->rst_info[is_uv].min_restoration_unit_size;
+    av2_reset_restoration_struct(cm, &cm->rst_info[is_uv], is_uv);
+    ntiles[is_uv] = rest_tiles_in_plane(cm, is_uv);
+    max_ntile = AVMMAX(max_ntile, ntiles[is_uv]);
+  }
+
+  RestSearchCtxt *rsc = alloc_rst_search_context(cpi, src, max_ntile);
+  for (int plane = AVM_PLANE_Y; plane <= (is_mono ? AVM_PLANE_Y : AVM_PLANE_V);
+       ++plane) {
+    search_plane_restoration(cpi, rsc, plane);
+  }
+  free_rst_search_context(rsc);
 }


### PR DESCRIPTION
Briefly,
1. Remove the always-true is_frame_filters_enabled() and other unreachable code
2. Unifies the two wienerns_copy_luma_* functions around a shared fill/extend helper, and refactor common candidate-eval and rui-setup code out of the wienerns finer search into two helper functions.
3. Split parameter search into sub-functions.
4. Move context setup/teardown to dedicated functions.
5. Move RestSearchCtxt and its vectors on the heap as the context is consuming ~16kb of stack space.
6. av2_extend_frame() on dgd buffer is moved out of RU-size loop. It is now per plane.
7. Improve monochrome handling.
8. Minor fixes / cleanup.