### PR TITLE
Fix subsampling rounding in rdopt_utils.h

### DIFF
--- a/av2/encoder/rdopt_utils.h
+++ b/av2/encoder/rdopt_utils.h
@@ -112,8 +112,8 @@ static AVM_INLINE int get_visible_dimensions(const MACROBLOCKD *xd, int plane,
 
   const int mi_x = x + (blk_col << MI_SIZE_LOG2);
   const int mi_y = y + (blk_row << MI_SIZE_LOG2);
-  const int plane_frame_width = frame_width >> ss_x;
-  const int plane_frame_height = frame_height >> ss_y;
+  const int plane_frame_width = (frame_width + ss_x) >> ss_x;
+  const int plane_frame_height = (frame_height + ss_y) >> ss_y;
   int valid_cols, valid_rows;
 
   if (mi_x + cols <= plane_frame_width) {


### PR DESCRIPTION
Fixes https://github.com/webmproject/CrabbyAvif/blob/c3136f98215bcb49e11581fa32f1703fad9d9740/tests/av2.rs#L35

---

I found the pattern used in this change in a few other places:

https://github.com/AOMediaCodec/avm/blob/cd2ba5446504e24c4ad1c7c06ef382214653a537/av2/common/alloccommon.c#L349-L350

https://github.com/AOMediaCodec/avm/blob/cd2ba5446504e24c4ad1c7c06ef382214653a537/avm_scale/generic/yv12config.c#L145-L146