### PR TITLE
Remove the chroma intra mode mask at speed 4 and above

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -620,9 +620,6 @@ static void set_good_speed_features_framesize_independent(
     // Disabling it until it is fixed.
     // sf->inter_sf.prune_comp_using_best_single_mode_ref = 2;
 
-    sf->intra_sf.intra_uv_mode_mask[TX_16X16] = UV_INTRA_DC_H_V_CFL;
-    sf->intra_sf.intra_uv_mode_mask[TX_32X32] = UV_INTRA_DC_H_V_CFL;
-    sf->intra_sf.intra_uv_mode_mask[TX_64X64] = UV_INTRA_DC_H_V_CFL;
     sf->intra_sf.intra_y_mode_mask[TX_16X16] = INTRA_DC_H_V;
     sf->intra_sf.intra_y_mode_mask[TX_32X32] = INTRA_DC_H_V;
     sf->intra_sf.intra_y_mode_mask[TX_64X64] = INTRA_DC_H_V;


### PR DESCRIPTION
Delete the three `sf->intra_sf.intra_uv_mode_mask` assignments from the `speed >= 4`, so `TX_16X16`, `TX_32X32` and `TX_64X64` keep the `UV_INTRA_ALL` that `init_intra_sf()` already set.

FG16 CTC, RA, A1 17 frames / A2 33 frames, speed = 4. `STATS_CHANGED` for speed = 4. (**Anchor**  `ad9c435`)

| Class | Y | Cb | Cr | wAvg | Enc% | Dec% |
|---|---|---|---|---|---|---|
| A1 | -0.38 | +0.10 | +0.01 | -0.34 | 101 | 101 | 
| A2 | -0.13 | +0.14 | -0.00 | -0.11 |  100 | 100 |