### PR TITLE
Properly disable uneven 4-way partitions for > 270p at speed 1

### DIFF
--- a/av2/encoder/speed_features.c
+++ b/av2/encoder/speed_features.c
@@ -186,7 +186,7 @@ static void set_good_speed_feature_framesize_dependent(
     if (!is_4k_or_larger) {
       sf->mv_sf.prune_mesh_search = 1;
     }
-    if (!is_270p_or_lesser) {
+    if (!is_270p_or_lesser && !cm->features.allow_screen_content_tools) {
       sf->part_sf.disable_uneven_4way_partitions = true;
     }
     sf->inter_sf.prune_ref_mv_idx_search = 1;
@@ -1189,6 +1189,12 @@ void av2_set_speed_features_framesize_dependent(AV2_COMP *cpi, int speed) {
       cpi->common.seq_params.max_pb_aspect_ratio_log2_m1 =
           new_max_ratio == 2 ? 0 : (new_max_ratio == 4 ? 1 : 2);
     }
+  }
+
+  if (!cpi->seq_params_locked) {
+    cpi->common.seq_params.enable_uneven_4way_partitions =
+        oxcf->part_cfg.enable_uneven_4way_partitions &&
+        !sf->part_sf.disable_uneven_4way_partitions;
   }
 }
 


### PR DESCRIPTION
This was attempted originally in
https://github.com/AOMediaCodec/avm/pull/5305, but it was not working as intended, because seq_params.enable_uneven_4way_partitions was set before any change to sf->part_sf.disable_uneven_4way_partitions was made.

We fix this as follows:

Update seq_params.enable_uneven_4way_partitions based on sf->part_sf.disable_uneven_4way_partitions in
av2_set_speed_features_framesize_dependent() before seq_params_locked.

At speed 1, this properly disables uneven 4-way partitions only when resolution is larger than 270p, while keeping them enabled for <= 270p. There is no behavior change for speed 0 (enabled for all resolutions) or speed >= 2 (disabled for all resolutions in framesize_independent).

Also, keep uneven 4-way partitions enabled for screen content at speed 1, as the loss / speed-up ratio is not good enough.

CTC RA 33 frames (Anchor: 4a8df58a7 + PR #5393):

```
+---------+--------+-------------+
| Summary |  YUV   |   Enc-time  |
+---------+--------+-------------+
|   A1    |  0.09% |    96.48%   |
|   A2    |  0.03% |    92.85%   |
|Avg wo B2|  0.10% |    92.18%   |
+---------+--------+-------------+
```

STATS_CHANGED for speed 1